### PR TITLE
Disable simulation on initialisation failure

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -56,8 +56,7 @@ namespace Crest
 
         public virtual void Start()
         {
-            InitData();
-            enabled = true;
+            enabled = InitData();
         }
 
         public static RenderTexture CreateLodDataTextures(RenderTextureDescriptor desc, string name, bool needToReadWriteTextureData)
@@ -76,7 +75,7 @@ namespace Crest
             return result;
         }
 
-        protected virtual void InitData()
+        protected virtual bool InitData()
         {
             Debug.Assert(SystemInfo.SupportsRenderTextureFormat(TextureFormat), "The graphics device does not support the render texture format " + TextureFormat.ToString());
 
@@ -85,6 +84,8 @@ namespace Crest
             var resolution = OceanRenderer.Instance.LodDataResolution;
             var desc = new RenderTextureDescriptor(resolution, resolution, TextureFormat, 0);
             _targets = CreateLodDataTextures(desc, SimName, NeedToReadWriteTextureData);
+
+            return true;
         }
 
         public virtual void UpdateLodData()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -83,9 +83,9 @@ namespace Crest
             Start();
         }
 
-        protected override void InitData()
+        protected override bool InitData()
         {
-            base.InitData();
+            if (!base.InitData()) return false;
 
             // Setup the RenderTexture and compute shader for combining
             // different animated wave LODs. As we use a single texture array
@@ -110,8 +110,7 @@ namespace Crest
             _combineShader = ComputeShaderHelpers.LoadShader(ShaderName);
             if (_combineShader == null)
             {
-                enabled = false;
-                return;
+                return false;
             }
             krnl_ShapeCombine = _combineShader.FindKernel("ShapeCombine");
             krnl_ShapeCombine_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_DISABLE_COMBINE");
@@ -122,6 +121,8 @@ namespace Crest
             krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON");
             krnl_ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE = _combineShader.FindKernel("ShapeCombine_FLOW_ON_DYNAMIC_WAVE_SIM_ON_DISABLE_COMBINE");
             _combineProperties = new PropertyWrapperCompute();
+
+            return true;
         }
 
         RenderTexture CreateCombineBuffer(RenderTextureDescriptor desc)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -53,12 +53,13 @@ namespace Crest
             Start();
         }
 
-        protected override void InitData()
+        protected override bool InitData()
         {
-            base.InitData();
+            if (!base.InitData()) return false;
 
             _active = new bool[OceanRenderer.Instance.CurrentLodCount];
             for (int i = 0; i < _active.Length; i++) _active[i] = true;
+            return true;
         }
 
         internal override void OnEnable()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -51,9 +51,9 @@ namespace Crest
             _renderSimProperties = new PropertyWrapperCompute();
         }
 
-        protected override void InitData()
+        protected override bool InitData()
         {
-            base.InitData();
+            if (!base.InitData()) return false;
 
             int resolution = OceanRenderer.Instance.LodDataResolution;
             var desc = new RenderTextureDescriptor(resolution, resolution, TextureFormat, 0);
@@ -61,6 +61,8 @@ namespace Crest
 
             TextureArrayHelpers.ClearToBlack(_targets);
             TextureArrayHelpers.ClearToBlack(_sources);
+
+            return true;
         }
 
         public void ValidateSourceData(bool usePrevTransform)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -99,9 +99,9 @@ namespace Crest
 #endif
         }
 
-        protected override void InitData()
+        protected override bool InitData()
         {
-            base.InitData();
+            if (!base.InitData()) return false;
 
             int resolution = OceanRenderer.Instance.LodDataResolution;
             var desc = new RenderTextureDescriptor(resolution, resolution, TextureFormat, 0);
@@ -109,6 +109,8 @@ namespace Crest
 
             TextureArrayHelpers.ClearToBlack(_sources);
             TextureArrayHelpers.ClearToBlack(_targets);
+
+            return true;
         }
 
         bool StartInitLight()

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -147,35 +147,35 @@ namespace Crest
 
         [Tooltip("Water depth information used for shallow water, shoreline foam, wave attenuation, among others."), SerializeField]
         bool _createSeaFloorDepthData = true;
-        public bool CreateSeaFloorDepthData { get { return _createSeaFloorDepthData; } }
+        public bool CreateSeaFloorDepthData => _createSeaFloorDepthData && !_wasLodDataSeaDepthsInitFailure;
 
         [Tooltip("Simulation of foam created in choppy water and dissipating over time."), SerializeField]
-        bool _createFoamSim = true;
-        public bool CreateFoamSim { get { return _createFoamSim; } }
+        internal bool _createFoamSim = true;
+        public bool CreateFoamSim => _createFoamSim && !_wasLodDataFoamInitFailure;
         [PredicatedField("_createFoamSim")]
         public SimSettingsFoam _simSettingsFoam;
 
         [Tooltip("Dynamic waves generated from interactions with objects such as boats."), SerializeField]
         bool _createDynamicWaveSim = false;
-        public bool CreateDynamicWaveSim { get { return _createDynamicWaveSim; } }
+        public bool CreateDynamicWaveSim => _createDynamicWaveSim && !_wasLodDataDynWavesInitFailure;
         [PredicatedField("_createDynamicWaveSim")]
         public SimSettingsWave _simSettingsDynamicWaves;
 
         [Tooltip("Horizontal motion of water body, akin to water currents."), SerializeField]
         bool _createFlowSim = false;
-        public bool CreateFlowSim { get { return _createFlowSim; } }
+        public bool CreateFlowSim => _createFlowSim && !_wasLodDataFlowInitFailure;
         [PredicatedField("_createFlowSim")]
         public SimSettingsFlow _simSettingsFlow;
 
         [Tooltip("Shadow information used for lighting water."), SerializeField]
         bool _createShadowData = false;
-        public bool CreateShadowData { get { return _createShadowData; } }
+        public bool CreateShadowData => _createShadowData && !_wasLodDataShadowInitFailure;
         [PredicatedField("_createShadowData")]
         public SimSettingsShadow _simSettingsShadow;
 
         [Tooltip("Clip surface information for clipping the ocean surface."), SerializeField]
         bool _createClipSurfaceData = false;
-        public bool CreateClipSurfaceData { get { return _createClipSurfaceData; } }
+        public bool CreateClipSurfaceData => _createClipSurfaceData && !_wasLodDataClipSurfaceInitFailure;
         public enum DefaultClippingState
         {
             NothingClipped,
@@ -239,11 +239,17 @@ namespace Crest
         [HideInInspector] public LodTransform _lodTransform;
         [HideInInspector] public LodDataMgrAnimWaves _lodDataAnimWaves;
         [HideInInspector] public LodDataMgrSeaFloorDepth _lodDataSeaDepths;
+        bool _wasLodDataSeaDepthsInitFailure = false;
         [HideInInspector] public LodDataMgrClipSurface _lodDataClipSurface;
+        bool _wasLodDataClipSurfaceInitFailure = false;
         [HideInInspector] public LodDataMgrDynWaves _lodDataDynWaves;
+        bool _wasLodDataDynWavesInitFailure = false;
         [HideInInspector] public LodDataMgrFlow _lodDataFlow;
+        bool _wasLodDataFlowInitFailure = false;
         [HideInInspector] public LodDataMgrFoam _lodDataFoam;
+        bool _wasLodDataFoamInitFailure = false;
         [HideInInspector] public LodDataMgrShadow _lodDataShadow;
+        bool _wasLodDataShadowInitFailure = false;
 
         /// <summary>
         /// The number of LODs/scales that the ocean is currently using.
@@ -409,6 +415,7 @@ namespace Crest
         void CreateDestroySubSystems()
         {
             {
+                // TODO: How should we handle failure of animated waves?
                 if (_lodDataAnimWaves == null)
                 {
                     _lodDataAnimWaves = new LodDataMgrAnimWaves(this);
@@ -421,7 +428,15 @@ namespace Crest
                 if (_lodDataClipSurface == null)
                 {
                     _lodDataClipSurface = new LodDataMgrClipSurface(this);
-                    _lodDatas.Add(_lodDataClipSurface);
+                    _wasLodDataClipSurfaceInitFailure = !_lodDataClipSurface.enabled;
+                    if (_wasLodDataClipSurfaceInitFailure)
+                    {
+                        _lodDataClipSurface = null;
+                    }
+                    else
+                    {
+                        _lodDatas.Add(_lodDataClipSurface);
+                    }
                 }
             }
             else
@@ -439,7 +454,15 @@ namespace Crest
                 if (_lodDataDynWaves == null)
                 {
                     _lodDataDynWaves = new LodDataMgrDynWaves(this);
-                    _lodDatas.Add(_lodDataDynWaves);
+                    _wasLodDataDynWavesInitFailure = !_lodDataDynWaves.enabled;
+                    if (_wasLodDataDynWavesInitFailure)
+                    {
+                        _lodDataDynWaves = null;
+                    }
+                    else
+                    {
+                        _lodDatas.Add(_lodDataDynWaves);
+                    }
                 }
             }
             else
@@ -457,7 +480,15 @@ namespace Crest
                 if (_lodDataFlow == null)
                 {
                     _lodDataFlow = new LodDataMgrFlow(this);
-                    _lodDatas.Add(_lodDataFlow);
+                    _wasLodDataFlowInitFailure = !_lodDataFlow.enabled;
+                    if (_wasLodDataFlowInitFailure)
+                    {
+                        _lodDataFlow = null;
+                    }
+                    else
+                    {
+                        _lodDatas.Add(_lodDataFlow);
+                    }
                 }
 
                 if (FlowProvider != null && !(FlowProvider is QueryFlow))
@@ -491,7 +522,15 @@ namespace Crest
                 if (_lodDataFoam == null)
                 {
                     _lodDataFoam = new LodDataMgrFoam(this);
-                    _lodDatas.Add(_lodDataFoam);
+                    _wasLodDataFoamInitFailure = !_lodDataFoam.enabled;
+                    if (_wasLodDataFoamInitFailure)
+                    {
+                        _lodDataFoam = null;
+                    }
+                    else
+                    {
+                        _lodDatas.Add(_lodDataFoam);
+                    }
                 }
             }
             else
@@ -509,7 +548,15 @@ namespace Crest
                 if (_lodDataSeaDepths == null)
                 {
                     _lodDataSeaDepths = new LodDataMgrSeaFloorDepth(this);
-                    _lodDatas.Add(_lodDataSeaDepths);
+                    _wasLodDataSeaDepthsInitFailure = !_lodDataSeaDepths.enabled;
+                    if (_wasLodDataClipSurfaceInitFailure)
+                    {
+                        _lodDataSeaDepths = null;
+                    }
+                    else
+                    {
+                        _lodDatas.Add(_lodDataSeaDepths);
+                    }
                 }
             }
             else
@@ -527,7 +574,15 @@ namespace Crest
                 if (_lodDataShadow == null)
                 {
                     _lodDataShadow = new LodDataMgrShadow(this);
-                    _lodDatas.Add(_lodDataShadow);
+                    _wasLodDataShadowInitFailure = !_lodDataSeaDepths.enabled;
+                    if (_wasLodDataShadowInitFailure)
+                    {
+                        _lodDataSeaDepths = null;
+                    }
+                    else
+                    {
+                        _lodDatas.Add(_lodDataShadow);
+                    }
                 }
             }
             else


### PR DESCRIPTION
This should help with #621. It makes more sense once integrated with #640.

The idea is if a simulation fails to initialise, then it should be disabled. It should make it more robust where less important simulations are not necessary.

I wasn't sure how to handle animated waves since it appears to be almost necessary and more tightly coupled.