### PR TITLE
VR/XR Underwater Post Processing Stack

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -1,3 +1,24 @@
-﻿{
-	"name": "Crest"
+{
+    "name": "Crest",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.vr",
+            "expression": "1.0.0",
+            "define": "ENABLE_VR_MODULE"
+        },
+        {
+            "name": "com.unity.modules.xr",
+            "expression": "1.0.0",
+            "define": "ENABLE_XR_MODULE"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs
@@ -1,0 +1,224 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// An adaptor layer for both VR/XR modules.
+
+// ENABLE_VR is defined if platform support XR.
+#if ENABLE_VR && (ENABLE_VR_MODULE || ENABLE_XR_MODULE)
+    #define _XR_ENABLED
+#endif
+
+#if ENABLE_VR && ENABLE_VR_MODULE
+    #define _VR_MODULE_ENABLED
+#endif
+
+#if ENABLE_VR && ENABLE_XR_MODULE
+    #define _XR_MODULE_ENABLED
+#endif
+
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+#if _XR_ENABLED
+using UnityEngine.XR;
+#endif
+
+namespace Crest
+{
+    public static class XRHelpers
+    {
+        static List<XRDisplaySubsystem> _displayList = new List<XRDisplaySubsystem>();
+
+        public static Matrix4x4 LeftEyeProjectionMatrix { get; private set; }
+        public static Matrix4x4 RightEyeProjectionMatrix { get; private set; }
+        public static Matrix4x4 LeftEyeViewMatrix { get; private set; }
+        public static Matrix4x4 RightEyeViewMatrix { get; private set; }
+
+        public static bool IsRunning
+        {
+            get
+            {
+                #if !_XR_ENABLED
+                    return false;
+                #endif
+
+                return IsNewSDKRunning || IsOldSDKRunning;
+            }
+        }
+
+        public static bool IsNewSDKRunning
+        {
+            get
+            {
+                // XRGeneralSettings.Instance.Manager.activeLoader.GetLoadedSubsystem is another way to access the XR
+                // device. But that requires a dependency on com.unity.xr.management.
+                #if _XR_MODULE_ENABLED
+                    return _displayList.Count > 0 && _displayList[0].running;
+                #else
+                    return false;
+                #endif
+            }
+        }
+
+        public static bool IsOldSDKRunning
+        {
+            get
+            {
+                #if _VR_MODULE_ENABLED
+                    return XRSettings.enabled;
+                #else
+                    return false;
+                #endif
+            }
+        }
+
+        public static bool IsSinglePass
+        {
+            get
+            {
+                #if !_XR_ENABLED
+                    return false;
+                #endif
+
+                #if _VR_MODULE_ENABLED
+                    if (IsOldSDKRunning)
+                    {
+                        return XRSettings.stereoRenderingMode != XRSettings.StereoRenderingMode.MultiPass;
+                    }
+                #endif
+
+                if (IsNewSDKRunning)
+                {
+                    return !(bool)Display?.singlePassRenderingDisabled;
+                }
+
+                return false;
+            }
+        }
+
+        // Double-wide is legacy single pass (single pass without instancing). It is being phased out.
+        public static bool IsDoubleWide
+        {
+            get
+            {
+                #if _VR_MODULE_ENABLED
+                    return IsOldSDKRunning && XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePass;
+                #else
+                    return false;
+                #endif
+            }
+        }
+
+        public static bool IsLegacyRenderer => GraphicsSettings.currentRenderPipeline == null;
+
+        // This is according to HDRP
+        public static int MaximumViews => IsSinglePass ? 2 : 1;
+
+        // Unity only supports one display right now.
+        public static XRDisplaySubsystem Display => IsNewSDKRunning ? _displayList[0] : null;
+
+        // This works for both old and new XR API in legacy renderer. If the VR module is disabled, this will be a
+        // compilation error, but an alternative is unknown at this point. Maybe once the new XR API improves.
+        public static RenderTextureDescriptor EyeRenderTextureDescriptor => XRSettings.eyeTextureDesc;
+
+        public static void SetViewProjectionMatrices(Camera camera, int viewIndex, int passIndex, CommandBuffer commandBuffer)
+        {
+            if (IsLegacyRenderer)
+            {
+                // Built-in is the same for old or new XR.
+                var eye = (Camera.StereoscopicEye)(IsSinglePass ? viewIndex : passIndex);
+                // It appears that the command buffer matrix changes were being overwritten so we just pass it as a
+                // property instead. According to documentation, GetGPUProjectionMatrix is correct way to get the final
+                // matrix similar to how Unity would do it.
+                commandBuffer.SetGlobalMatrix("_ViewProjectionMatrix",
+                    GL.GetGPUProjectionMatrix(camera.GetStereoProjectionMatrix(eye), true) *
+                    camera.GetStereoViewMatrix(eye));
+                commandBuffer.SetViewProjectionMatrices(camera.worldToCameraMatrix, camera.projectionMatrix);
+            }
+            else if (IsNewSDKRunning)
+            {
+                if (Display.GetRenderPassCount() > 0)
+                {
+                    Display.GetRenderPass(passIndex, out var xrPass);
+                    xrPass.GetRenderParameter(camera, viewIndex, out var xrEye);
+                    commandBuffer.SetViewProjectionMatrices(xrEye.view, xrEye.projection);
+                }
+            }
+            else
+            {
+                var eye = (Camera.StereoscopicEye) (IsSinglePass ? viewIndex : passIndex);
+                commandBuffer.SetViewProjectionMatrices(camera.GetStereoViewMatrix(eye), camera.GetStereoProjectionMatrix(eye));
+            }
+        }
+
+        public static void SetViewProjectionMatrices(Camera camera)
+        {
+            if (IsLegacyRenderer)
+            {
+                return;
+            }
+
+            if (IsNewSDKRunning)
+            {
+                if (IsSinglePass)
+                {
+                    camera.SetStereoViewMatrix(Camera.StereoscopicEye.Left, LeftEyeViewMatrix);
+                    camera.SetStereoViewMatrix(Camera.StereoscopicEye.Right, RightEyeViewMatrix);
+                }
+                else
+                {
+                    camera.projectionMatrix = LeftEyeProjectionMatrix;
+                }
+            }
+        }
+
+        public static void UpdatePassIndex(ref int passIndex)
+        {
+            if (IsSinglePass)
+            {
+                passIndex = 0;
+            }
+            else
+            {
+                passIndex += 1;
+                passIndex %= 2;
+            }
+        }
+
+        public static void Update(Camera camera)
+        {
+            #if _XR_MODULE_ENABLED
+                SubsystemManager.GetInstances(_displayList);
+            #endif
+
+            if (!IsRunning)
+            {
+                return;
+            }
+
+            // Let's cache these values for SPI.
+            if (IsSinglePass)
+            {
+                if (!IsLegacyRenderer && IsNewSDKRunning && Display.GetRenderPassCount() > 0)
+                {
+                    Display.GetRenderPass(0, out XRDisplaySubsystem.XRRenderPass xrPass);
+                    xrPass.GetRenderParameter(camera, 0, out XRDisplaySubsystem.XRRenderParameter xrLeftEye);
+                    xrPass.GetRenderParameter(camera, 1, out XRDisplaySubsystem.XRRenderParameter xrRightEye);
+                    LeftEyeViewMatrix = xrLeftEye.view;
+                    RightEyeViewMatrix = xrRightEye.view;
+                    LeftEyeProjectionMatrix = xrLeftEye.projection;
+                    RightEyeProjectionMatrix = xrRightEye.projection;
+                }
+                else
+                {
+                    LeftEyeViewMatrix = camera.GetStereoViewMatrix(Camera.StereoscopicEye.Left);
+                    RightEyeViewMatrix = camera.GetStereoViewMatrix(Camera.StereoscopicEye.Right);
+                    LeftEyeProjectionMatrix = camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Left);
+                    RightEyeProjectionMatrix = camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Right);
+                }
+            }
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a06687ea593cf442be651314f36aeca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/PostProcessStack/UnderwaterPostProcessMaskRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/PostProcessStack/UnderwaterPostProcessMaskRenderer.cs
@@ -28,8 +28,11 @@ namespace Crest
             _cameraFrustumPlanes = GeometryUtility.CalculateFrustumPlanes(_mainCamera);
             _maskCommandBuffer = new CommandBuffer();
             _maskCommandBuffer.name = "Ocean Mask Command Buffer";
+            // @FixMe: BeforeForwardAlpha breaks XR SPI right eye completely for MockHMD (not tested on XR hardware).
+            // This could either be a Unity bug or we have to restore something after the command buffer is executed.
+            // BeforeForwardAlpha is necessary for features that rely on the ocean shader using the mask.
+            // https://issuetracker.unity3d.com/product/unity/issues/guid/1261545
             _mainCamera.AddCommandBuffer(
-                // CameraEvent.BeforeForwardAlpha,
                 XRHelpers.IsSinglePass && !XRHelpers.IsDoubleWide
                         ? CameraEvent.AfterForwardAlpha
                         : CameraEvent.BeforeForwardAlpha,

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/PostProcessStack/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/PostProcessStack/UnderwaterRenderer.cs
@@ -35,6 +35,8 @@ namespace Crest
         UnderwaterSphericalHarmonicsData _sphericalHarmonicsData = new UnderwaterSphericalHarmonicsData();
         bool _firstRender = true;
 
+        int _stereoEyeIndex = -1;
+
         public override void Init()
         {
 
@@ -47,6 +49,15 @@ namespace Crest
 
         public override void Render(PostProcessRenderContext context)
         {
+            if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
+            {
+                _stereoEyeIndex = (_stereoEyeIndex + 1) % 2;
+            }
+            else
+            {
+                _stereoEyeIndex = 0;
+            }
+
             PropertySheet underWaterPostProcessEffect = context.propertySheets.Get(Shader.Find("Crest/Underwater/Post Process Stack"));
             PropertyWrapperPropertySheet underwaterPostProcessMaterialWrapper = new PropertyWrapperPropertySheet(underWaterPostProcessEffect);
 
@@ -81,10 +92,16 @@ namespace Crest
                 _firstRender || settings._copyOceanMaterialParamsEachFrame.value,
                 settings._viewOceanMask.value,
                 horizonSafetyMarginMultiplier,
-                settings._filterOceanData.value
+                settings._filterOceanData.value,
+                _stereoEyeIndex
             );
             _firstRender = false;
 
+
+            if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
+            {
+                context.command.SetGlobalInt("_StereoEyeIndex", _stereoEyeIndex);
+            }
 
             context.command.BlitFullscreenTriangle(context.source, context.destination, underWaterPostProcessEffect, 0);
         }

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/PostProcessStack/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/PostProcessStack/UnderwaterRenderer.cs
@@ -35,6 +35,7 @@ namespace Crest
         UnderwaterSphericalHarmonicsData _sphericalHarmonicsData = new UnderwaterSphericalHarmonicsData();
         bool _firstRender = true;
 
+        // We need to track the stereo eye index for XR SPI for usage in scripts and shaders.
         int _stereoEyeIndex = -1;
 
         public override void Init()
@@ -49,6 +50,8 @@ namespace Crest
 
         public override void Render(PostProcessRenderContext context)
         {
+            // Render is called per eye for XR SPI. We are keeping track of the eye index to determine which eye is
+            // being processed for both scripts and shaders. It is possible that Unity might change this behaviour.
             if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
             {
                 _stereoEyeIndex = (_stereoEyeIndex + 1) % 2;
@@ -97,7 +100,9 @@ namespace Crest
             );
             _firstRender = false;
 
-
+            // We are currently using CG shaders which means we cannot use the HLSL includes from the post-processing
+            // stack package. This leaves some variables not set like unity_StereoEyeIndex. We could setup each eye
+            // correctly so we do not need the eye index, but this might diverge from downstream too much.
             if (context.stereoRenderingMode == PostProcessRenderContext.StereoRenderingMode.SinglePassInstanced)
             {
                 context.command.SetGlobalInt("_StereoEyeIndex", _stereoEyeIndex);

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -232,6 +232,9 @@ namespace Crest
                 // Store projection matrix to restore later.
                 var projectionMatrix = camera.projectionMatrix;
 
+                // For VR/XR SPI and the PPS, the render function is called per eye. This branch prevents an out of
+                // bounds exception when calling ViewportToWorldPoint in GetHorizonPosNormal. This is not the case for
+                // the SRP volume framework.
                 if (stereoEyeIndex == 0)
                 {
                     // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -132,7 +132,8 @@ namespace Crest
             bool copyParamsFromOceanMaterial,
             bool debugViewPostProcessMask,
             float horizonSafetyMarginMultiplier,
-            int dataSliceOffset
+            int dataSliceOffset,
+            int stereoEyeIndex
         )
         {
             // TODO(TRC):Now Re-enable this with a property wrapper abstraction
@@ -231,26 +232,31 @@ namespace Crest
                 // Store projection matrix to restore later.
                 var projectionMatrix = camera.projectionMatrix;
 
-                // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
-                camera.projectionMatrix = XRHelpers.LeftEyeProjectionMatrix;
-
-                var inverseViewProjectionMatrix = (XRHelpers.LeftEyeProjectionMatrix * XRHelpers.LeftEyeViewMatrix).inverse;
-                underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
-
+                if (stereoEyeIndex == 0)
                 {
-                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Left, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
-                    underwaterPostProcessMaterialWrapper.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
+                    // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
+                    camera.projectionMatrix = XRHelpers.LeftEyeProjectionMatrix;
+
+                    var inverseViewProjectionMatrix = (XRHelpers.LeftEyeProjectionMatrix * XRHelpers.LeftEyeViewMatrix).inverse;
+                    underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
+
+                    {
+                        GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Left, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
+                        underwaterPostProcessMaterialWrapper.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
+                    }
                 }
-
-                // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
-                camera.projectionMatrix = XRHelpers.RightEyeProjectionMatrix;
-
-                var inverseViewProjectionMatrixRightEye = (XRHelpers.RightEyeProjectionMatrix * XRHelpers.RightEyeViewMatrix).inverse;
-                underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjectionRight, inverseViewProjectionMatrixRightEye);
-
+                else
                 {
-                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Right, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
-                    underwaterPostProcessMaterialWrapper.SetVector(sp_HorizonPosNormalRight, new Vector4(pos.x, pos.y, normal.x, normal.y));
+                    // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
+                    camera.projectionMatrix = XRHelpers.RightEyeProjectionMatrix;
+
+                    var inverseViewProjectionMatrixRightEye = (XRHelpers.RightEyeProjectionMatrix * XRHelpers.RightEyeViewMatrix).inverse;
+                    underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjectionRight, inverseViewProjectionMatrixRightEye);
+
+                    {
+                        GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Right, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
+                        underwaterPostProcessMaterialWrapper.SetVector(sp_HorizonPosNormalRight, new Vector4(pos.x, pos.y, normal.x, normal.y));
+                    }
                 }
 
                 // Restore projection matrix.
@@ -301,7 +307,6 @@ namespace Crest
             NativeArray<Vector3> v_world = new NativeArray<Vector3>(4, Allocator.Temp);
             try
             {
-
                 v_screenXY_viewZ[0] = new Vector3(0f, 0f, camera.farClipPlane);
                 v_screenXY_viewZ[1] = new Vector3(0f, 1f, camera.farClipPlane);
                 v_screenXY_viewZ[2] = new Vector3(1f, 1f, camera.farClipPlane);

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterPostProcessUtils.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Rendering;
-using UnityEngine.XR;
 
 namespace Crest
 {
@@ -83,14 +82,22 @@ namespace Crest
         public static void PopulateOceanMask(
             CommandBuffer commandBuffer, Camera camera, List<OceanChunkRenderer> chunksToRender, Plane[] frustumPlanes,
             RenderTexture colorBuffer, RenderTexture depthBuffer,
-            Material oceanMaskMaterial,
+            Material oceanMaskMaterial, int depthSlice, int passIndex,
             bool debugDisableOceanMask
         )
         {
             // Get all ocean chunks and render them using cmd buffer, but with mask shader
-            commandBuffer.SetRenderTarget(colorBuffer.colorBuffer, depthBuffer.depthBuffer);
+            commandBuffer.SetRenderTarget(colorBuffer.colorBuffer, depthBuffer.depthBuffer, mipLevel: 0, CubemapFace.Unknown, depthSlice: depthSlice);
             commandBuffer.ClearRenderTarget(true, true, Color.white * UNDERWATER_MASK_NO_MASK);
-            commandBuffer.SetViewProjectionMatrices(camera.worldToCameraMatrix, camera.projectionMatrix);
+
+            if (XRHelpers.IsRunning)
+            {
+                XRHelpers.SetViewProjectionMatrices(camera, depthSlice, passIndex, commandBuffer);
+            }
+            else
+            {
+                commandBuffer.SetViewProjectionMatrices(camera.worldToCameraMatrix, camera.projectionMatrix);
+            }
 
             if (!debugDisableOceanMask)
             {
@@ -217,26 +224,17 @@ namespace Crest
             }
 
             // Have to set these explicitly as the built-in transforms aren't in world-space for the blit function
-            if (!XRSettings.enabled || XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.MultiPass)
+            if (XRHelpers.IsSinglePass)
             {
+                XRHelpers.SetViewProjectionMatrices(camera);
 
-                var inverseViewProjectionMatrix = (camera.projectionMatrix * camera.worldToCameraMatrix).inverse;
-                underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
-
-                {
-                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Mono, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
-                    underwaterPostProcessMaterialWrapper.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
-                }
-            }
-            else
-            {
                 // Store projection matrix to restore later.
                 var projectionMatrix = camera.projectionMatrix;
 
                 // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
-                camera.projectionMatrix = camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Left);
+                camera.projectionMatrix = XRHelpers.LeftEyeProjectionMatrix;
 
-                var inverseViewProjectionMatrix = (camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Left) * camera.GetStereoViewMatrix(Camera.StereoscopicEye.Left)).inverse;
+                var inverseViewProjectionMatrix = (XRHelpers.LeftEyeProjectionMatrix * XRHelpers.LeftEyeViewMatrix).inverse;
                 underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
 
                 {
@@ -245,9 +243,9 @@ namespace Crest
                 }
 
                 // We need to set the matrix ourselves. Maybe ViewportToWorldPoint has a bug.
-                camera.projectionMatrix = camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Right);
+                camera.projectionMatrix = XRHelpers.RightEyeProjectionMatrix;
 
-                var inverseViewProjectionMatrixRightEye = (camera.GetStereoProjectionMatrix(Camera.StereoscopicEye.Right) * camera.GetStereoViewMatrix(Camera.StereoscopicEye.Right)).inverse;
+                var inverseViewProjectionMatrixRightEye = (XRHelpers.RightEyeProjectionMatrix * XRHelpers.RightEyeViewMatrix).inverse;
                 underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjectionRight, inverseViewProjectionMatrixRightEye);
 
                 {
@@ -257,6 +255,18 @@ namespace Crest
 
                 // Restore projection matrix.
                 camera.projectionMatrix = projectionMatrix;
+            }
+            else
+            {
+                XRHelpers.SetViewProjectionMatrices(camera);
+
+                var inverseViewProjectionMatrix = (camera.projectionMatrix * camera.worldToCameraMatrix).inverse;
+                underwaterPostProcessMaterialWrapper.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
+
+                {
+                    GetHorizonPosNormal(camera, Camera.MonoOrStereoscopicEye.Mono, seaLevel, horizonSafetyMarginMultiplier, out Vector2 pos, out Vector2 normal);
+                    underwaterPostProcessMaterialWrapper.SetVector(sp_HorizonPosNormal, new Vector4(pos.x, pos.y, normal.x, normal.y));
+                }
             }
 
             // Not sure why we need to do this - blit should set it...?

--- a/crest/Assets/Crest/Crest/Shaders/Resources/OceanUnderwaterMask.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/OceanUnderwaterMask.shader
@@ -36,6 +36,8 @@ Shader "Crest/Underwater/Ocean Mask"
 				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
+			// For some reason the command buffer would not accept matrix changes. Probably being overwritten.
+			float4x4 _ViewProjectionMatrix;
 
 			#include "../OceanConstants.hlsl"
 			#include "../OceanInputsDriven.hlsl"
@@ -90,7 +92,12 @@ Shader "Crest/Underwater/Ocean Mask"
 					SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, worldPos, sss);
 				}
 
+#if defined(UNITY_STEREO_INSTANCING_ENABLED)
+				output.positionCS = mul(_ViewProjectionMatrix, float4(worldPos, 1.0));
+#else
 				output.positionCS = mul(UNITY_MATRIX_VP, float4(worldPos, 1.0));
+#endif
+				
 				return output;
 			}
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
@@ -72,6 +72,8 @@ Shader "Crest/Underwater/Post Process Stack"
 			struct Attributes
 			{
 				float3 vertex : POSITION;
+
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct Varyings
@@ -79,11 +81,17 @@ Shader "Crest/Underwater/Post Process Stack"
 				float4 positionCS : SV_POSITION;
 				float2 uv : TEXCOORD0;
 				float3 viewWS : TEXCOORD1;
+
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 			Varyings Vert (Attributes input)
 			{
 				Varyings output;
+
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_INITIALIZE_OUTPUT(Varyings, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 				output.positionCS = float4(input.vertex.xy, 0.0, 1.0);
 				output.uv = (input.vertex.xy + 1.0) * 0.5;
 #if UNITY_UV_STARTS_AT_TOP
@@ -106,10 +114,9 @@ Shader "Crest/Underwater/Post Process Stack"
 				return output;
 			}
 
-			sampler2D _MainTex;
-			sampler2D _CrestOceanMaskTexture;
-			sampler2D _CrestOceanMaskDepthTexture;
-
+			UNITY_DECLARE_SCREENSPACE_TEXTURE(_MainTex);
+			UNITY_DECLARE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture);
+			UNITY_DECLARE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture);
 
 			half3 ApplyUnderwaterEffect(half3 sceneColour, const float sceneZ01, const half3 view, bool isOceanSurface)
 			{
@@ -147,6 +154,9 @@ Shader "Crest/Underwater/Post Process Stack"
 
 			fixed4 Frag (Varyings input) : SV_Target
 			{
+				// We need this when sampling a screenspace texture.
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
 				float3 viewWS;
 				float farPlanePixelHeight;
 
@@ -166,12 +176,12 @@ Shader "Crest/Underwater/Post Process Stack"
 
 				const float2 uvScreenSpace = UnityStereoTransformScreenSpaceTex(input.uv);
 
-				half3 sceneColour = tex2D(_MainTex, uvScreenSpace).rgb;
+				half3 sceneColour = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_MainTex, uvScreenSpace).rgb;
 
 				float sceneZ01 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CameraDepthTexture, uvScreenSpace).x;
 
-				float mask = tex2D(_CrestOceanMaskTexture, uvScreenSpace).x;
-				const float oceanDepth01 = tex2D(_CrestOceanMaskDepthTexture, uvScreenSpace);
+				float mask = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, uvScreenSpace).x;
+				const float oceanDepth01 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, uvScreenSpace);
 				bool isOceanSurface = mask != UNDERWATER_MASK_NO_MASK && (sceneZ01 < oceanDepth01);
 				bool isUnderwater = mask == UNDERWATER_MASK_WATER_SURFACE_BELOW || (isBelowHorizon && mask != UNDERWATER_MASK_WATER_SURFACE_ABOVE);
 				sceneZ01 = isOceanSurface ? oceanDepth01 : sceneZ01;
@@ -188,9 +198,9 @@ Shader "Crest/Underwater/Post Process Stack"
 					// a calculation to get it smooth both above and below, but might be more complex.
 					float wt_mul = 0.9;
 					float4 dy = float4(0.0, -1.0, -2.0, -3.0) / _ScreenParams.y;
-					wt *= (tex2D(_CrestOceanMaskTexture, uvScreenSpace + dy.xy).x > mask) ? wt_mul : 1.0;
-					wt *= (tex2D(_CrestOceanMaskTexture, uvScreenSpace + dy.xz).x > mask) ? wt_mul : 1.0;
-					wt *= (tex2D(_CrestOceanMaskTexture, uvScreenSpace + dy.xw).x > mask) ? wt_mul : 1.0;
+					wt *= (UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, uvScreenSpace + dy.xy).x > mask) ? wt_mul : 1.0;
+					wt *= (UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, uvScreenSpace + dy.xz).x > mask) ? wt_mul : 1.0;
+					wt *= (UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, uvScreenSpace + dy.xw).x > mask) ? wt_mul : 1.0;
 				}
 #endif // _MENISCUS_ON
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
@@ -56,7 +56,7 @@ Shader "Crest/Underwater/Post Process Stack"
 			half3 _AmbientLighting;
 
 			// In-built Unity textures
-			sampler2D _CameraDepthTexture;
+			UNITY_DECLARE_SCREENSPACE_TEXTURE(_CameraDepthTexture);
 			sampler2D _Normals;
 
 			#include "../OceanEmission.hlsl"
@@ -168,7 +168,7 @@ Shader "Crest/Underwater/Post Process Stack"
 
 				half3 sceneColour = tex2D(_MainTex, uvScreenSpace).rgb;
 
-				float sceneZ01 = tex2D(_CameraDepthTexture, uvScreenSpace).x;
+				float sceneZ01 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CameraDepthTexture, uvScreenSpace).x;
 
 				float mask = tex2D(_CrestOceanMaskTexture, uvScreenSpace).x;
 				const float oceanDepth01 = tex2D(_CrestOceanMaskDepthTexture, uvScreenSpace);

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UnderwaterPostProcess.shader
@@ -68,6 +68,7 @@ Shader "Crest/Underwater/Post Process Stack"
 			float4 _HorizonPosNormalRight;
 			half _DataSliceOffset;
 
+			// unity_StereoEyeIndex is not being set so we handle it ourselves.
 			uint _StereoEyeIndex;
 
 			// Ported from StdLib, we can't include it as it'll conflict with internal Unity includes
@@ -86,7 +87,6 @@ Shader "Crest/Underwater/Post Process Stack"
 			Varyings Vert (Attributes input)
 			{
 				Varyings output;
-
 				output.positionCS = float4(input.vertex.xy, 0.0, 1.0);
 				output.uv = (input.vertex.xy + 1.0) * 0.5;
 #if UNITY_UV_STARTS_AT_TOP

--- a/crest/Packages/manifest.json
+++ b/crest/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.ide.rider": "1.1.4",
     "com.unity.ide.vscode": "1.2.1",
-    "com.unity.postprocessing": "2.3.0",
+    "com.unity.postprocessing": "https://github.com/Unity-Technologies/PostProcessing.git",
     "com.unity.test-framework": "1.1.14",
     "com.unity.timeline": "1.2.15",
     "com.unity.ugui": "1.0.0",
@@ -32,5 +32,11 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
+  },
+  "lock": {
+    "com.unity.postprocessing": {
+      "revision": "HEAD",
+      "hash": "bf1957be6024f23f0204bf2b05f9f7c6ce1c98fd"
+    }
   }
 }

--- a/crest/Packages/manifest.json
+++ b/crest/Packages/manifest.json
@@ -32,11 +32,5 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  },
-  "lock": {
-    "com.unity.postprocessing": {
-      "revision": "HEAD",
-      "hash": "bf1957be6024f23f0204bf2b05f9f7c6ce1c98fd"
-    }
   }
 }


### PR DESCRIPTION
Adds support for VR/XR to the underwater effect implemented for the post-processing stack.

Working:
- [x] Multi-Pass
- [ ] Single Pass
- [x] Single Pass Instanced

Single Pass is not working because the depth texture is double-wide and I am not sure how to sample that one correctly yet. We could drop single pass support for the underwater effect since it is deprecated.

One difficulty with the underwater post-process shader is that it is a CG shader and not an HLSL shader. It appears that Unity does not set the variables correctly for CG so sampling textures becomes a re-engineering effort. HLSL is easier for VR/XR from what I can see.

The other is that single-pass instanced behaves a bit different than it does in HDRP. The _Render_ function is called per eye. This is normally how multi-pass works. Some extra code had to be added to handle that.

Also, I am using the latest post-processing package from Unity's github. They have some fixes for SPI but I need to recheck if it is actually necessary.

This PR has #637 merged into #299 which this is branched from.