### PR TITLE
Combine changes

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -84,7 +84,6 @@ namespace Crest
                 _showOceanData = GUI.Toggle(new Rect(x, y, w, h), _showOceanData, "Show sim data"); y += h;
 
                 LodDataMgrAnimWaves._shapeCombinePass = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrAnimWaves._shapeCombinePass, "Shape combine pass"); y += h;
-                LodDataMgrAnimWaves._shapeCombinePassPingPong = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrAnimWaves._shapeCombinePassPingPong, "Combine pass ping pong"); y += h;
 
                 LodDataMgrShadow.s_processData = GUI.Toggle(new Rect(x, y, w, h), LodDataMgrShadow.s_processData, "Process Shadows"); y += h;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -43,7 +43,7 @@ namespace Crest
         /// Ping pong between render targets to do the combine. Disabling this uses a compute shader instead which doesn't need
         /// to copy back and forth between targets, but has dodgy historical support as pre-DX11.3 hardware may not support typed UAV loads.
         /// </summary>
-        public static bool _shapeCombinePassPingPong = true;
+        public static bool _shapeCombinePassPingPong = false;
 
         RenderTexture _waveBuffers;
         RenderTexture _combineBuffer;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -39,12 +39,6 @@ namespace Crest
         /// </summary>
         public static bool _shapeCombinePass = true;
 
-        /// <summary>
-        /// Ping pong between render targets to do the combine. Disabling this uses a compute shader instead which doesn't need
-        /// to copy back and forth between targets, but has dodgy historical support as pre-DX11.3 hardware may not support typed UAV loads.
-        /// </summary>
-        public static bool _shapeCombinePassPingPong = false;
-
         RenderTexture _waveBuffers;
         RenderTexture _combineBuffer;
 
@@ -234,7 +228,7 @@ namespace Crest
                 OceanRenderer.Instance._lodTransform._renderData[lodIdx].Validate(0, SimName);
             }
 
-            foreach(var gerstner in _gerstners)
+            foreach (var gerstner in _gerstners)
             {
                 gerstner.CrestUpdate(buf);
             }
@@ -255,7 +249,7 @@ namespace Crest
             }
 
             // Combine the LODs - copy results from biggest LOD down to LOD 0
-            if (_shapeCombinePassPingPong)
+            if (Settings.PingPongCombinePass)
             {
                 CombinePassPingPong(buf);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -29,6 +29,10 @@ namespace Crest
         int _maxQueryCount = QueryBase.MAX_QUERY_COUNT_DEFAULT;
         public int MaxQueryCount { get { return _maxQueryCount; } }
 
+        [Tooltip("Whether to use a graphics shader for combining the wave cascades together. Disabling this uses a compute shader instead which doesn't need to copy back and forth between targets, but it may not work on some GPUs, in particular pre-DX11.3 hardware, which do not support typed UAV loads. The fail behaviour is a flat ocean."), SerializeField]
+        bool _pingPongCombinePass = true;
+        public bool PingPongCombinePass => _pingPongCombinePass;
+
         /// <summary>
         /// Provides ocean shape to CPU.
         /// </summary>

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -20,6 +20,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 			CGPROGRAM
 			#pragma vertex Vert
 			#pragma fragment Frag
+			#pragma target 3.5
 
 			#pragma multi_compile __ CREST_DYNAMIC_WAVE_SIM_ON_INTERNAL
 			#pragma multi_compile __ CREST_FLOW_ON_INTERNAL

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -151,6 +151,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 			CGPROGRAM
 			#pragma vertex Vert
 			#pragma fragment Frag
+			#pragma target 3.5
 
 			#include "UnityCG.cginc"
 


### PR DESCRIPTION
Two changes related to the combine pass..

Firstly, added target pragma which apparently fixes an issue on Quest.

The second changes defaults to not doing ping-pong passes for the combine. The ping pong approach uses a graphics shader and copies results backwards and forwards from an aux RT. This is here because early DX10 GPUs missed a feature we need to run the combine as a compute shader (typed loads). So we added two paths, and defaulted to the "safe" one.

I feel we should change the default to the efficient compute path now, given that the old gpus are something like 15years old now, and see how many people report issues. The symptom is that it silently fails to combine the cascades and the ocean will appear flat. If we don't hear issues perhaps we can consider switching completely over to the compute path.