### PR TITLE
Fix null ref ex when adding ocean comp to new GO

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -266,7 +266,7 @@ namespace Crest
             // Shader needs sea level to determine water depth. Ocean instance might not be available in prefabs.
             var centerPoint = Vector3.zero;
             centerPoint.y = OceanRenderer.Instance != null
-                ? OceanRenderer.Instance.Root.position.y : transform.position.y;
+                ? OceanRenderer.Instance.SeaLevel : transform.position.y;
 
             _copyDepthMaterial.SetVector("_OceanCenterPosWorld", centerPoint);
 


### PR DESCRIPTION
**Status**: Ready to merge

Repro steps are to make a new scene, make a new GO, and add OceanRenderer component. This resulted in a spew of null ref exceptions for me, on 2019.4.16. This is following the setup instructions we ship with crest.

This change defers creation of the surface, and minor changes to avoid other systems trying to get the Root transform before it is created.

Not excited to merge this at the last minute just before release.. however its holding up to my tests so far. I tested with different paths of creating/loading ocean scenes, and tested standalone build.