### PR TITLE
Expand tile epsilon to cover new crack bug

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -317,7 +317,7 @@ Shader "Crest/Ocean"
 				// Scale up by small "epsilon" to solve numerical issues. Expand slightly about tile center.
 				// :OceanGridPrecisionErrors
 				const float2 tileCenterXZ = UNITY_MATRIX_M._m03_m23;
-				o.worldPos.xz = lerp( tileCenterXZ, o.worldPos.xz, 1.0004 );
+				o.worldPos.xz = lerp( tileCenterXZ, o.worldPos.xz, 1.00111 );
 
 				o.lodAlpha_worldXZUndisplaced_oceanDepth.x = lodAlpha;
 				o.lodAlpha_worldXZUndisplaced_oceanDepth.yz = o.worldPos.xz;

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -317,7 +317,7 @@ Shader "Crest/Ocean"
 				// Scale up by small "epsilon" to solve numerical issues. Expand slightly about tile center.
 				// :OceanGridPrecisionErrors
 				const float2 tileCenterXZ = UNITY_MATRIX_M._m03_m23;
-				o.worldPos.xz = lerp( tileCenterXZ, o.worldPos.xz, 1.0001 );
+				o.worldPos.xz = lerp( tileCenterXZ, o.worldPos.xz, 1.0004 );
 
 				o.lodAlpha_worldXZUndisplaced_oceanDepth.x = lodAlpha;
 				o.lodAlpha_worldXZUndisplaced_oceanDepth.yz = o.worldPos.xz;


### PR DESCRIPTION
Latest post in issue #665 . This change expands tile epsilon to cover new crack bug. I didnt see any negative side effects of this increased epsilon and it's still quite small. The other repro scenes look fine to me with it as well (tested in editor).
