### PR TITLE
Inline settings editing attribute with predicate field support

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
@@ -11,7 +11,7 @@ namespace Crest
     using UnityEditor;
 #endif
 
-    public class EmbeddedFieldAttribute : PropertyAttribute
+    public class EmbeddedFieldAttribute : MultiPropertyAttribute
     {
 #if UNITY_EDITOR
         internal EmbeddedAssetEditor editor;
@@ -23,20 +23,16 @@ namespace Crest
             editor = new EmbeddedAssetEditor();
 #endif
         }
-    }
 
 #if UNITY_EDITOR
-    [CustomPropertyDrawer(typeof(EmbeddedFieldAttribute))]
-    public class EmbeddedFieldAttributePropertyDrawer : PropertyDrawer
-    {
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer)
         {
-            EmbeddedFieldAttribute embeddedAttribute = (EmbeddedFieldAttribute)attribute;
-            embeddedAttribute.editor.DrawEditorCombo(this, property, "asset");
+            EmbeddedFieldAttribute embeddedAttribute = this;
+            embeddedAttribute.editor.DrawEditorCombo(drawer, property, "asset");
         }
 
         // Removes space above embedded editor so the embedded editor replaces this drawer.
-        public override float GetPropertyHeight(SerializedProperty property, GUIContent label) => 0f;
-    }
+        internal override float? GetPropertyHeight(SerializedProperty property, GUIContent label) => 0f;
 #endif
+    }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -1,0 +1,39 @@
+﻿// Crest Ocean System
+
+// Taken and modified from: https://forum.unity.com/threads/drawing-a-field-using-multiple-property-drawers.479377/
+
+// This class allows multiple attributes to be used together providing they inherit from this class. It also eliminates
+// the requirement to create a custom property drawer as the MultiPropertyDrawer class handles all of that for us. The
+// implementation difference when creating a custom attribute is to place the property drawer code in the attribute
+// instead. Also, any change to the GUI state must not be reset so it can be stacked. The MultiPropertyDrawer class
+// resets the GUI state for us.
+
+namespace Crest
+{
+    using UnityEditor;
+
+#if UNITY_EDITOR
+    using Crest.EditorHelpers;
+    using UnityEngine;
+#endif
+
+    public abstract class MultiPropertyAttribute : PropertyAttribute
+    {
+#if UNITY_EDITOR
+        /// <summary>
+        /// Override this method to customise the label.
+        /// </summary>
+        internal virtual GUIContent BuildLabel(GUIContent label) => label;
+
+        /// <summary>
+        /// Override this method to make your own IMGUI based GUI for the property.
+        /// </summary>
+        internal abstract void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer);
+
+        /// <summary>
+        /// Override this method to specify how tall the GUI for this field is in pixels.
+        /// </summary>
+        internal virtual float? GetPropertyHeight(SerializedProperty property, GUIContent label) => null;
+    }
+#endif
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 624b7c14a87484083a392f0979204735
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EmbeddedAssetHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EmbeddedAssetHelpers.cs
@@ -102,7 +102,10 @@ namespace Crest.EditorHelpers
                         foldoutRect, property.isExpanded, GUIContent.none, true);
 
                     bool canEditAsset = AssetDatabase.IsOpenForEdit(m_Editor.target, StatusQueryOptions.UseCachedIfPossible);
-                    GUI.enabled = canEditAsset;
+
+                    // We take the current GUI state into account to support attribute stacking.
+                    GUI.enabled = GUI.enabled && canEditAsset;
+
                     if (property.isExpanded)
                     {
                         EditorGUILayout.Separator();

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
@@ -1,0 +1,73 @@
+﻿// Crest Ocean System
+
+// Taken and modified from: https://forum.unity.com/threads/drawing-a-field-using-multiple-property-drawers.479377/
+
+// This class draws all the attributes which inherit from MultiPropertyAttribute. This class may need to be extended to
+// handle reseting GUI states as we need them.
+
+namespace Crest.EditorHelpers
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using UnityEditor;
+    using UnityEngine;
+
+    [CustomPropertyDrawer(typeof(MultiPropertyAttribute), true)]
+    public class MultiPropertyDrawer : PropertyDrawer
+    {
+        List<object> _multiPropertyAttributes = new List<object>();
+        List<object> MultiPropertyAttributes
+        {
+            get
+            {
+                // Populate list with attributes (MultiPropertyAttribute) if empty. There should at least be one since
+                // MultiPropertyDrawer targets MultiPropertyAttribute.
+                if (_multiPropertyAttributes == null || _multiPropertyAttributes.Count == 0)
+                {
+                    // TODO: Use something other than Linq.
+                    _multiPropertyAttributes = fieldInfo.GetCustomAttributes(typeof(MultiPropertyAttribute), false)
+                        .OrderBy(x => ((PropertyAttribute) x).order).ToList();
+
+                }
+
+                return _multiPropertyAttributes;
+            }
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            float height = base.GetPropertyHeight(property, label);
+
+            // Go through the attributes, and try to get an altered height. If no altered height, then return the
+            // default height.
+            foreach (MultiPropertyAttribute attribute in MultiPropertyAttributes)
+            {
+                // TODO: Build label here too?
+                var temporaryHeight = attribute.GetPropertyHeight(property, label);
+                if (temporaryHeight.HasValue)
+                {
+                    height = temporaryHeight.Value;
+                    break;
+                }
+            }
+
+            return height;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            // Store the original GUI state so it can be reset later.
+            var originalColor = GUI.color;
+            var originalEnabled = GUI.enabled;
+
+            foreach (MultiPropertyAttribute attribute in MultiPropertyAttributes)
+            {
+                attribute.OnGUI(position, property, attribute.BuildLabel(label), this);
+            }
+
+            // Handle resetting the GUI state.
+            GUI.color = originalColor;
+            GUI.enabled = originalEnabled;
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1284cc26bae2f460793ff317c5b8a9c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
@@ -6,13 +6,14 @@ using System;
 using UnityEngine;
 
 #if UNITY_EDITOR
+using Crest.EditorHelpers;
 using UnityEditor;
 #endif
 
 namespace Crest
 {
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-    public class PredicatedFieldAttribute : PropertyAttribute
+    public class PredicatedFieldAttribute : MultiPropertyAttribute
     {
         public readonly string _propertyName;
         public readonly bool _inverted;
@@ -67,33 +68,16 @@ namespace Crest
 
             return _inverted ? !result : result;
         }
-#endif
-    }
 
-#if UNITY_EDITOR
-    [CustomPropertyDrawer(typeof(PredicatedFieldAttribute))]
-    public class PredicatedFieldAttributePropertyDrawer : PropertyDrawer
-    {
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer)
         {
-            var attrib = (attribute as PredicatedFieldAttribute);
-            var propName = attrib._propertyName;
-            var prop = property.serializedObject.FindProperty(propName);
-
-            var before = GUI.enabled;
-            if (prop != null)
+            // Get the other property to be the predicate for the enabled/disabled state of this property.
+            var otherProperty = property.serializedObject.FindProperty(_propertyName);
+            if (otherProperty != null)
             {
-                GUI.enabled = attrib.GUIEnabled(prop);
+                GUI.enabled = GUIEnabled(otherProperty);
             }
-            else
-            {
-                Debug.LogError($"PredicatedFieldAttributePropertyDrawer - field '{propName}' not found.");
-            }
-
-            EditorGUI.PropertyField(position, property, label);
-
-            GUI.enabled = before;
-        }
-    }
+          }
 #endif
+    }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -174,25 +174,25 @@ namespace Crest
         [Tooltip("Simulation of foam created in choppy water and dissipating over time."), SerializeField]
         bool _createFoamSim = true;
         public bool CreateFoamSim { get { return _createFoamSim; } }
-        [EmbeddedField]
+        [PredicatedField("_createFoamSim", order = 0), EmbeddedField(order = 1)]
         public SimSettingsFoam _simSettingsFoam;
 
         [Tooltip("Dynamic waves generated from interactions with objects such as boats."), SerializeField]
         bool _createDynamicWaveSim = false;
         public bool CreateDynamicWaveSim { get { return _createDynamicWaveSim; } }
-        [EmbeddedField]
+        [PredicatedField("_createDynamicWaveSim", order = 0), EmbeddedField(order = 1)]
         public SimSettingsWave _simSettingsDynamicWaves;
 
         [Tooltip("Horizontal motion of water body, akin to water currents."), SerializeField]
         bool _createFlowSim = false;
         public bool CreateFlowSim { get { return _createFlowSim; } }
-        [EmbeddedField]
+        [PredicatedField("_createFlowSim", order = 0), EmbeddedField(order = 1)]
         public SimSettingsFlow _simSettingsFlow;
 
         [Tooltip("Shadow information used for lighting water."), SerializeField]
         bool _createShadowData = false;
         public bool CreateShadowData { get { return _createShadowData; } }
-        [EmbeddedField]
+        [PredicatedField("_createShadowData", order = 0), EmbeddedField(order = 1)]
         public SimSettingsShadow _simSettingsShadow;
 
         [Tooltip("Clip surface information for clipping the ocean surface."), SerializeField]


### PR DESCRIPTION
Open this PR for discussing and merging into #741 and finally into #737

Idea and code taken from:
https://forum.unity.com/threads/drawing-a-field-using-multiple-property-drawers.479377/

Basically allows attribute stacking. Writing the GUI code is a little different as you are not suppose to reset the GUI code so the next attribute in the stack receives the changes. This allows our predicated field and embedded asset field to work together.

I haven't fully evaluated the code yet to see if there are any drawbacks. But everything appears to be working well. It also simplifies the code as we don't need to define our own property drawers.

Usage:
```csharp
[PredicatedField("_createFoamSim", order = 0), EmbeddedField(order = 1)]
public SimSettingsFoam _simSettingsFoam;
```

<img width="2032" alt="23223" src="https://user-images.githubusercontent.com/5249806/106833651-c264da80-6648-11eb-9c4d-04d2538edf76.png">