### PR TITLE
Fix: always update cache components in editor

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -542,7 +542,7 @@ namespace Crest
                     isValid = false;
                 }
 
-                if (transform.lossyScale.x != transform.lossyScale.z)
+                if (!Mathf.Approximately(transform.lossyScale.x, transform.lossyScale.z))
                 {
                     showMessage
                     (

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -103,25 +103,13 @@ namespace Crest
 #if UNITY_EDITOR
         void Update()
         {
+            // We need to switch the quad texture if the user changes the cache type in the editor.
+            InitCacheQuad();
+
             if (_forceAlwaysUpdateDebug)
             {
                 PopulateCache(updateComponents: true);
             }
-        }
-
-        bool _isFirstOnValidate = true;
-
-        void OnValidate()
-        {
-            // OnValidate also runs between Awake and Start regardless of change.
-            if (_isFirstOnValidate)
-            {
-                _isFirstOnValidate = false;
-                return;
-            }
-
-            // If the user switches cache type, we want to switch the target texture.
-            InitCacheQuad();
         }
 #endif
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -542,6 +542,19 @@ namespace Crest
                     isValid = false;
                 }
 
+                if (transform.lossyScale.x != transform.lossyScale.z)
+                {
+                    showMessage
+                    (
+                        "The <i>Ocean Depth Cache</i> in realtime only supports a uniform scale for X and Z. " +
+                        "These values currently do not match. " +
+                        $"Its current scale in the hierarchy is: X = {transform.lossyScale.x} Z = {transform.lossyScale.z}.",
+                        ValidatedHelper.MessageType.Error, this
+                    );
+
+                    isValid = false;
+                }
+
                 // We used to test if nothing is present that would render into the cache, but these could probably come from other scenes, and AssignLayer means
                 // objects can be tagged up at run-time.
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -105,10 +105,25 @@ namespace Crest
         {
             if (_forceAlwaysUpdateDebug)
             {
-                PopulateCache();
+                PopulateCache(updateComponents: true);
             }
         }
 #endif
+
+        float CalculateCacheCameraOrthographicSize()
+        {
+            return Mathf.Max(transform.lossyScale.x / 2f, transform.lossyScale.z / 2f);
+        }
+
+        Vector3 CalculateCacheCameraPosition()
+        {
+            return transform.position + Vector3.up * _cameraMaxTerrainHeight;
+        }
+
+        bool IsCacheTextureOutdated(RenderTexture texture)
+        {
+            return texture != null && (texture.width != _resolution || texture.height != _resolution);
+        }
 
         RenderTexture MakeRT(bool depthStencilTarget)
         {
@@ -136,14 +151,24 @@ namespace Crest
             return result;
         }
 
-        bool InitObjects()
+        bool InitObjects(bool updateComponents)
         {
+            if (updateComponents && IsCacheTextureOutdated(_cacheTexture))
+            {
+                // Destroy the texture so it can be recreated.
+                _cacheTexture.Release();
+                _cacheTexture = null;
+            }
+
             if (_cacheTexture == null)
             {
                 _cacheTexture = MakeRT(false);
             }
 
-            if (_camDepthCache == null)
+            // We want to know this later.
+            var isDepthCacheCameraCreation = _camDepthCache == null;
+
+            if (isDepthCacheCameraCreation)
             {
                 var errorShown = false;
                 var layerMask = 0;
@@ -182,11 +207,9 @@ namespace Crest
 
                 _camDepthCache = new GameObject("DepthCacheCam").AddComponent<Camera>();
                 _camDepthCache.gameObject.hideFlags = _hideDepthCacheCam ? HideFlags.HideAndDontSave : HideFlags.DontSave;
-                _camDepthCache.transform.position = transform.position + Vector3.up * _cameraMaxTerrainHeight;
                 _camDepthCache.transform.parent = transform;
                 _camDepthCache.transform.localEulerAngles = 90f * Vector3.right;
                 _camDepthCache.orthographic = true;
-                _camDepthCache.orthographicSize = Mathf.Max(transform.lossyScale.x / 2f, transform.lossyScale.z / 2f);
                 _camDepthCache.cullingMask = layerMask;
                 _camDepthCache.clearFlags = CameraClearFlags.SolidColor;
                 // Clear to 'very deep'
@@ -198,6 +221,20 @@ namespace Crest
                 _camDepthCache.cameraType = CameraType.Reflection;
                 // I'd prefer to destroy the camera object, but I found sometimes (on first start of editor) it will fail to render.
                 _camDepthCache.gameObject.SetActive(false);
+            }
+
+            if (updateComponents || isDepthCacheCameraCreation)
+            {
+                // Calculate here so it is always updated.
+                _camDepthCache.transform.position = CalculateCacheCameraPosition();
+                _camDepthCache.orthographicSize = CalculateCacheCameraOrthographicSize();
+            }
+
+            if (updateComponents && IsCacheTextureOutdated(_camDepthCache.targetTexture))
+            {
+                // Destroy the texture so it can be recreated.
+                _camDepthCache.targetTexture.Release();
+                _camDepthCache.targetTexture = null;
             }
 
             if (_camDepthCache.targetTexture == null)
@@ -247,21 +284,25 @@ namespace Crest
             qr.enabled = false;
         }
 
-        public void PopulateCache()
+        /// <summary>
+        /// Populates the ocean depth cache. Call this method if using <i>On Demand<i>.
+        /// </summary>
+        /// <param name="updateComponents">
+        /// Updates components like the depth cache camera. Pass true if you have changed any depth cache properties.
+        /// </param>
+        public void PopulateCache(bool updateComponents = false)
         {
-            // Make sure we have required objects
-            if (!InitObjects())
+            // Nothing to populate for baked.
+            if (_type == OceanDepthCacheType.Baked)
             {
                 return;
             }
 
-#if UNITY_EDITOR
-            // Users must call this themselves during runtime if they change depth cache settings during runtime.
-            if (!Application.isPlaying || _forceAlwaysUpdateDebug)
+            // Make sure we have required objects.
+            if (!InitObjects(updateComponents))
             {
-                UpdateCacheComponents();
+                return;
             }
-#endif
 
             // Render scene, saving depths in depth buffer.
             _camDepthCache.Render();
@@ -292,54 +333,6 @@ namespace Crest
 
             // Copy from depth buffer into the cache
             Graphics.Blit(null, _cacheTexture, _copyDepthMaterial);
-        }
-
-        /// <summary>
-        /// Updates components like the depth cache camera. Call this after changing any of the depth cache settings
-        /// like resolution.
-        /// </summary>
-        public void UpdateCacheComponents()
-        {
-            UpdateCacheCamera();
-            UpdateCacheTexture();
-        }
-
-        void UpdateCacheCamera()
-        {
-            if (_camDepthCache == null)
-            {
-                return;
-            }
-
-            _camDepthCache.transform.position = transform.position + Vector3.up * _cameraMaxTerrainHeight;
-            _camDepthCache.orthographicSize = Mathf.Max(transform.lossyScale.x / 2f, transform.lossyScale.z / 2f);
-
-            if (_camDepthCache.targetTexture.width != _resolution || _camDepthCache.targetTexture.height != _resolution)
-            {
-                _camDepthCache.targetTexture.Release();
-                _camDepthCache.targetTexture = MakeRT(true);
-                _camDepthCache.targetTexture.Create();
-            }
-        }
-
-        void UpdateCacheTexture()
-        {
-            if (_cacheTexture == null)
-            {
-                return;
-            }
-
-            if (_cacheTexture.width != _resolution || _cacheTexture.height != _resolution)
-            {
-                _cacheTexture.Release();
-                _cacheTexture = MakeRT(false);
-                _cacheTexture.Create();
-
-                if (_drawCacheQuad != null)
-                {
-                    _drawCacheQuad.GetComponent<Renderer>().sharedMaterial.mainTexture = _cacheTexture;
-                }
-            }
         }
 
 #if UNITY_EDITOR
@@ -411,7 +404,7 @@ namespace Crest
 
             if ((!playing || isOnDemand) && dc.Type != OceanDepthCache.OceanDepthCacheType.Baked && GUILayout.Button("Populate cache"))
             {
-                dc.PopulateCache();
+                dc.PopulateCache(updateComponents: true);
             }
 
             if (isBakeable && GUILayout.Button("Save cache to file"))
@@ -446,9 +439,30 @@ namespace Crest
 
     public partial class OceanDepthCache : IValidated
     {
+        bool IsCacheOutdated()
+        {
+            return _camDepthCache.orthographicSize != CalculateCacheCameraOrthographicSize() ||
+                _camDepthCache.transform.position != CalculateCacheCameraPosition() ||
+                IsCacheTextureOutdated(_camDepthCache.targetTexture) ||
+                IsCacheTextureOutdated(_cacheTexture);
+        }
+
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             var isValid = true;
+
+            if (_camDepthCache != null && _camDepthCache.targetTexture != null && _cacheTexture != null)
+            {
+                if (IsCacheOutdated())
+                {
+                    showMessage
+                    (
+                        "Depth cache is outdated. Click <i>Populate Cache</i> or re-bake the cache to bring the cache " +
+                        "up-to-date with component changes.",
+                        ValidatedHelper.MessageType.Warning, this
+                    );
+                }
+            }
 
             if (_type == OceanDepthCacheType.Baked)
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -292,21 +292,6 @@ namespace Crest
 
             // Copy from depth buffer into the cache
             Graphics.Blit(null, _cacheTexture, _copyDepthMaterial);
-
-            var leaveEnabled = _forceAlwaysUpdateDebug;
-
-            if (!leaveEnabled)
-            {
-                _camDepthCache.targetTexture = null;
-
-#if UNITY_EDITOR
-                if (EditorApplication.isPlaying)
-#endif
-                {
-                    // Only disable component when in play mode, otherwise it changes authoring data
-                    enabled = false;
-                }
-            }
         }
 
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -108,6 +108,21 @@ namespace Crest
                 PopulateCache(updateComponents: true);
             }
         }
+
+        bool _isFirstOnValidate = true;
+
+        void OnValidate()
+        {
+            // OnValidate also runs between Awake and Start regardless of change.
+            if (_isFirstOnValidate)
+            {
+                _isFirstOnValidate = false;
+                return;
+            }
+
+            // If the user switches cache type, we want to switch the target texture.
+            InitCacheQuad();
+        }
 #endif
 
         float CalculateCacheCameraOrthographicSize()


### PR DESCRIPTION
Fix: #617 (partially)

Fixes an issue where the properties (max terrain height and resolution) on the depth cache or its transform (scale) are changed, the components (camera and textures) are not updated when in the editor when they should be. Users would have to enter and exit play mode which would cause confusion and possibly confusing bug reports. The update method is public so users can call during runtime if they need to change properties on the depth cache.