### PR TITLE
Fix PSSL/PS4 shader errors

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -101,7 +101,7 @@ void ApplyCaustics(in const half3 i_view, in const half3 i_lightDir, in const fl
 
 	const float3 scenePosUV = WorldToUV(scenePos.xz, cascadeData1, _LD_SliceIndex + 1);
 
-	half3 disp = 0.;
+	float3 disp = 0.0;
 	// this gives height at displaced position, not exactly at query position.. but it helps. i cant pass this from vert shader
 	// because i dont know it at scene pos.
 	SampleDisplacements(_LD_TexArray_AnimatedWaves, scenePosUV, 1.0, disp);

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -71,7 +71,7 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 	// SSS - based off pinch
 #if _SUBSURFACESCATTERING_ON
 	{
-		const float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
+		const float2x2 jacobian = (float4(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
 		// Determinant is < 1 for pinched, < 0 for overlap/inversion
 		const float det = determinant( jacobian );
 		const float sssMax = 0.6;

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -113,8 +113,8 @@ void PosToSliceIndices
 	const float2 worldXZ,
 	const float minSlice,
 	const float oceanScale0,
-	out float slice0,
-	out float slice1,
+	out uint slice0,
+	out uint slice1,
 	out float lodAlpha
 )
 {
@@ -125,7 +125,7 @@ void PosToSliceIndices
 
 	lodAlpha = frac(sliceNumber);
 	slice0 = floor(sliceNumber);
-	slice1 = slice0 + 1.0;
+	slice1 = slice0 + 1;
 
 	// lod alpha is remapped to ensure patches weld together properly. patches can vary significantly in shape (with
 	// strips added and removed), and this variance depends on the base density of the mesh, as this defines the strip width.

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -83,7 +83,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	// > 1: Stretch
 	// < 1: Squash
 	// < 0: Overlap
-	const float2x2 jacobian = (float2x2(disp_x.xz, disp_z.xz) - disp.xzxz) / cascadeData._texelWidth;
+	const float2x2 jacobian = (float4(disp_x.xz, disp_z.xz) - disp.xzxz) / cascadeData._texelWidth;
 	// Determinant is < 1 for pinched, < 0 for overlap/inversion
 	const float det = determinant( jacobian );
 	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase * 0.7 );


### PR DESCRIPTION
Reported by @woistjadefox in issue #624:

> Tried to make a build but I get these old errors:
> ![image](https://user-images.githubusercontent.com/58563011/96013237-5108de00-0e45-11eb-8eb5-341ca42873b8.png)
> [editor_error_log.txt](https://github.com/crest-ocean/crest/files/5379376/editor_error_log.txt)
> 
> I think this happend in a version before already. Should I just switch all half3 and half2 to float3 / float2 in the underwater shader for testing reasons?

Not sure if I got them all. Some of these might be URP specific so I will have to do a pass there too. This also includes a fix for the determinant wanting float4 for PSSL which was reported on Discord.

@woistjadefox If you could test this branch and let me know if you see any more errors and I will try and fix them here.