### PR TITLE
Fix ShapeGerstner breaking in build

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -588,12 +588,12 @@ namespace Crest
         {
             _firstUpdate = true;
 
-#if UNITY_EDITOR
             // Initialise with spectrum
             if (_spectrum != null)
             {
                 _activeSpectrum = _spectrum;
             }
+#if UNITY_EDITOR
             if (_activeSpectrum == null)
             {
                 _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();


### PR DESCRIPTION
Reported by @holdingjason on Discord. The active spectrum isn't set from the serialised spectrum in builds.