### PR TITLE
Add embedded material editor to OceanRenderer

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -762,11 +762,14 @@ namespace Crest
 
         void WritePerFrameMaterialParams()
         {
-            // Hack - due to SV_IsFrontFace occasionally coming through as true for back faces,
-            // add a param here that forces ocean to be in underwater state. I think the root
-            // cause here might be imprecision or numerical issues at ocean tile boundaries, although
-            // i'm not sure why cracks are not visible in this case.
-            OceanMaterial.SetFloat(sp_ForceUnderwater, ViewerHeightAboveWater < -2f ? 1f : 0f);
+            if (OceanMaterial != null)
+            {
+                // Hack - due to SV_IsFrontFace occasionally coming through as true for back faces,
+                // add a param here that forces ocean to be in underwater state. I think the root
+                // cause here might be imprecision or numerical issues at ocean tile boundaries, although
+                // i'm not sure why cracks are not visible in this case.
+                OceanMaterial.SetFloat(sp_ForceUnderwater, ViewerHeightAboveWater < -2f ? 1f : 0f);
+            }
 
             _lodTransform.WriteCascadeParams(_cascadeParamsTgt, _cascadeParamsSrc);
             _bufCascadeDataTgt.SetData(_cascadeParamsTgt);

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1357,7 +1357,14 @@ namespace Crest
         // Adapted from: http://answers.unity.com/answers/975894/view.html
         void DrawMaterialEditor()
         {
-            if ((_materialEditor == null && _target._material != null) || (Material)_materialEditor.target != _target._material)
+            Material oldMaterial = null;
+
+            if (_materialEditor != null)
+            {
+                oldMaterial = (Material)_materialEditor.target;
+            }
+
+            if (oldMaterial != _target._material)
             {
                 serializedObject.ApplyModifiedProperties();
 
@@ -1371,7 +1378,6 @@ namespace Crest
                 {
                     // Create a new instance of the default MaterialEditor.
                     _materialEditor = (MaterialEditor)CreateEditor(_target._material);
-
                 }
             }
 


### PR DESCRIPTION
Adds a material editor similar to what the mesh renderers get. The only difference is that this appears right after the component rather than after all other components.

<img width="1552" alt="222" src="https://user-images.githubusercontent.com/5249806/109097257-d9d93580-76d3-11eb-9cd6-f57fb507f795.png">
<img width="1552" alt="111" src="https://user-images.githubusercontent.com/5249806/109097265-de055300-76d3-11eb-9cd2-97731dca1eb1.png">

I wasn't able to make the feature an attribute like the SO editor. This is more difficult as the foldout should appear after the component at the very least. It is probably possible but will require more engineering than the other.