### PR TITLE
Add inline button to fix validation issues

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -32,9 +32,10 @@ namespace Crest
         {
             public string _message;
             public Object _object;
+            public System.Action<SerializedObject> _action;
         }
 
-        // This is a shared resource. It will be cleared before use. It is only used by the HelpBox delegate since we 
+        // This is a shared resource. It will be cleared before use. It is only used by the HelpBox delegate since we
         // want to group them by severity (MessageType). Make sure length matches MessageType length.
         public static readonly List<HelpBoxMessage>[] messages = new[]
         {
@@ -43,9 +44,9 @@ namespace Crest
             new List<HelpBoxMessage>(),
         };
 
-        public delegate void ShowMessage(string message, MessageType type, Object @object = null);
+        public delegate void ShowMessage(string message, MessageType type, Object @object = null, System.Action<SerializedObject> action = null);
 
-        public static void DebugLog(string message, MessageType type, Object @object = null)
+        public static void DebugLog(string message, MessageType type, Object @object = null, System.Action<SerializedObject> action = null)
         {
             message = $"Validation: {message} Click this message to highlight the problem object.";
 
@@ -57,12 +58,12 @@ namespace Crest
             }
         }
 
-        public static void HelpBox(string message, MessageType type, Object @object = null)
+        public static void HelpBox(string message, MessageType type, Object @object = null, System.Action<SerializedObject> action = null)
         {
-            messages[(int)type].Add(new HelpBoxMessage { _message = message, _object = @object });
+            messages[(int)type].Add(new HelpBoxMessage { _message = message, _object = @object, _action = action });
         }
 
-        public static void Suppressed(string message, MessageType type, Object @object = null)
+        public static void Suppressed(string message, MessageType type, Object @object = null, System.Action<SerializedObject> action = null)
         {
         }
 
@@ -99,6 +100,7 @@ namespace Crest
     {
         static readonly bool _groupMessages = false;
         static GUIContent s_jumpButtonContent = null;
+        static GUIContent s_fixButtonContent = null;
 
         public void ShowValidationMessages()
         {
@@ -176,12 +178,32 @@ namespace Crest
                                 {
                                     if (s_jumpButtonContent == null)
                                     {
-                                        s_jumpButtonContent = new GUIContent(EditorGUIUtility.FindTexture("d_scenepicking_pickable_hover"), "Jump to object to resolve issue");
+                                        s_jumpButtonContent = new GUIContent(EditorGUIUtility.FindTexture("scenepicking_pickable_hover@2x"), "Jump to object to resolve issue");
                                     }
 
                                     if (GUILayout.Button(s_jumpButtonContent, GUILayout.ExpandWidth(false), GUILayout.ExpandHeight(true)))
                                     {
                                         Selection.activeObject = message._object;
+                                    }
+                                }
+                            }
+
+                            // Fix the issue button.
+                            if (message._action != null)
+                            {
+                                if (s_fixButtonContent == null)
+                                {
+                                    s_fixButtonContent = new GUIContent(EditorGUIUtility.FindTexture("SceneViewTools@2x"), "Fix the issue");
+                                }
+
+                                if (GUILayout.Button(s_fixButtonContent, GUILayout.ExpandWidth(false), GUILayout.ExpandHeight(true)))
+                                {
+                                    var serializedObject = new SerializedObject(message._object);
+                                    message._action.Invoke(serializedObject);
+                                    if (serializedObject.ApplyModifiedProperties())
+                                    {
+                                        // SerializedObject does this for us, but gives the history item a nicer label.
+                                        Undo.RecordObject(message._object, $"Fix for {message._object.name}");
                                     }
                                 }
                             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -164,17 +164,25 @@ namespace Crest
                             EditorGUILayout.BeginHorizontal();
                             EditorGUILayout.HelpBox(message._message, messageType);
 
-                            // Jump to object button
-                            if (message._object != null && Selection.activeObject != message._object)
+                            // Jump to object button.
+                            if (message._object != null)
                             {
-                                if (s_jumpButtonContent == null)
-                                {
-                                    s_jumpButtonContent = new GUIContent(EditorGUIUtility.FindTexture("d_scenepicking_pickable_hover"), "Jump to object to resolve issue");
-                                }
+                                // Selection.activeObject can be message._object.gameObject instead of the component
+                                // itself. We soft cast to MonoBehaviour to get the gameObject for comparison.
+                                // Alternatively, we could always pass gameObject instead of "this".
+                                var casted = message._object as MonoBehaviour;
 
-                                if (GUILayout.Button(s_jumpButtonContent, GUILayout.ExpandWidth(false), GUILayout.ExpandHeight(true)))
+                                if (Selection.activeObject != message._object && (casted == null || casted.gameObject != Selection.activeObject))
                                 {
-                                    Selection.activeObject = message._object;
+                                    if (s_jumpButtonContent == null)
+                                    {
+                                        s_jumpButtonContent = new GUIContent(EditorGUIUtility.FindTexture("d_scenepicking_pickable_hover"), "Jump to object to resolve issue");
+                                    }
+
+                                    if (GUILayout.Button(s_jumpButtonContent, GUILayout.ExpandWidth(false), GUILayout.ExpandHeight(true)))
+                                    {
+                                        Selection.activeObject = message._object;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
Adds a "fix" button (similar to the jump button) to solve validation issues.

<img width="2032" alt="33333" src="https://user-images.githubusercontent.com/5249806/109214436-ae535b00-7766-11eb-95f7-7cafa182bfa2.png">

#767 is a really good case for this which I have provided as a test commit. It will migrate the layer names to the layer mask for the user.

Implementation was a lot simpler than anticipated too which is nice.

I have also added a fix for the jump button. *Selection.activeObject* could be the GO which isn't what we pass through (we pass "this" which is the component). Alternatively, it could be fixed by always passing the GO but the current fix covers both cases.

The icon was chosen from the following [list of icons](https://github.com/halak/unity-editor-icons). I couldn't find a suitable fix or repair icon.

Let me know what you think.