### PR TITLE
Add tooltip attribute for materials/shaders

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/MaterialTooltipDrawer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/MaterialTooltipDrawer.cs
@@ -1,0 +1,182 @@
+﻿// Crest Ocean System
+
+// Adapted from: https://raw.githubusercontent.com/supyrb/ConfigurableShaders/master/Scripts/Editor/MaterialTooltipDrawer.cs
+// License: https://github.com/supyrb/ConfigurableShaders/blob/master/LICENSE.md
+
+namespace Crest.Editor
+{
+    using System.Reflection;
+    using UnityEditor;
+    using UnityEngine;
+
+    /// <summary>
+    /// Draws a tooltip for material properties. <see cref="MaterialCrestTooltipDrawer"/>
+    /// Usage: CrestTooltip(Write your tooltip here without quotes. Only special characters allowed are periods.)
+    /// </summary>
+    public class MaterialCrestTooltipDrawer : MaterialPropertyDrawer
+    {
+        protected string tooltip;
+        protected GUIContent guiContent;
+        MethodInfo DefaultShaderPropertyInternal;
+        object[] methodArguments = new object[3];
+
+        public MaterialCrestTooltipDrawer()
+        {
+        }
+
+        public MaterialCrestTooltipDrawer(string tooltip)
+        {
+            // Use a prefix to determine parameter purpose.
+            if (tooltip.StartsWith("_Tooltip") || !tooltip.StartsWith("_"))
+            {
+                this.tooltip = tooltip.Replace("_Tooltip ", "");
+            }
+
+            guiContent = new GUIContent(string.Empty, this.tooltip);
+
+            // Use reflection to get the internal method.
+            var methodArgumentTypes = new[] { typeof(Rect), typeof(MaterialProperty), typeof(GUIContent) };
+            DefaultShaderPropertyInternal = typeof(MaterialEditor).GetMethod("DefaultShaderPropertyInternal",
+                BindingFlags.Instance | BindingFlags.NonPublic, null, methodArgumentTypes, null);
+        }
+
+        public static string ExtractTooltip(string p1, string p2)
+        {
+            return p1.StartsWith("_Tooltip ") ? p1 : p2;
+        }
+
+        public override void OnGUI(Rect position, MaterialProperty property, string label, MaterialEditor editor)
+        {
+            guiContent.text = label;
+
+            if (DefaultShaderPropertyInternal != null)
+            {
+                // I don't know why, but just calling this here will influence spacing. Must be setting internal GUI state.
+                EditorGUILayout.GetControlRect(true, MaterialEditor.GetDefaultPropertyHeight(property) - 20, EditorStyles.layerMaskField);
+
+                methodArguments[0] = position;
+                methodArguments[1] = property;
+                methodArguments[2] = guiContent;
+
+                switch (property.type)
+                {
+                    case MaterialProperty.PropType.Texture:
+                        editor.TextureProperty(position, property, label, tooltip, !property.flags.HasFlag(MaterialProperty.PropFlags.NoScaleOffset));
+                        break;
+                    case MaterialProperty.PropType.Vector:
+                        VectorProperty(position, property, guiContent);
+                        break;
+                    default: // Range, Float, Color etc
+                        DefaultShaderPropertyInternal.Invoke(editor, methodArguments);
+                        break;
+                }
+            }
+        }
+
+        // The already defined VectorProperty method strips the tooltip away.
+        Vector4 VectorProperty(Rect position, MaterialProperty prop, GUIContent label)
+        {
+            EditorGUI.BeginChangeCheck();
+            EditorGUI.showMixedValue = prop.hasMixedValue;
+
+            // We want to make room for the field in case it's drawn on the same line as the label
+            // Set label width to default width (zero) temporarily
+            var oldLabelWidth = EditorGUIUtility.labelWidth;
+            EditorGUIUtility.labelWidth = 0f;
+
+            Vector4 newValue = EditorGUI.Vector4Field(position, label, prop.vectorValue);
+
+            EditorGUIUtility.labelWidth = oldLabelWidth;
+
+            EditorGUI.showMixedValue = false;
+            if (EditorGUI.EndChangeCheck())
+                prop.vectorValue = newValue;
+
+            return prop.vectorValue;
+        }
+    }
+
+    // There can only be one property drawer per property. We have to redefine the built-in drawers to include the
+    // tooltip parameter. The list of drawers and thier source code:
+    // ToggleDrawer, EnumDrawer, KeywordEnumDrawer, PowerSliderDrawer, IntRangeDrawer
+    // https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/MaterialPropertyDrawer.cs
+
+    // Adapted from: https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/Inspector/MaterialPropertyDrawer.cs#L323
+    internal class MaterialCrestToggleDrawer : MaterialCrestTooltipDrawer
+    {
+        protected readonly string keyword;
+
+        public MaterialCrestToggleDrawer()
+        {
+        }
+
+        public MaterialCrestToggleDrawer(string p1) : base(p1)
+        {
+            // Use a prefix to determine parameter purpose.
+            if (p1.StartsWith("_Keyword "))
+            {
+                keyword = p1.Replace("_Keyword ", "");
+            }
+        }
+
+        public MaterialCrestToggleDrawer(string p1, string p2) : base(ExtractTooltip(p1, p2))
+        {
+            // Use a prefix to determine parameter purpose.
+            keyword = p1.StartsWith("_Keyword ") ? p1 : p2;
+            keyword = keyword.Replace("_Keyword ", "");
+        }
+
+        static bool IsPropertyTypeSuitable(MaterialProperty prop)
+        {
+            return prop.type == MaterialProperty.PropType.Float || prop.type == MaterialProperty.PropType.Range;
+        }
+
+        public override void OnGUI(Rect position, MaterialProperty prop, GUIContent label, MaterialEditor editor)
+        {
+            label.tooltip = tooltip;
+
+            EditorGUI.BeginChangeCheck();
+
+            bool value = (Mathf.Abs(prop.floatValue) > 0.001f);
+            EditorGUI.showMixedValue = prop.hasMixedValue;
+            value = EditorGUI.Toggle(position, label, value);
+            EditorGUI.showMixedValue = false;
+            if (EditorGUI.EndChangeCheck())
+            {
+                prop.floatValue = value ? 1.0f : 0.0f;
+                SetKeyword(prop, value);
+            }
+        }
+
+        public override void Apply(MaterialProperty prop)
+        {
+            base.Apply(prop);
+            if (!IsPropertyTypeSuitable(prop))
+                return;
+
+            if (prop.hasMixedValue)
+                return;
+
+            SetKeyword(prop, (Mathf.Abs(prop.floatValue) > 0.001f));
+        }
+
+        void SetKeyword(MaterialProperty prop, bool on)
+        {
+            SetKeywordInternal(prop, on, "_ON");
+        }
+
+        protected void SetKeywordInternal(MaterialProperty prop, bool on, string defaultKeywordSuffix)
+        {
+            // if no keyword is provided, use <uppercase property name> + defaultKeywordSuffix
+            string kw = string.IsNullOrEmpty(keyword) ? prop.name.ToUpperInvariant() + defaultKeywordSuffix : keyword;
+            // set or clear the keyword
+            foreach (Material material in prop.targets)
+            {
+                if (on)
+                    material.EnableKeyword(kw);
+                else
+                    material.DisableKeyword(kw);
+            }
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Editor/MaterialTooltipDrawer.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/MaterialTooltipDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a19db1e8759d47ad8e3548d528431ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -7,32 +7,32 @@ Shader "Crest/Ocean"
 	Properties
 	{
 		[Header(Normal Mapping)]
-		// Whether to add normal detail from a texture. Can be used to add visual detail to the water surface
-		[Toggle] _ApplyNormalMapping("Enable", Float) = 1
-		// Normal map texture (should be set to Normals type in the properties)
+		[CrestToggle(_Tooltip Whether to add normal detail from a texture. Can be used to add visual detail to the water surface)]
+		_ApplyNormalMapping("Enable", Float) = 1
+		[CrestTooltip(Normal map texture should be set to Normals type in the properties)]
 		[NoScaleOffset] _Normals("Normal Map", 2D) = "bump" {}
-		// Strength of normal map influence
+		[CrestTooltip(Strength of normal map influence)]
 		_NormalsStrength("Strength", Range(0.01, 2.0)) = 0.36
-		// Scale of normal map texture
+		[CrestTooltip(Scale of normal map texture)]
 		_NormalsScale("Scale", Range(0.01, 200.0)) = 40.0
 
 		// Base light scattering settings which give water colour
 		[Header(Scattering)]
-		// Base colour when looking straight down into water
+		[CrestTooltip(Base colour when looking straight down into water)]
 		_Diffuse("Diffuse", Color) = (0.0, 0.0124, 0.566, 1.0)
-		// Base colour when looking into water at shallow/grazing angle
+		[CrestTooltip(Base colour when looking into water at shallow slash grazing angle)]
 		_DiffuseGrazing("Diffuse Grazing", Color) = (0.184, 0.393, 0.519, 1)
-		// Changes colour in shadow. Requires 'Create Shadow Data' enabled on OceanRenderer script.
-		[Toggle] _Shadows("Shadowing", Float) = 0
-		// Base colour in shadow
+		[CrestToggle(_Tooltip Changes colour in shadow. Requires Create Shadow Data enabled on OceanRenderer script.)]
+		_Shadows("Shadowing", Float) = 0
+		[CrestToggle(_Tooltip Base colour in shadow.)]
 		_DiffuseShadow("Diffuse (Shadow)", Color) = (0.0, 0.356, 0.565, 1.0)
 
 		[Header(Subsurface Scattering)]
-		// Whether to to emulate light scattering through the water volume
-		[Toggle] _SubSurfaceScattering("Enable", Float) = 1
-		// Colour tint for primary light contribution
+		[CrestToggle(_Tooltip Whether to to emulate light scattering through the water volume)]
+		_SubSurfaceScattering("Enable", Float) = 1
+		[CrestTooltip(Colour tint for primary light contribution)]
 		_SubSurfaceColour("Colour", Color) = (0.0, 0.48, 0.36)
-		// Amount of primary light contribution that always comes in
+		[CrestTooltip(Amount of primary light contribution that always comes in)]
 		_SubSurfaceBase("Base Mul", Range(0.0, 4.0)) = 1.0
 		// Primary light contribution in direction of light to emulate light passing through waves
 		_SubSurfaceSun("Sun Mul", Range(0.0, 10.0)) = 4.5
@@ -71,14 +71,14 @@ Shader "Crest/Ocean"
 		_PlanarReflectionIntensity("Planar Reflection Intensity", Range(0.0, 1.0)) = 1.0
 		// Whether to use an overridden reflection cubemap (provided in the next property)
 		[Toggle] _OverrideReflectionCubemap("Override Reflection Cubemap", Float) = 0
-		// Custom environment map to reflect
+		[CrestTooltip(Custom environment map to reflect)]
 		[NoScaleOffset] _ReflectionCubemapOverride("Override Reflection Cubemap", CUBE) = "" {}
 
 		[Header(Procedural Skybox)]
 		// Enable a simple procedural skybox, not suitable for realistic reflections, but can be useful to give control over reflection colour
 		// especially in stylized/non realistic applications
 		[Toggle] _ProceduralSky("Enable", Float) = 0
-		// Base sky colour
+		[CrestTooltip(Base sky colour)]
 		[HDR] _SkyBase("Base", Color) = (1.0, 1.0, 1.0, 1.0)
 		// Colour in sun direction
 		[HDR] _SkyTowardsSun("Towards Sun", Color) = (1.0, 1.0, 1.0, 1.0)
@@ -130,7 +130,7 @@ Shader "Crest/Ocean"
 		[Header(Transparency)]
 		// Whether light can pass through the water surface
 		[Toggle] _Transparency("Enable", Float) = 1
-		// Scattering coefficient within water volume, per channel
+		[CrestTooltip(Scattering coefficient within water volume per channel)]
 		_DepthFogDensity("Fog Density", Vector) = (0.33, 0.23, 0.37, 1.0)
 		// How strongly light is refracted when passing through water surface
 		_RefractionStrength("Refraction Strength", Range(0.0, 2.0)) = 0.1


### PR DESCRIPTION
Incomplete. Need to finish all the other built-in attributes like Enum and KeywordEnum. Looking for feedback if you think this is worth pursuing further.

Code is based on (MIT):
https://github.com/supyrb/ConfigurableShaders/blob/master/Scripts/Editor/MaterialSimpleToggleDrawer.cs

Adds our own material/shader attributes so we can add tooltips.

<img width="2032" alt="123" src="https://user-images.githubusercontent.com/5249806/109348237-1c605680-7829-11eb-9446-5f5c8e8af4ef.png">

## Usage

Tooltip
```shader
[CrestTooltip(Normal map texture should be set to Normals type in the properties)]
```

Toggle:
```shader
[CrestToggle(_Tooltip Whether to add normal detail from a texture. Can be used to add visual detail to the water surface)]
```

I have prefixed with Crest to avoid conflicts since they are global.

## Issues
- It requires redefining the built-in drawer attributes (like Toggle) as only one drawer per property is allowed
  - Others: ToggleDrawer, EnumDrawer, KeywordEnumDrawer, PowerSliderDrawer, IntRangeDrawer
- For special characters, only whitespace and periods are allowed
- Attributes with multiple parameters require a prefix (eg _Tooltip) to determine what they are intended for

## Alternatives

### Custom Shader GUI
A custom shader GUI (custom material inspector in other words). This would require manually rendering properties ourselves so they show up. A custom inspector has its own advantages.

### Decorator
The *Header* attribute is a decorator drawer which can have multiple. We could have a button at the inspector which enabled help boxes. Once enabled, these decorator drawers would activate.