### PR TITLE
Hide some gizmo icons in the scene view

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -42,6 +43,23 @@ namespace Crest.EditorHelpers
             }
 
             return sceneCamera;
+        }
+
+        // https://docs.unity3d.com/Manual/ClassIDReference.html
+        const int MONO_BEHAVIOUR_CLASS_ID = 114;
+
+        // Adapted from: https://github.com/Unity-Technologies/com.unity.probuilder/blob/9c3775/Editor/EditorCore/EditorUtility.cs#L572
+        // I do not know why the ProBuilder package can directly access AnnotationUtility in 2019+ when we cannot.
+        static MethodInfo s_setIconEnabled;
+        static MethodInfo SetIconEnabled => s_setIconEnabled = s_setIconEnabled ??
+            Assembly.GetAssembly(typeof(Editor))
+            ?.GetType("UnityEditor.AnnotationUtility")
+            ?.GetMethod("SetIconEnabled", BindingFlags.Static | BindingFlags.NonPublic, null,
+                new System.Type[] { typeof(int), typeof(string), typeof(int) }, null);
+
+        public static void SetGizmoIconEnabled(System.Type scriptType, bool isEnabled)
+        {
+            SetIconEnabled?.Invoke(null, new object[] { MONO_BEHAVIOUR_CLASS_ID, scriptType.Name, isEnabled ? 1 : 0 });
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -37,6 +37,13 @@ namespace Crest
 
         static int sp_DisplacementSamplingIterations = Shader.PropertyToID("_DisplacementSamplingIterations");
 
+#if UNITY_EDITOR
+        void Awake()
+        {
+            EditorHelpers.EditorHelpers.SetGizmoIconEnabled(typeof(RegisterClipSurfaceInput), false);
+        }
+#endif
+
         private void LateUpdate()
         {
             if (OceanRenderer.Instance == null || _renderer == null)

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -20,6 +20,11 @@ namespace Crest.Spline
 #if UNITY_EDITOR
     public partial class Spline : IValidated
     {
+        void Awake()
+        {
+            EditorHelpers.EditorHelpers.SetGizmoIconEnabled(typeof(Spline), false);
+        }
+
         public void OnDrawGizmos()
         {
             Gizmos.color = Color.black * 0.5f;

--- a/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
@@ -14,6 +14,11 @@ namespace Crest.Spline
     public class SplinePoint : MonoBehaviour
     {
 #if UNITY_EDITOR
+        void Awake()
+        {
+            EditorHelpers.EditorHelpers.SetGizmoIconEnabled(typeof(SplinePoint), false);
+        }
+
         void OnDrawGizmos()
         {
             // We could not get gizmos or handles to work well when 3D Icons is enabled. problems included


### PR DESCRIPTION
Uses reflection in Awake to disable the icon for the scene view. I have only added it to a few for now. If we go with this solution then I will add the rest.

The only downside is that it takes the user's choice away since it will always overwrite. But that should be okay.

Let me know what you think.