### PR TITLE
Clip setting enum missing

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -216,7 +216,7 @@ namespace Crest
             EverythingClipped,
         }
         [Tooltip("Whether to clip nothing by default (and clip inputs remove patches of surface), or to clip everything by default (and clip inputs add patches of surface).")]
-        [PredicatedField("_createClipSurfaceData")]
+        //[PredicatedField("_createClipSurfaceData")]
         public DefaultClippingState _defaultClippingState = DefaultClippingState.NothingClipped;
 
         [Header("Edit Mode Params")]


### PR DESCRIPTION
@daleeidd this is an odd one - the "everything/nothing" option seems to get hidden by the PredicatedField attribute. I havent had time to dig deeper. Is this something you have encountered?

On a side note, i'm thinking about moving this option to a new settings data, since they are easy to create now. Which would fix this in a different way. Still i felt it was worth flagging this issue.