### PR TITLE
Fix PredicatedFieldAttribute not rendering

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
@@ -25,7 +25,7 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer)
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer, bool isLast)
         {
             EmbeddedFieldAttribute embeddedAttribute = this;
             embeddedAttribute.editor.DrawEditorCombo(drawer, property, "asset");

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -28,7 +28,7 @@ namespace Crest
         /// <summary>
         /// Override this method to make your own IMGUI based GUI for the property.
         /// </summary>
-        internal abstract void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer);
+        internal abstract void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer, bool isLast);
 
         /// <summary>
         /// Override this method to specify how tall the GUI for this field is in pixels.

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
@@ -62,9 +62,11 @@ namespace Crest.EditorHelpers
             var originalColor = GUI.color;
             var originalEnabled = GUI.enabled;
 
-            foreach (MultiPropertyAttribute attribute in MultiPropertyAttributes)
+            for (var index = 0; index < MultiPropertyAttributes.Count; index++)
             {
-                attribute.OnGUI(position, property, attribute.BuildLabel(label), this);
+                var attribute = (MultiPropertyAttribute)MultiPropertyAttributes[index];
+                var isLast = index == MultiPropertyAttributes.Count - 1;
+                attribute.OnGUI(position, property, attribute.BuildLabel(label), this, isLast);
             }
 
             // Handle resetting the GUI state.

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
@@ -69,7 +69,7 @@ namespace Crest
             return _inverted ? !result : result;
         }
 
-        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer)
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer, bool isLast)
         {
             // Get the other property to be the predicate for the enabled/disabled state of this property.
             var otherProperty = property.serializedObject.FindProperty(_propertyName);
@@ -77,7 +77,12 @@ namespace Crest
             {
                 GUI.enabled = GUIEnabled(otherProperty);
             }
-          }
+
+            if (isLast)
+            {
+                EditorGUI.PropertyField(position, property, label);
+            }
+        }
 #endif
     }
 }


### PR DESCRIPTION
I forgot to handle the case where the PredicatedFieldAttribute is the only MultiPropertyAttribute and needs to call EditorGUI.PropertyField. The way the system works is that the last MultiPropertyAttribute handles rendering. This wasn't a problem with the embedded attributes because they handled the call and the PredicatedFieldAttribute only "decorated".