### PR TITLE
Don't let gerstner waves shader sample displacement

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AnimWavesGerstnerBatchGeometry.shader
@@ -39,7 +39,6 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 
 			CBUFFER_START(GerstnerPerMaterial)
 			half _FeatherWidth;
-			float3 _DisplacementAtInputPosition;
 			CBUFFER_END
 
 			struct Attributes
@@ -66,8 +65,6 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Batch Geometry"
 				Varyings o;
 
 				float3 worldPos = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0)).xyz;
-				// Correct for displacement
-				worldPos.xz -= _DisplacementAtInputPosition.xz;
 
 				o.positionCS = mul(UNITY_MATRIX_VP, float4(worldPos, 1.0));
 


### PR DESCRIPTION
This creates a feedback loop of doom and is making the patch of waves in boat.unity flicker for me.
