### PR TITLE
Make shader keyword check compatible with Shader Graph shader

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -30,6 +30,9 @@ namespace Crest
         public const int THREAD_GROUP_SIZE_X = 8;
         public const int THREAD_GROUP_SIZE_Y = 8;
 
+        // NOTE: This is a temporary solution to keywords having prefixes downstream.
+        internal const string MATERIAL_KEYWORD_PREFIX = "";
+
         protected abstract int GetParamIdSampler(bool sourceLod = false);
 
         protected abstract bool NeedToReadWriteTextureData { get; }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -19,6 +19,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8_UNorm;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
 
+        internal const string MATERIAL_KEYWORD_PROPERTY = "_ClipSurface";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_CLIPSURFACE_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Clipping must be enabled on the ocean material to enable clipping holes in the water surface. Tick the <i>Enable</i> option in the <i>Clip Surface</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The clipping feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
@@ -35,7 +36,9 @@ namespace Crest
             base.Start();
 
 #if UNITY_EDITOR
-            if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(LodDataMgrClipSurface.MATERIAL_KEYWORD))
+            if (OceanRenderer.Instance.OceanMaterial != null
+                && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
+                && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
                 Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -19,7 +19,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8_UNorm;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
 
-        internal const string MATERIAL_KEYWORD = "_CLIPSURFACE_ON";
+        internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_CLIPSURFACE_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Clipping must be enabled on the ocean material to enable clipping holes in the water surface. Tick the <i>Enable</i> option in the <i>Clip Surface</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The clipping feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -19,7 +19,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16G16_SFloat;
         protected override bool NeedToReadWriteTextureData { get { return false; } }
 
-        internal const string MATERIAL_KEYWORD = "_FLOW_ON";
+        internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FLOW_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow must be enabled on the ocean material. Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the Flow feature on the ocean material to save performance.";
         bool _targetsClear = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -19,6 +19,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16G16_SFloat;
         protected override bool NeedToReadWriteTextureData { get { return false; } }
 
+        internal const string MATERIAL_KEYWORD_PROPERTY = "_Flow";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FLOW_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow must be enabled on the ocean material. Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the Flow feature on the ocean material to save performance.";
@@ -52,7 +53,9 @@ namespace Crest
             base.Start();
 
 #if UNITY_EDITOR
-            if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
+            if (OceanRenderer.Instance.OceanMaterial != null
+                && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
+                && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
                 Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -19,7 +19,7 @@ namespace Crest
         public override string SimName { get { return "Foam"; } }
         protected override GraphicsFormat RequestedTextureFormat => Settings._renderTextureGraphicsFormat;
 
-        internal const string MATERIAL_KEYWORD = "_FOAM_ON";
+        internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam must be enabled on the ocean material. Tick the <i>Enable</i> option in the <i>Foam</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Foam feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Foam Sim</i> option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -19,6 +19,7 @@ namespace Crest
         public override string SimName { get { return "Foam"; } }
         protected override GraphicsFormat RequestedTextureFormat => Settings._renderTextureGraphicsFormat;
 
+        internal const string MATERIAL_KEYWORD_PROPERTY = "_Foam";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam must be enabled on the ocean material. Tick the <i>Enable</i> option in the <i>Foam</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Foam feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Foam Sim</i> option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
@@ -55,7 +56,8 @@ namespace Crest
             base.Start();
 
 #if UNITY_EDITOR
-            if (OceanRenderer.Instance != null && OceanRenderer.Instance.OceanMaterial != null
+            if (OceanRenderer.Instance.OceanMaterial != null
+                && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
                 && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
                 Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -84,6 +84,7 @@ namespace Crest
 
 #if UNITY_EDITOR
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateClipSurfaceData;
+        protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
         protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -29,6 +29,7 @@ namespace Crest
             oceanComponent.FindProperty("_createFlowSim").boolValue = true;
         }
 
+        protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrFlow.MATERIAL_KEYWORD;
         protected override string KeywordMissingErrorMessage => LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING;
 #endif // UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -29,6 +29,7 @@ namespace Crest
             oceanComponent.FindProperty("_createFoamSim").boolValue = true;
         }
 
+        protected override string RequiredShaderKeywordProperty => LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrFoam.MATERIAL_KEYWORD;
         protected override string KeywordMissingErrorMessage => LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING;
 #endif // UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -258,6 +258,8 @@ namespace Crest
     {
         protected abstract bool FeatureEnabled(OceanRenderer ocean);
         protected virtual string RequiredShaderKeyword => null;
+        // NOTE: Temporary until shader keywords are the same across pipelines.
+        protected virtual string RequiredShaderKeywordProperty => null;
 
         protected virtual string FeatureDisabledErrorMessage => "Feature must be enabled on the OceanRenderer component.";
         protected virtual string KeywordMissingErrorMessage => "Feature must be enabled on the ocean material.";
@@ -274,7 +276,7 @@ namespace Crest
                 isValid = false;
             }
 
-            if (!string.IsNullOrEmpty(RequiredShaderKeyword) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
+            if (!string.IsNullOrEmpty(RequiredShaderKeyword) && ocean.OceanMaterial.HasProperty(RequiredShaderKeywordProperty) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
             {
                 showMessage(KeywordMissingErrorMessage, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -22,7 +22,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8G8_UNorm;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
 
-        internal const string MATERIAL_KEYWORD = "_SHADOWS_ON";
+        internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_SHADOWS_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing must be enabled on the ocean material. Tick the <i>Shadowing</i> option in the <i>Scattering</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The shadow feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Shadow Data</i> option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -22,6 +22,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8G8_UNorm;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
 
+        internal const string MATERIAL_KEYWORD_PROPERTY = "_Shadows";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_SHADOWS_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing must be enabled on the ocean material. Tick the <i>Shadowing</i> option in the <i>Scattering</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The shadow feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Shadow Data</i> option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
@@ -95,7 +96,9 @@ namespace Crest
             }
 
 #if UNITY_EDITOR
-            if (!OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
+            if (OceanRenderer.Instance.OceanMaterial != null
+                && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
+                && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
                 Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1282,7 +1282,13 @@ namespace Crest
                 );
             }
 
-            if (ocean.CreateFoamSim != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrFoam.MATERIAL_KEYWORD))
+            // For safety.
+            if (ocean == null || ocean.OceanMaterial == null)
+            {
+                return isValid;
+            }
+
+            if (ocean.OceanMaterial.HasProperty(LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY) && ocean.CreateFoamSim != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrFoam.MATERIAL_KEYWORD))
             {
                 if (ocean.CreateFoamSim)
                 {
@@ -1294,7 +1300,7 @@ namespace Crest
                 }
             }
 
-            if (ocean.CreateFlowSim != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrFlow.MATERIAL_KEYWORD))
+            if (ocean.OceanMaterial.HasProperty(LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY) && ocean.CreateFlowSim != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrFlow.MATERIAL_KEYWORD))
             {
                 if (ocean.CreateFlowSim)
                 {
@@ -1306,7 +1312,7 @@ namespace Crest
                 }
             }
 
-            if (ocean.CreateShadowData != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrShadow.MATERIAL_KEYWORD))
+            if (ocean.OceanMaterial.HasProperty(LodDataMgrShadow.MATERIAL_KEYWORD_PROPERTY) && ocean.CreateShadowData != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrShadow.MATERIAL_KEYWORD))
             {
                 if (ocean.CreateShadowData)
                 {
@@ -1318,7 +1324,7 @@ namespace Crest
                 }
             }
 
-            if (ocean.CreateClipSurfaceData != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrClipSurface.MATERIAL_KEYWORD))
+            if (ocean.OceanMaterial.HasProperty(LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY) && ocean.CreateClipSurfaceData != ocean.OceanMaterial.IsKeywordEnabled(LodDataMgrClipSurface.MATERIAL_KEYWORD))
             {
                 if (ocean.CreateClipSurfaceData)
                 {


### PR DESCRIPTION
Shader keywords differ with SG. They either have a prefix or are missing. The point of this PR is to reduce diff noise and increase compatibility. Hopefully, this will be a temporary solution.

Adds a *MATERIAL_KEYWORD_PREFIX* constant which is used:
```csharp
internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
```
For built-in, the prefix is an empty string, but CREST_ will be added in HDRP (diff noise).

MATERIAL_KEYWORD_PROPERTY

The next is skipping any keyword where the *OceanMaterial.HasProperty* is false. This checks the property name. So for foam we check "_Foam" which matches with "FOAM_ON".

So with SG, if we do not have a keyword defined, then it will be skipped.

*MATERIAL_KEYWORD_PROPERTY* has been added which will need to be changed in HDRP (diff noise).

This will give us time to consider #769 more carefully. If that PR is merged only the prefix change needs to be reverted. The HasProperty fix will probably need to stay.