### PR TITLE
Rearrange and rename ocean material properties

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -10,46 +10,46 @@ Shader "Crest/Ocean"
 		// Whether to add normal detail from a texture. Can be used to add visual detail to the water surface
 		[Toggle] _ApplyNormalMapping("Enable", Float) = 1
 		// Normal map texture (should be set to Normals type in the properties)
-		[NoScaleOffset] _Normals("Normal Map", 2D) = "bump" {}
-		// Strength of normal map influence
-		_NormalsStrength("Strength", Range(0.01, 2.0)) = 0.36
+		[NoScaleOffset] _Normals("Normals", 2D) = "bump" {}
 		// Scale of normal map texture
-		_NormalsScale("Scale", Range(0.01, 200.0)) = 40.0
+		_NormalsScale("Normal Scale", Range(0.01, 200.0)) = 40.0
+		// Strength of normal map influence
+		_NormalsStrength("Normal Strength", Range(0.01, 2.0)) = 0.36
 
 		// Base light scattering settings which give water colour
 		[Header(Scattering)]
 		// Base colour when looking straight down into water
-		_Diffuse("Diffuse", Color) = (0.0, 0.0124, 0.566, 1.0)
+		_Diffuse("Scatter Colour Base", Color) = (0.0, 0.0124, 0.566, 1.0)
 		// Base colour when looking into water at shallow/grazing angle
-		_DiffuseGrazing("Diffuse Grazing", Color) = (0.184, 0.393, 0.519, 1)
+		_DiffuseGrazing("Scatter Colour Grazing", Color) = (0.184, 0.393, 0.519, 1)
 		// Changes colour in shadow. Requires 'Create Shadow Data' enabled on OceanRenderer script.
 		[Toggle] _Shadows("Shadowing", Float) = 0
 		// Base colour in shadow
-		_DiffuseShadow("Diffuse (Shadow)", Color) = (0.0, 0.356, 0.565, 1.0)
+		_DiffuseShadow("Scatter Colour Shadow", Color) = (0.0, 0.356, 0.565, 1.0)
+
+		[Header(Shallow Scattering)]
+		// Enable light scattering in shallow water
+		[Toggle] _SubSurfaceShallowColour("Enable", Float) = 1
+		// Colour in shallow water
+		_SubSurfaceShallowCol("Scatter Colour Shallow", Color) = (0.552, 1.0, 1.0, 1.0)
+		// Max depth that is considered 'shallow'
+		_SubSurfaceDepthMax("Scatter Colour Shallow Depth Max", Range(0.01, 50.0)) = 10.0
+		// Fall off of shallow scattering
+		_SubSurfaceDepthPower("Scatter Colour Shallow Depth Falloff", Range(0.01, 10.0)) = 2.5
+		// Shallow water colour in shadow (see comment on Shadowing param above)
+		_SubSurfaceShallowColShadow("Scatter Colour Shallow Shadow", Color) = (0.144, 0.226, 0.212, 1)
 
 		[Header(Subsurface Scattering)]
 		// Whether to to emulate light scattering through the water volume
 		[Toggle] _SubSurfaceScattering("Enable", Float) = 1
 		// Colour tint for primary light contribution
-		_SubSurfaceColour("Colour", Color) = (0.0, 0.48, 0.36)
+		_SubSurfaceColour("SSS Tint", Color) = (0.0, 0.48, 0.36)
 		// Amount of primary light contribution that always comes in
-		_SubSurfaceBase("Base Mul", Range(0.0, 4.0)) = 1.0
+		_SubSurfaceBase("SSS Intensity Base", Range(0.0, 4.0)) = 1.0
 		// Primary light contribution in direction of light to emulate light passing through waves
-		_SubSurfaceSun("Sun Mul", Range(0.0, 10.0)) = 4.5
+		_SubSurfaceSun("SSS Intensity Sun", Range(0.0, 10.0)) = 4.5
 		// Fall-off for primary light scattering to affect directionality
-		_SubSurfaceSunFallOff("Sun Fall-Off", Range(1.0, 16.0)) = 5.0
-
-		[Header(Shallow Scattering)]
-		// Enable light scattering in shallow water
-		[Toggle] _SubSurfaceShallowColour("Enable", Float) = 1
-		// Max depth that is considered 'shallow'
-		_SubSurfaceDepthMax("Depth Max", Range(0.01, 50.0)) = 10.0
-		// Fall off of shallow scattering
-		_SubSurfaceDepthPower("Depth Power", Range(0.01, 10.0)) = 2.5
-		// Colour in shallow water
-		_SubSurfaceShallowCol("Shallow Colour", Color) = (0.552, 1.0, 1.0, 1.0)
-		// Shallow water colour in shadow (see comment on Shadowing param above)
-		_SubSurfaceShallowColShadow("Shallow Colour (Shadow)", Color) = (0.144, 0.226, 0.212, 1)
+		_SubSurfaceSunFallOff("SSS Sun Falloff", Range(1.0, 16.0)) = 5.0
 
 		// Reflection properites
 		[Header(Reflection Environment)]
@@ -72,7 +72,7 @@ Shader "Crest/Ocean"
 		// Whether to use an overridden reflection cubemap (provided in the next property)
 		[Toggle] _OverrideReflectionCubemap("Override Reflection Cubemap", Float) = 0
 		// Custom environment map to reflect
-		[NoScaleOffset] _ReflectionCubemapOverride("Override Reflection Cubemap", CUBE) = "" {}
+		[NoScaleOffset] _ReflectionCubemapOverride("Reflection Cubemap Override", CUBE) = "" {}
 
 		[Header(Procedural Skybox)]
 		// Enable a simple procedural skybox, not suitable for realistic reflections, but can be useful to give control over reflection colour
@@ -88,50 +88,58 @@ Shader "Crest/Ocean"
 		[HDR] _SkyAwayFromSun("Away From Sun", Color) = (1.0, 1.0, 1.0, 1.0)
 
 		[Header(Add Directional Light)]
+		// Add specular highlights from the the primary light.
 		[Toggle] _ComputeDirectionalLight("Enable", Float) = 1
-		_DirectionalLightFallOff("Fall-Off", Range(1.0, 4096.0)) = 275.0
-		[Toggle] _DirectionalLightVaryRoughness("Vary Fall-Off Over Distance", Float) = 0
-		_DirectionalLightFarDistance("Far Distance", Float) = 137.0
-		_DirectionalLightFallOffFar("Fall-Off At Far Distance", Range(1.0, 4096.0)) = 42.0
+		// Specular highlight intensity.
 		_DirectionalLightBoost("Boost", Range(0.0, 512.0)) = 7.0
+		// Falloff of the specular highlights from source to camera.
+		_DirectionalLightFallOff("Falloff", Range(1.0, 4096.0)) = 275.0
+		// Helps to spread out specular highlight in mid-to-background.
+		[Toggle] _DirectionalLightVaryRoughness("Vary Falloff Over Distance", Float) = 0
+		// Definition of far distance.
+		_DirectionalLightFarDistance("Far Distance", Float) = 137.0
+		// Same as "Falloff" except only up to "Far Distance".
+		_DirectionalLightFallOffFar("Falloff At Far Distance", Range(1.0, 4096.0)) = 42.0
 
 		[Header(Foam)]
 		// Enable foam layer on ocean surface
 		[Toggle] _Foam("Enable", Float) = 1
 		// Foam texture
-		[NoScaleOffset] _FoamTexture("Texture", 2D) = "white" {}
+		[NoScaleOffset] _FoamTexture("Foam", 2D) = "white" {}
 		// Foam texture scale
-		_FoamScale("Scale", Range(0.01, 50.0)) = 10.0
+		_FoamScale("Foam Scale", Range(0.01, 50.0)) = 10.0
+		// Controls how gradual the transition is from full foam to no foam
+		_WaveFoamFeather("Foam Feather", Range(0.001, 1.0)) = 0.4
 		// Scale intensity of lighting
-		_WaveFoamLightScale("Light Scale", Range(0.0, 2.0)) = 1.35
+		_WaveFoamLightScale("Foam Light Scale", Range(0.0, 2.0)) = 1.35
 		// Colour tint for whitecaps / foam on water surface
-		_FoamWhiteColor("White Foam Color", Color) = (1.0, 1.0, 1.0, 1.0)
-		// Colour tint bubble foam underneath water surface
-		_FoamBubbleColor("Bubble Foam Color", Color) = (0.64, 0.83, 0.82, 1.0)
-		// Parallax for underwater bubbles to give feeling of volume
-		_FoamBubbleParallax("Bubble Foam Parallax", Range(0.0, 0.5)) = 0.14
+		_FoamWhiteColor("Foam Tint", Color) = (1.0, 1.0, 1.0, 1.0)
 		// Proximity to sea floor where foam starts to get generated
 		_ShorelineFoamMinDepth("Shoreline Foam Min Depth", Range(0.01, 5.0)) = 0.27
-		// Controls how gradual the transition is from full foam to no foam
-		_WaveFoamFeather("Wave Foam Feather", Range(0.001, 1.0)) = 0.4
-		// How much underwater bubble foam is generated
-		_WaveFoamBubblesCoverage("Wave Foam Bubbles Coverage", Range(0.0, 5.0)) = 1.68
 
 		[Header(Foam 3D Lighting)]
 		// Generates normals for the foam based on foam values/texture and use it for foam lighting
 		[Toggle] _Foam3DLighting("Enable", Float) = 1
 		// Strength of the generated normals
-		_WaveFoamNormalStrength("Normals Strength", Range(0.0, 30.0)) = 3.5
+		_WaveFoamNormalStrength("Foam Normal Strength", Range(0.0, 30.0)) = 3.5
 		// Acts like a gloss parameter for specular response
-		_WaveFoamSpecularFallOff("Specular Fall-Off", Range(1.0, 512.0)) = 293.0
+		_WaveFoamSpecularFallOff("Specular Falloff", Range(1.0, 512.0)) = 293.0
 		// Strength of specular response
 		_WaveFoamSpecularBoost("Specular Boost", Range(0.0, 16.0)) = 0.15
+
+		[Header(Foam Bubbles)]
+		// Colour tint bubble foam underneath water surface
+		_FoamBubbleColor("Foam Bubbles Color", Color) = (0.64, 0.83, 0.82, 1.0)
+		// Parallax for underwater bubbles to give feeling of volume
+		_FoamBubbleParallax("Foam Bubbles Parallax", Range(0.0, 0.5)) = 0.14
+		// How much underwater bubble foam is generated
+		_WaveFoamBubblesCoverage("Foam Bubbles Coverage", Range(0.0, 5.0)) = 1.68
 
 		[Header(Transparency)]
 		// Whether light can pass through the water surface
 		[Toggle] _Transparency("Enable", Float) = 1
 		// Scattering coefficient within water volume, per channel
-		_DepthFogDensity("Fog Density", Vector) = (0.33, 0.23, 0.37, 1.0)
+		_DepthFogDensity("Depth Fog Density", Vector) = (0.33, 0.23, 0.37, 1.0)
 		// How strongly light is refracted when passing through water surface
 		_RefractionStrength("Refraction Strength", Range(0.0, 2.0)) = 0.1
 
@@ -141,19 +149,19 @@ Shader "Crest/Ocean"
 		// Caustics texture
 		[NoScaleOffset] _CausticsTexture("Caustics", 2D) = "black" {}
 		// Caustics texture scale
-		_CausticsTextureScale("Scale", Range(0.0, 25.0)) = 5.0
+		_CausticsTextureScale("Caustics Scale", Range(0.0, 25.0)) = 5.0
 		// The 'mid' value of the caustics texture, around which the caustic texture values are scaled
-		_CausticsTextureAverage("Texture Average Value", Range(0.0, 1.0)) = 0.07
+		_CausticsTextureAverage("Caustics Texture Grey Point", Range(0.0, 1.0)) = 0.07
 		// Scaling / intensity
-		_CausticsStrength("Strength", Range(0.0, 10.0)) = 3.2
+		_CausticsStrength("Caustics Strength", Range(0.0, 10.0)) = 3.2
 		// The depth at which the caustics are in focus
-		_CausticsFocalDepth("Focal Depth", Range(0.0, 250.0)) = 2.0
+		_CausticsFocalDepth("Caustics Focal Depth", Range(0.0, 250.0)) = 2.0
 		// The range of depths over which the caustics are in focus
-		_CausticsDepthOfField("Depth Of Field", Range(0.01, 1000.0)) = 0.33
+		_CausticsDepthOfField("Caustics Depth of Field", Range(0.01, 1000.0)) = 0.33
 		// How much the caustics texture is distorted
-		_CausticsDistortionStrength("Distortion Strength", Range(0.0, 0.25)) = 0.16
+		_CausticsDistortionStrength("Caustics Distortion Strength", Range(0.0, 0.25)) = 0.16
 		// The scale of the distortion pattern used to distort the caustics
-		_CausticsDistortionScale("Distortion Scale", Range(0.01, 50.0)) = 25.0
+		_CausticsDistortionScale("Caustics Distortion Scale", Range(0.01, 50.0)) = 25.0
 
 		// To use the underwater effect the UnderWaterCurtainGeom and UnderWaterMeniscus prefabs must be parented to the camera.
 		[Header(Underwater)]


### PR DESCRIPTION
Makes it similar to shader graph. It will help with documentation and referencing.

I chose the names from HDRP where they matched.

I also made two new sections: _Shallow Scattering_ and _Foam Bubbles_. Breaks up the documentation better with these additional headings and properly groups foam bubbles settings together.