### PR TITLE
Use AddComponentMenu for easier component searching

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 /// <summary>
 /// Simple type of buoyancy - takes one sample and matches boat height and orientation to water height and normal.
 /// </summary>
+[AddComponentMenu(Crest.Internal.Constants.MENU_PREFIX_EXAMPLE + "Boat Align Normal")]
 public class BoatAlignNormal : FloatingObjectBase
 {
     [Header("Buoyancy Force")]

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/RippleGenerator.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/RippleGenerator.cs
@@ -5,6 +5,7 @@
 using Crest;
 using UnityEngine;
 
+[AddComponentMenu(Crest.Internal.Constants.MENU_PREFIX_EXAMPLE + "Ripple Generator")]
 public class RippleGenerator : MonoBehaviour
 {
     public bool _animate = true;

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 /// <summary>
 /// Attach this script to any GameObject and it will create three collision probes in front of the camera
 /// </summary>
+[AddComponentMenu(Crest.Internal.Constants.MENU_PREFIX_EXAMPLE + "Ocean Sample Displacement Demo")]
 public class OceanSampleDisplacementDemo : MonoBehaviour
 {
     public bool _trackCamera = true;

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightDemo.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 /// <summary>
 /// Places the game object on the water surface by moving it vertically.
 /// </summary>
+[AddComponentMenu(Crest.Internal.Constants.MENU_PREFIX_EXAMPLE + "Ocean Sample Height Demo")]
 public class OceanSampleHeightDemo : MonoBehaviour
 {
     SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleHeightEvents.cs
@@ -13,6 +13,7 @@ using UnityEditor;
 /// <summary>
 /// Emits useful events (UnityEvents) based on the sampled height of the ocean surface.
 /// </summary>
+[AddComponentMenu(Crest.Internal.Constants.MENU_PREFIX_EXAMPLE + "Ocean Sample Height Events")]
 public class OceanSampleHeightEvents : MonoBehaviour
 {
     [Header("Settings For All Events")]
@@ -101,7 +102,7 @@ public class OceanSampleHeightEvents : MonoBehaviour
             EditorGUILayout.Space();
             EditorGUILayout.HelpBox
             (
-                "For the Above/Below Ocean Surface Events, whenever this game object goes below or above the ocean " + 
+                "For the Above/Below Ocean Surface Events, whenever this game object goes below or above the ocean " +
                 "surface, the appropriate event is fired once per state change. It can be used to trigger audio to " +
                 "play underwater and much more. For the Distance From Ocean Surface event, it will pass the " +
                 "distance every frame (passing normalised distance to audio volume as an example).",

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
@@ -12,9 +12,10 @@ namespace Crest
 {
     /// <summary>
     /// Provides out-scattering based on the camera's underwater depth. It scales down environmental lighting
-    /// (directional light, reflections, ambient etc) with the underwater depth. This works with vanilla lighting, but 
+    /// (directional light, reflections, ambient etc) with the underwater depth. This works with vanilla lighting, but
     /// uncommon or custom lighting will require a custom solution (use this for reference).
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_EXAMPLE + "Underwater Environmental Lighting")]
     public class UnderwaterEnvironmentalLighting : MonoBehaviour
     {
         [Tooltip("How much this effect applies. Values less than 1 attenuate light less underwater. Value of 1 is physically based."), SerializeField, Range(0f, 3f)]

--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 
 namespace Crest
 {
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_EXAMPLE + "Whirlpool")]
     public class Whirlpool : MonoBehaviour
     {
         [Range(0, 1000), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
@@ -9,6 +9,7 @@ namespace Crest
     /// <summary>
     /// Debug draw crosses in an area around the GameObject on the water surface.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_DEBUG + "Visualise Collision Area")]
     public class VisualiseCollisionArea : MonoBehaviour
     {
         [SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseRayTrace.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseRayTrace.cs
@@ -9,6 +9,7 @@ namespace Crest
     /// <summary>
     /// Debug draw a line trace from this gameobjects position, in this gameobjects forward direction.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_DEBUG + "Visualise Ray Trace")]
     public class VisualiseRayTrace : MonoBehaviour
     {
         RayTraceHelper _rayTrace = new RayTraceHelper(50f, 2f);

--- a/crest/Assets/Crest/Crest/Scripts/Constants.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Constants.cs
@@ -1,0 +1,17 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest.Internal
+{
+    public static class Constants
+    {
+        const string PREFIX = "Crest ";
+        public const string MENU_SCRIPTS = "Scripts/Crest/";
+        public const string MENU_PREFIX_SCRIPTS = MENU_SCRIPTS + PREFIX;
+        public const string MENU_PREFIX_INTERNAL = MENU_SCRIPTS + "Internal/";
+        public const string MENU_PREFIX_DEBUG = MENU_SCRIPTS + "Debug/" + PREFIX;
+        public const string MENU_PREFIX_SPLINE = MENU_SCRIPTS + "Spline/" + PREFIX;
+        public const string MENU_PREFIX_EXAMPLE = MENU_SCRIPTS + "Example/" + PREFIX;
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Constants.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Constants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eceb0e0a458e64d4bb77aa597cf18761
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -36,6 +36,7 @@ namespace Crest
     /// point it moves everything so that the camera is back at the origin. There is also an option to disable physics beyond a certain point. This
     /// script should normally be attached to the viewpoint, typically the main camera.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Floating Origin")]
     public class FloatingOrigin : MonoBehaviour
     {
         [Tooltip("Use a power of 2 to avoid pops in ocean surface geometry."), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -9,6 +9,7 @@ using UnityEngine.SceneManagement;
 namespace Crest
 {
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_DEBUG + "Ocean Debug GUI")]
     public class OceanDebugGUI : MonoBehaviour
     {
         public bool _showOceanData = true;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -10,6 +10,7 @@ namespace Crest
     /// Helper script for alpha geometry rendering on top of ocean surface. This is required to select the best
     /// LOD and assign the shape texture to the material.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Render Alpha On Surface")]
     public class RenderAlphaOnSurface : MonoBehaviour
     {
         public bool _drawBounds = false;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderWireFrame.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderWireFrame.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 /// Triggers the scene render to happen in wireframe. Unfortunately this currently affects the GUI elements as well.
 /// </summary>
 [RequireComponent(typeof(Camera))]
+[AddComponentMenu(Crest.Internal.Constants.MENU_PREFIX_DEBUG + "Render Wire Frame")]
 public class RenderWireFrame : MonoBehaviour
 {
     public bool _gui = true;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -20,6 +20,7 @@ namespace Crest
     /// Handles effects that need to track the water surface. Feeds in wave data and disables rendering when
     /// not close to water.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Underwater Effect")]
     public partial class UnderwaterEffect : MonoBehaviour
     {
         [Header("Copy params from Ocean material")]

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -13,6 +13,7 @@ namespace Crest
     /// <summary>
     /// Boat physics by sampling at multiple probe points.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Boat Probes")]
     public class BoatProbes : FloatingObjectBase
     {
         [Header("Forces")]

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -13,6 +13,7 @@ namespace Crest
     /// <summary>
     /// Drives object/water interaction - sets parameters each frame on material that renders into the dynamic wave sim.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Object Water Interaction")]
     public partial class ObjectWaterInteraction : MonoBehaviour
     {
         [Range(0f, 2f), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteractionAdaptor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteractionAdaptor.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 
 namespace Crest
 {
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Object Water Interaction Adaptor")]
     public class ObjectWaterInteractionAdaptor : FloatingObjectBase
     {
         public override float ObjectWidth => 0f;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -12,6 +12,7 @@ namespace Crest
     /// Applies simple approximation of buoyancy force - force based on submerged depth and torque based on alignment
     /// to water normal.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Simple Floating Object")]
     public class SimpleFloatingObject : FloatingObjectBase
     {
         [Header("Buoyancy Force")]

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -14,6 +14,7 @@ namespace Crest
     /// This script and associated shader approximate the interaction between a sphere and the water. Multiple
     /// spheres can be used to model the interaction of a non-spherical shape.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Sphere Water Interaction")]
     public partial class SphereWaterInteraction : MonoBehaviour
     {
         float Radius => 0.5f * transform.lossyScale.x;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -17,6 +17,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [HelpURL("https://github.com/wave-harmonic/crest/blob/master/USERGUIDE.md#shorelines-and-shallow-water")]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Depth Cache")]
     public partial class OceanDepthCache : MonoBehaviour
     {
         public enum OceanDepthCacheType

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// Registers a custom input to the wave shape. Attach this GameObjects that you want to render into the displacmeent textures to affect ocean shape.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(MENU_PREFIX + "Animated Waves Input")]
     public class RegisterAnimWavesInput : RegisterLodDataInput<LodDataMgrAnimWaves>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// Registers a custom input to the clip surface simulation. Attach this to GameObjects that you want to use to
     /// clip the surface of the ocean.
     /// </summary>
+    [AddComponentMenu(MENU_PREFIX + "Clip Surface Input")]
     public class RegisterClipSurfaceInput : RegisterLodDataInput<LodDataMgrClipSurface>
     {
         bool _enabled = true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// Registers a custom input to the dynamic wave simulation. Attach this GameObjects that you want to influence the sim to add ripples etc.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(MENU_PREFIX + "Dynamic Waves Input")]
     public class RegisterDynWavesInput : RegisterLodDataInput<LodDataMgrDynWaves>
     {
         public override float Wavelength => 0f;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// Registers a custom input to the flow data. Attach this GameObjects that you want to influence the horizontal flow of the water volume.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(MENU_PREFIX + "Flow Input")]
     public class RegisterFlowInput : RegisterLodDataInputDisplacementCorrection<LodDataMgrFlow>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// Registers a custom input to the foam simulation. Attach this GameObjects that you want to influence the foam simulation, such as depositing foam on the surface.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(MENU_PREFIX + "Foam Input")]
     public class RegisterFoamInput : RegisterLodDataInputDisplacementCorrection<LodDataMgrFoam>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -60,6 +60,8 @@ namespace Crest
         bool _checkShaderName = true;
 #endif
 
+        public const string MENU_PREFIX = Internal.Constants.MENU_SCRIPTS + "LOD Inputs/Crest Register ";
+
         public abstract float Wavelength { get; }
 
         public abstract bool Enabled { get; }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -12,6 +12,7 @@ namespace Crest
     /// For static objects, use an Ocean Depth Cache.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(MENU_PREFIX + "Sea Floor Depth Input")]
     public class RegisterSeaFloorDepthInput : RegisterLodDataInput<LodDataMgrSeaFloorDepth>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// Registers a custom input for shadow data. Attach this to GameObjects that you want use to override shadows.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(MENU_PREFIX + "Shadow Input")]
     public class RegisterShadowInput : RegisterLodDataInput<LodDataMgrShadow>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -15,6 +15,7 @@ namespace Crest
     /// Sets shader parameters for each geometry tile/chunk.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_INTERNAL + "Ocean Chunk Renderer")]
     public class OceanChunkRenderer : MonoBehaviour
     {
         public bool _drawRenderBounds = false;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -22,6 +22,7 @@ namespace Crest
     /// and moves/scales the ocean based on the viewpoint. It also hosts a number of global settings that can be tweaked here.
     /// </summary>
     [ExecuteAlways, SelectionBase]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Renderer")]
     public partial class OceanRenderer : MonoBehaviour
     {
         [Tooltip("The viewpoint which drives the ocean detail. Defaults to the camera."), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -79,6 +79,7 @@ namespace Crest
     /// <summary>
     /// Attach to a camera to generate a reflection texture which can be sampled in the ocean shader.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Planar Reflections")]
     public class OceanPlanarReflection : MonoBehaviour
     {
         [SerializeField] LayerMask _reflectionLayers = 1;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -18,6 +18,7 @@ namespace Crest
     /// Gerstner ocean waves.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner")]
     public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin
 #if UNITY_EDITOR
         , IReceiveSplinePointOnDrawGizmosSelectedMessages

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -16,6 +16,7 @@ namespace Crest
     /// Generates a number of batches of Gerstner waves.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner Batched")]
     public partial class ShapeGerstnerBatched : MonoBehaviour, ICollProvider, IFloatingOrigin
     {
         public enum GerstnerMode

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -11,6 +11,7 @@ namespace Crest.Spline
     /// Simple spline object. Spline points are child gameobjects.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SPLINE + "Spline")]
     public partial class Spline : MonoBehaviour
     {
         [Tooltip("Connect start and end point to close spline into a loop. Requires at least 3 spline points.")]

--- a/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
@@ -11,6 +11,7 @@ namespace Crest.Spline
     /// Spline point, intended to be child of Spline object
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SPLINE + "Spline Point")]
     public class SplinePoint : MonoBehaviour
     {
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -15,6 +15,7 @@ namespace Crest
     /// culled if they don't overlap any WaterBody.
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Water Body")]
     public partial class WaterBody : MonoBehaviour
     {
 #pragma warning disable 414


### PR DESCRIPTION
Reorganises our scripts in the component menu by adding submenus. Also adds a "Crest" prefix to our scripts so that they all come up if someone searches "Crest". I didn't touch any components that were generic utilities. There is also an additional file for housing constants.

Searching:
<img width="276" alt="Add Component Menu Search" src="https://user-images.githubusercontent.com/5249806/111836212-2e2a9c00-88b3-11eb-837f-46bc444af6aa.png">

Submenus:
<img width="276" alt="Add Component Menu Sub-Menus" src="https://user-images.githubusercontent.com/5249806/111836696-f2440680-88b3-11eb-8aff-e01c236479c4.png">