### PR TITLE
Validation fix descriptions to describe fix to user

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
@@ -41,7 +41,7 @@ namespace Crest
                 showMessage
                 (
                     "Layer name required by AssignLayer script.",
-                    "Specify the name of a valid layer in the 'Layer Name' field.",
+                    "Specify the name of a valid layer in the <i>Layer Name</i> field.",
                     ValidatedHelper.MessageType.Error, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
@@ -3,7 +3,6 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 using UnityEngine;
-using System.Diagnostics.Tracing;
 
 #if UNITY_EDITOR
 using UnityEditor;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/AssignLayer.cs
@@ -3,6 +3,7 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 using UnityEngine;
+using System.Diagnostics.Tracing;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -41,6 +42,7 @@ namespace Crest
                 showMessage
                 (
                     "Layer name required by AssignLayer script.",
+                    "Specify the name of a valid layer in the 'Layer Name' field.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -51,7 +53,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    $"Layer <i>{_layerName}</i> does not exist in the project, please add it.",
+                    $"Layer <i>{_layerName}</i> does not exist in the project.",
+                    $"Add a layer with name in the <i>Tags and Layers</i> section of the Project Settings.",
                     ValidatedHelper.MessageType.Error, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -251,7 +251,7 @@ namespace Crest
                 showMessage
                 (
                     "Underwater effects expect to be parented to a camera.",
-                    "Parent this GameObject underneath a GameObject that has a Camera component attached.",
+                    "Parent this GameObject underneath a GameObject that has a <i>Camera</i> component attached.",
                     ValidatedHelper.MessageType.Error, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -251,6 +251,7 @@ namespace Crest
                 showMessage
                 (
                     "Underwater effects expect to be parented to a camera.",
+                    "Parent this GameObject underneath a GameObject that has a Camera component attached.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -265,6 +266,7 @@ namespace Crest
                 showMessage
                 (
                     $"Shader assigned to underwater effect expected to be of type <i>{shaderPrefix}</i>.",
+                    $"Assign shader of type <i>{shaderPrefix}</i>.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -286,6 +288,7 @@ namespace Crest
                             $"Keyword {keyword} was enabled on the underwater material <i>{renderer.sharedMaterial.name}</i>"
                             + $"but not on the ocean material <i>{ocean.OceanMaterial.name}</i>, underwater appearance "
                             + "may not match ocean surface in standalone builds.",
+                            "Compare the toggles on the ocean material and the underwater material and ensure they match.",
                             ValidatedHelper.MessageType.Warning, this
                         );
                     }
@@ -305,6 +308,7 @@ namespace Crest
                             $"Keyword {keyword} is enabled on the ocean material <i>{ocean.OceanMaterial.name}</i> but "
                             + $"not on the underwater material <i>{renderer.sharedMaterial.name}</i>, underwater "
                             + "appearance may not match ocean surface in standalone builds.",
+                            "Compare the toggles on the ocean material and the underwater material and ensure they match.",
                             ValidatedHelper.MessageType.Warning, this
                         );
                     }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -32,7 +32,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>Collision Source</i> in <i>Animated Waves Settings</i> is set to <i>None</i>. The floating objects in the scene will use a flat horizontal plane.",
-                    "Set the Collision Source to ComputeShaderQueries to incorporate waves into physics.",
+                    "Set the <i>Collision Source</i> to <i>ComputeShaderQueries</i> to incorporate waves into physics.",
                     ValidatedHelper.MessageType.Warning, ocean,
                     SimSettingsAnimatedWaves.FixSetCollisionSourceToCompute
                 );

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -32,6 +32,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>Collision Source</i> in <i>Animated Waves Settings</i> is set to <i>None</i>. The floating objects in the scene will use a flat horizontal plane.",
+                    "Set the <i>Collision Source</i> to <i>ComputeShaderQueries</i> to get accurate physics.",
                     ValidatedHelper.MessageType.Warning, ocean
                 );
 
@@ -44,6 +45,7 @@ namespace Crest
                 showMessage
                 (
                     $"Expected to have one rigidbody on floating object, currently has {rbs.Length} object(s).",
+                    "Remove additional <i>Rigidbody</i> components.",
                     ValidatedHelper.MessageType.Error, this
                 );
             }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -33,7 +33,8 @@ namespace Crest
                 (
                     "<i>Collision Source</i> in <i>Animated Waves Settings</i> is set to <i>None</i>. The floating objects in the scene will use a flat horizontal plane.",
                     "Set the Collision Source to ComputeShaderQueries to incorporate waves into physics.",
-                    ValidatedHelper.MessageType.Warning, ocean, SimSettingsAnimatedWaves.FixSetCollisionSourceToCompute
+                    ValidatedHelper.MessageType.Warning, ocean,
+                    SimSettingsAnimatedWaves.FixSetCollisionSourceToCompute
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -32,8 +32,8 @@ namespace Crest
                 showMessage
                 (
                     "<i>Collision Source</i> in <i>Animated Waves Settings</i> is set to <i>None</i>. The floating objects in the scene will use a flat horizontal plane.",
-                    "Set the <i>Collision Source</i> to <i>ComputeShaderQueries</i> to get accurate physics.",
-                    ValidatedHelper.MessageType.Warning, ocean
+                    "Set the Collision Source to ComputeShaderQueries to incorporate waves into physics.",
+                    ValidatedHelper.MessageType.Warning, ocean, SimSettingsAnimatedWaves.FixSetCollisionSourceToCompute
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -168,7 +168,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>ObjectWaterInteraction</i> requires dynamic wave simulation to be enabled on <i>OceanRenderer</i>.",
+                    "<i>ObjectWaterInteraction</i> requires dynamic wave simulation to be enabled.",
+                    $"Enable <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_NAME}</i> option on the <i>OceanRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
 
@@ -179,7 +180,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>ObjectWaterInteraction</i> script requires a parent <i>GameObject</i>.",
+                    "<i>ObjectWaterInteraction</i> script requires a parent GameObject.",
+                    "Create a primary GameObject for the object, and parent this underneath it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -190,8 +192,9 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>ObjectWaterInteraction</i> script requires <i>RegisterDynWavesInput</i> script to be present.",
-                    ValidatedHelper.MessageType.Error, this
+                    "<i>ObjectWaterInteraction</i> script requires <i>RegisterDynWavesInput</i> component to be present.",
+                    "Attach a <i>RegisterDynWavesInput</i> component.",
+                    ValidatedHelper.MessageType.Error, this, ValidatedHelper.FixAttachComponent<RegisterDynWavesInput>
                 );
 
                 isValid = false;
@@ -201,8 +204,10 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>ObjectWaterInteraction</i> script requires <i>Renderer</i> component.",
-                    ValidatedHelper.MessageType.Error, this
+                    "<i>ObjectWaterInteraction</i> component requires <i>MeshRenderer</i> component.",
+                    "Attach a MeshRenderer component.",
+                    ValidatedHelper.MessageType.Error, this,
+                    ValidatedHelper.FixAttachComponent<MeshRenderer>
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -195,7 +195,8 @@ namespace Crest
                 (
                     "<i>ObjectWaterInteraction</i> script requires <i>RegisterDynWavesInput</i> component to be present.",
                     "Attach a RegisterDynWavesInput component.",
-                    ValidatedHelper.MessageType.Error, this, ValidatedHelper.FixAttachComponent<RegisterDynWavesInput>
+                    ValidatedHelper.MessageType.Error, this,
+                    ValidatedHelper.FixAttachComponent<RegisterDynWavesInput>
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -169,8 +169,9 @@ namespace Crest
                 showMessage
                 (
                     "<i>ObjectWaterInteraction</i> requires dynamic wave simulation to be enabled.",
-                    $"Enable <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_NAME}</i> option on the <i>OceanRenderer</i> component.",
-                    ValidatedHelper.MessageType.Error, ocean
+                    $"Enable {LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL} option on the OceanRenderer component.",
+                    ValidatedHelper.MessageType.Error, ocean,
+                    (so) => OceanRenderer.FixSetFeatureEnabled(so, LodDataMgrDynWaves.FEATURE_TOGGLE_NAME, true)
                 );
 
                 isValid = false;
@@ -193,7 +194,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>ObjectWaterInteraction</i> script requires <i>RegisterDynWavesInput</i> component to be present.",
-                    "Attach a <i>RegisterDynWavesInput</i> component.",
+                    "Attach a RegisterDynWavesInput component.",
                     ValidatedHelper.MessageType.Error, this, ValidatedHelper.FixAttachComponent<RegisterDynWavesInput>
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -169,7 +169,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>ObjectWaterInteraction</i> requires dynamic wave simulation to be enabled.",
-                    $"Enable {LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL} option on the OceanRenderer component.",
+                    $"Enable the <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL}</i> option on the <i>OceanRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, ocean,
                     (so) => OceanRenderer.FixSetFeatureEnabled(so, LodDataMgrDynWaves.FEATURE_TOGGLE_NAME, true)
                 );
@@ -194,7 +194,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>ObjectWaterInteraction</i> script requires <i>RegisterDynWavesInput</i> component to be present.",
-                    "Attach a RegisterDynWavesInput component.",
+                    "Attach a <i>RegisterDynWavesInput</i> component.",
                     ValidatedHelper.MessageType.Error, this,
                     ValidatedHelper.FixAttachComponent<RegisterDynWavesInput>
                 );
@@ -207,7 +207,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>ObjectWaterInteraction</i> component requires <i>MeshRenderer</i> component.",
-                    "Attach a MeshRenderer component.",
+                    "Attach a <i>MeshRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, this,
                     ValidatedHelper.FixAttachComponent<MeshRenderer>
                 );

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -206,8 +206,9 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> requires dynamic wave simulation to be enabled on <i>OceanRenderer</i>.",
-                    $"Enable <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_NAME}</i> option on the <i>OceanRenderer</i> component.",
-                    ValidatedHelper.MessageType.Error, ocean
+                    $"Enable {LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL} option on the <i>OceanRenderer</i> component.",
+                    ValidatedHelper.MessageType.Error, ocean,
+                    (so) => OceanRenderer.FixSetFeatureEnabled(so, LodDataMgrDynWaves.FEATURE_TOGGLE_NAME, true)
                 );
 
                 isValid = false;
@@ -230,7 +231,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> component requires <i>RegisterDynWavesInput</i> component to be present.",
-                    "Attach a <i>RegisterDynWavesInput</i> component.",
+                    "Attach a RegisterDynWavesInput component.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -242,7 +243,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> component requires a <i>MeshRenderer</i> component.",
-                    "Attach a <i>MeshRenderer</i> component.",
+                    "Attach a MeshRenderer component.",
                     ValidatedHelper.MessageType.Error, this,
                     ValidatedHelper.FixAttachComponent<MeshRenderer>
                 );

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -206,7 +206,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> requires dynamic wave simulation to be enabled on <i>OceanRenderer</i>.",
-                    $"Enable {LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL} option on the <i>OceanRenderer</i> component.",
+                    $"Enable the <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL}</i> option on the <i>OceanRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, ocean,
                     (so) => OceanRenderer.FixSetFeatureEnabled(so, LodDataMgrDynWaves.FEATURE_TOGGLE_NAME, true)
                 );
@@ -231,7 +231,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> component requires <i>RegisterDynWavesInput</i> component to be present.",
-                    "Attach a RegisterDynWavesInput component.",
+                    "Attach a <i>RegisterDynWavesInput</i> component.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -243,7 +243,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> component requires a <i>MeshRenderer</i> component.",
-                    "Attach a MeshRenderer component.",
+                    "Attach a <i>MeshRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, this,
                     ValidatedHelper.FixAttachComponent<MeshRenderer>
                 );

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -206,6 +206,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> requires dynamic wave simulation to be enabled on <i>OceanRenderer</i>.",
+                    $"Enable <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_NAME}</i> option on the <i>OceanRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
 
@@ -216,7 +217,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>SphereWaterInteraction</i> script requires a parent <i>GameObject</i>.",
+                    "<i>SphereWaterInteraction</i> component requires a parent <i>GameObject</i>.",
+                    "Create a primary GameObject for the object, and parent this underneath it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -227,7 +229,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>SphereWaterInteraction</i> script requires <i>RegisterDynWavesInput</i> script to be present.",
+                    "<i>SphereWaterInteraction</i> component requires <i>RegisterDynWavesInput</i> component to be present.",
+                    "Attach a <i>RegisterDynWavesInput</i> component.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -238,8 +241,10 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>SphereWaterInteraction</i> script requires <i>Renderer</i> component.",
-                    ValidatedHelper.MessageType.Error, this
+                    "<i>SphereWaterInteraction</i> component requires a <i>MeshRenderer</i> component.",
+                    "Attach a <i>MeshRenderer</i> component.",
+                    ValidatedHelper.MessageType.Error, this,
+                    ValidatedHelper.FixAttachComponent<MeshRenderer>
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -22,9 +22,9 @@ namespace Crest
         internal const string MATERIAL_KEYWORD_PROPERTY = "_ClipSurface";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_CLIPSURFACE_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Clipping must be enabled on the ocean material to enable clipping holes in the water surface.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Clip Surface</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the Enable option in the Clip Surface parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The clipping feature is disabled on this component but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the Create Clip Surface Data option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
 
         bool _targetsClear = false;
 
@@ -42,7 +42,7 @@ namespace Crest
                 && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
                 && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
-                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
+                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING + " " + ERROR_MATERIAL_KEYWORD_MISSING_FIX, _ocean);
             }
 #endif
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -21,8 +21,10 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_ClipSurface";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_CLIPSURFACE_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Clipping must be enabled on the ocean material to enable clipping holes in the water surface. Tick the <i>Enable</i> option in the <i>Clip Surface</i> parameter section on the material currently assigned to the OceanRenderer component.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The clipping feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Clipping must be enabled on the ocean material to enable clipping holes in the water surface.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Clip Surface</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The clipping feature is disabled on this component but is enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
 
         bool _targetsClear = false;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -22,9 +22,9 @@ namespace Crest
         internal const string MATERIAL_KEYWORD_PROPERTY = "_ClipSurface";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_CLIPSURFACE_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Clipping must be enabled on the ocean material to enable clipping holes in the water surface.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the Enable option in the Clip Surface parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Clip Surface</i> parameter section on the material currently assigned to the <i>OceanRenderer</i> component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The clipping feature is disabled on this component but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the Create Clip Surface Data option on this component to turn it on, or disable the Clipping feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the <i>Clipping</i> feature on the ocean material to save performance.";
 
         bool _targetsClear = false;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -22,7 +22,8 @@ namespace Crest
 
         public bool _rotateLaplacian = true;
 
-        public const string FEATURE_TOGGLE_NAME = "Create Dynamic Wave Sim";
+        public const string FEATURE_TOGGLE_NAME = "_createDynamicWaveSim";
+        public const string FEATURE_TOGGLE_LABEL = "Create Dynamic Wave Sim";
         public const string DYNWAVES_KEYWORD = "CREST_DYNAMIC_WAVE_SIM_ON_INTERNAL";
 
         bool[] _active;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -22,6 +22,7 @@ namespace Crest
 
         public bool _rotateLaplacian = true;
 
+        public const string FEATURE_TOGGLE_NAME = "Create Dynamic Wave Sim";
         public const string DYNWAVES_KEYWORD = "CREST_DYNAMIC_WAVE_SIM_ON_INTERNAL";
 
         bool[] _active;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -21,7 +21,7 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Flow";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FLOW_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow must be enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow is not enabled on the ocean material and will not be visible.";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the Flow feature on the ocean material to save performance.";
@@ -59,7 +59,7 @@ namespace Crest
                 && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
                 && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
-                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
+                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING + " " + ERROR_MATERIAL_KEYWORD_MISSING_FIX, _ocean);
             }
 #endif
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -21,8 +21,10 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Flow";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FLOW_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow must be enabled on the ocean material. Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the OceanRenderer component.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the Flow feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow must be enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the Flow feature on the ocean material to save performance.";
         bool _targetsClear = false;
 
         public const string FLOW_KEYWORD = "CREST_FLOW_ON_INTERNAL";

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -22,9 +22,9 @@ namespace Crest
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Flow";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FLOW_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Flow is not enabled on the ocean material and will not be visible.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the <i>OceanRenderer</i> component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the Flow feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the <i>Flow</i> feature on the ocean material to save performance.";
         bool _targetsClear = false;
 
         public const string FLOW_KEYWORD = "CREST_FLOW_ON_INTERNAL";

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -21,8 +21,10 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Foam";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam must be enabled on the ocean material. Tick the <i>Enable</i> option in the <i>Foam</i> parameter section on the material currently assigned to the OceanRenderer component.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Foam feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Foam Sim</i> option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam must be enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Foam</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Foam feature is disabled on this component but is enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Foam Sim</i> option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
 
         readonly int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
         readonly int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -22,9 +22,9 @@ namespace Crest
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Foam";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam is not enabled on the ocean material and will not be visible.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the Enable option in the Foam parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Foam</i> parameter section on the material currently assigned to the <i>OceanRenderer</i> component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Foam feature is disabled on this component but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the Create Foam Sim option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Foam Sim</i> option on this component to turn it on, or disable the <i>Foam</i> feature on the ocean material to save performance.";
 
         readonly int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
         readonly int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -21,10 +21,10 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Foam";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam must be enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Foam</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Foam is not enabled on the ocean material and will not be visible.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the Enable option in the Foam parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Foam feature is disabled on this component but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Foam Sim</i> option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the Create Foam Sim option on this component to turn it on, or disable the Foam feature on the ocean material to save performance.";
 
         readonly int sp_FoamFadeRate = Shader.PropertyToID("_FoamFadeRate");
         readonly int sp_WaveFoamStrength = Shader.PropertyToID("_WaveFoamStrength");
@@ -62,7 +62,7 @@ namespace Crest
                 && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
                 && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
-                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
+                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING + " " + ERROR_MATERIAL_KEYWORD_MISSING_FIX, _ocean);
             }
 #endif
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -438,7 +438,7 @@ namespace Crest
                     showMessage
                     (
                         "Depth cache is outdated.",
-                        "Click <i>Populate Cache</i> or re-bake the cache to bring the cache up-to-date with component changes.",
+                        "Click Populate Cache or re-bake the cache to bring the cache up-to-date with component changes.",
                         ValidatedHelper.MessageType.Warning, this
                     );
                 }
@@ -465,7 +465,7 @@ namespace Crest
                     showMessage
                     (
                         "No layers specified for rendering into depth cache.",
-                        "Specify one or may layers using the <i>Layers</i> field.",
+                        "Specify one or may layers using the Layers field.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -477,7 +477,7 @@ namespace Crest
                     showMessage
                     (
                         $"<i>Force Always Update Debug</i> option is enabled on depth cache <i>{gameObject.name}</i>, which means it will render every frame instead of running from the cache.",
-                        "Disable the <i>Force Always Update Debug</i> option.",
+                        "Disable the Force Always Update Debug option.",
                         ValidatedHelper.MessageType.Warning, this
                     );
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -438,7 +438,7 @@ namespace Crest
                     showMessage
                     (
                         "Depth cache is outdated.",
-                        "Click Populate Cache or re-bake the cache to bring the cache up-to-date with component changes.",
+                        "Click <i>Populate Cache</i> or re-bake the cache to bring the cache up-to-date with component changes.",
                         ValidatedHelper.MessageType.Warning, this
                     );
                 }
@@ -450,7 +450,7 @@ namespace Crest
                 {
                     showMessage
                     (
-                        "Depth cache type is 'Saved Cache' but no saved cache data is provided.",
+                        "Depth cache type is <i>Saved Cache</i> but no saved cache data is provided.",
                         "Assign a saved cache asset.",
                         ValidatedHelper.MessageType.Error, this
                     );

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -437,8 +437,8 @@ namespace Crest
                 {
                     showMessage
                     (
-                        "Depth cache is outdated. Click <i>Populate Cache</i> or re-bake the cache to bring the cache " +
-                        "up-to-date with component changes.",
+                        "Depth cache is outdated.",
+                        "Click <i>Populate Cache</i> or re-bake the cache to bring the cache up-to-date with component changes.",
                         ValidatedHelper.MessageType.Warning, this
                     );
                 }
@@ -451,6 +451,7 @@ namespace Crest
                     showMessage
                     (
                         "Depth cache type is 'Saved Cache' but no saved cache data is provided.",
+                        "Assign a saved cache asset.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -464,6 +465,7 @@ namespace Crest
                     showMessage
                     (
                         "No layers specified for rendering into depth cache.",
+                        "Specify one or may layers using the <i>Layers</i> field.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -475,6 +477,7 @@ namespace Crest
                     showMessage
                     (
                         $"<i>Force Always Update Debug</i> option is enabled on depth cache <i>{gameObject.name}</i>, which means it will render every frame instead of running from the cache.",
+                        "Disable the <i>Force Always Update Debug</i> option.",
                         ValidatedHelper.MessageType.Warning, this
                     );
 
@@ -485,7 +488,8 @@ namespace Crest
                 {
                     showMessage
                     (
-                        $"Cache resolution {_resolution} is very low. Is this intentional?",
+                        $"Cache resolution {_resolution} is very low, which may not be intentional.",
+                        "Increase the resolution.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -496,9 +500,10 @@ namespace Crest
                 {
                     showMessage
                     (
-                        "The <i>Ocean Depth Cache</i> in realtime only supports a uniform scale for X and Z. " +
+                        "The <i>Ocean Depth Cache</i> in real-time only supports a uniform scale for X and Z. " +
                         "These values currently do not match. " +
                         $"Its current scale in the hierarchy is: X = {transform.lossyScale.x} Z = {transform.lossyScale.z}.",
+                        "Ensure the X & Z scale values are equal on this object and all parents in the hierarchy.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -513,6 +518,7 @@ namespace Crest
                 showMessage
                 (
                     "Ocean depth cache transform scale is small and will capture a small area of the world. The scale sets the size of the area that will be cached, and this cache is set to render a very small area.",
+                    "Increase the X & Z scale to increase the size of the cache.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 
@@ -524,6 +530,7 @@ namespace Crest
                 showMessage
                 (
                     $"Ocean depth cache scale Y should be set to 1.0. Its current scale in the hierarchy is {transform.lossyScale.y}.",
+                    "Set the Y scale to 1.0.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -535,6 +542,7 @@ namespace Crest
                 showMessage
                 (
                     "It is recommended that the cache is placed at the same height (y component of position) as the ocean, i.e. at the sea level. If the cache is created before the ocean is present, the cache height will inform the sea level.",
+                    "Set the Y position to the same height as the ocean object.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 
@@ -555,6 +563,7 @@ namespace Crest
                     (
                         "It is not expected that a depth cache object has a Renderer component in its hierarchy." +
                         "The cache is typically attached to an empty GameObject. Please refer to the example content.",
+                        "Remove the Renderer component from this object or its children.",
                         ValidatedHelper.MessageType.Warning, renderer
                     );
 
@@ -579,14 +588,11 @@ namespace Crest
                 (
                     "<i>Layer Names</i> on the <i>Ocean Depth Cache</i> is obsolete and is no longer used. " +
                     "Use <i>Layers</i> instead.",
+                    "Populate layer mask using the legacy layer names data.",
                     ValidatedHelper.MessageType.Error, this, (SerializedObject serializedObject) =>
                     {
-                        if (serializedObject != null)
-                        {
-                            serializedObject.FindProperty("_layers").intValue = LayerMask.GetMask(_layerNames);
-                            serializedObject.FindProperty("_layerNames").arraySize = 0;
-                        }
-                        return "Populate layer mask using the legacy layer names data";
+                        serializedObject.FindProperty("_layers").intValue = LayerMask.GetMask(_layerNames);
+                        serializedObject.FindProperty("_layerNames").arraySize = 0;
                     }
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -589,7 +589,8 @@ namespace Crest
                     "<i>Layer Names</i> on the <i>Ocean Depth Cache</i> is obsolete and is no longer used. " +
                     "Use <i>Layers</i> instead.",
                     "Populate layer mask using the legacy layer names data.",
-                    ValidatedHelper.MessageType.Error, this, (SerializedObject serializedObject) =>
+                    ValidatedHelper.MessageType.Error, this,
+                    (SerializedObject serializedObject) =>
                     {
                         serializedObject.FindProperty("_layers").intValue = LayerMask.GetMask(_layerNames);
                         serializedObject.FindProperty("_layerNames").arraySize = 0;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -581,8 +581,12 @@ namespace Crest
                     "Use <i>Layers</i> instead.",
                     ValidatedHelper.MessageType.Error, this, (SerializedObject serializedObject) =>
                     {
-                        serializedObject.FindProperty("_layers").intValue = LayerMask.GetMask(_layerNames);
-                        serializedObject.FindProperty("_layerNames").arraySize = 0;
+                        if (serializedObject != null)
+                        {
+                            serializedObject.FindProperty("_layers").intValue = LayerMask.GetMask(_layerNames);
+                            serializedObject.FindProperty("_layerNames").arraySize = 0;
+                        }
+                        return "Populate layer mask using the legacy layer names data";
                     }
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -74,7 +74,7 @@ namespace Crest
 #if UNITY_EDITOR
         // Animated waves are always enabled
         protected override bool FeatureEnabled(OceanRenderer ocean) => true;
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent) => null;
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent) { }
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -70,11 +70,5 @@ namespace Crest
                 OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxDisplacementHorizontal, maxDispVert, 0f);
             }
         }
-
-#if UNITY_EDITOR
-        // Animated waves are always enabled
-        protected override bool FeatureEnabled(OceanRenderer ocean) => true;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent) { }
-#endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -74,7 +74,7 @@ namespace Crest
 #if UNITY_EDITOR
         // Animated waves are always enabled
         protected override bool FeatureEnabled(OceanRenderer ocean) => true;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent) { }
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent) => null;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -84,14 +84,11 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "Create Clip Surface Data";
+        protected override string FeatureToggleName => "_createClipSurfaceData";
+        protected override string FeatureToggleLabel => "Create Clip Surface Data";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateClipSurfaceData;
         protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
-        {
-            oceanComponent.FindProperty("_createClipSurfaceData").boolValue = true;
-        }
 
         protected override string KeywordMissingErrorMessage => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING;
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -84,19 +84,15 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => "Create Clip Surface Data";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateClipSurfaceData;
         protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            if (oceanComponent != null)
-            {
-                oceanComponent.FindProperty("_createClipSurfaceData").boolValue = true;
-            }
-            return "Enable 'Create Clip Surface Data' option on OceanRenderer component.";
+            oceanComponent.FindProperty("_createClipSurfaceData").boolValue = true;
         }
 
-        protected override string FeatureDisabledErrorMessage => "<i>Create Clip Surface Data</i> must be enabled on the OceanRenderer component to enable clipping holes in the water surface.";
         protected override string KeywordMissingErrorMessage => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING;
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -90,7 +90,8 @@ namespace Crest
         protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
 
-        protected override string KeywordMissingErrorMessage => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING;
+        protected override string MaterialFeatureDisabledError => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING;
+        protected override string MaterialFeatureDisabledFix => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
 #endif
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -87,9 +87,13 @@ namespace Crest
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateClipSurfaceData;
         protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            oceanComponent.FindProperty("_createClipSurfaceData").boolValue = true;
+            if (oceanComponent != null)
+            {
+                oceanComponent.FindProperty("_createClipSurfaceData").boolValue = true;
+            }
+            return "Enable 'Create Clip Surface Data' option on OceanRenderer component.";
         }
 
         protected override string FeatureDisabledErrorMessage => "<i>Create Clip Surface Data</i> must be enabled on the OceanRenderer component to enable clipping holes in the water surface.";

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -24,11 +24,8 @@ namespace Crest
 
 #if UNITY_EDITOR
         protected override string FeatureToggleName => LodDataMgrDynWaves.FEATURE_TOGGLE_NAME;
+        protected override string FeatureToggleLabel => LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL;
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateDynamicWaveSim;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
-        {
-            oceanComponent.FindProperty("_createDynamicWaveSim").boolValue = true;
-        }
 #endif
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -23,15 +23,11 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Dynamic Waves";
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => LodDataMgrDynWaves.FEATURE_TOGGLE_NAME;
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateDynamicWaveSim;
-        protected override string FeatureDisabledErrorMessage => "<i>Create Dynamic Wave Sim</i> must be enabled on the OceanRenderer component to enable the dynamic wave simulation.";
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            if (oceanComponent != null)
-            {
-                oceanComponent.FindProperty("_createDynamicWaveSim").boolValue = true;
-            }
-            return "Enable 'Create Dynamic Wave Sim' option on OceanRenderer component.";
+            oceanComponent.FindProperty("_createDynamicWaveSim").boolValue = true;
         }
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -25,9 +25,13 @@ namespace Crest
 #if UNITY_EDITOR
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateDynamicWaveSim;
         protected override string FeatureDisabledErrorMessage => "<i>Create Dynamic Wave Sim</i> must be enabled on the OceanRenderer component to enable the dynamic wave simulation.";
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            oceanComponent.FindProperty("_createDynamicWaveSim").boolValue = true;
+            if (oceanComponent != null)
+            {
+                oceanComponent.FindProperty("_createDynamicWaveSim").boolValue = true;
+            }
+            return "Enable 'Create Dynamic Wave Sim' option on OceanRenderer component.";
         }
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -25,9 +25,13 @@ namespace Crest
 #if UNITY_EDITOR
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFlowSim;
         protected override string FeatureDisabledErrorMessage => "<i>Create Flow Sim</i> must be enabled on the OceanRenderer component to enable flow on the water surface.";
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            oceanComponent.FindProperty("_createFlowSim").boolValue = true;
+            if (oceanComponent != null)
+            {
+                oceanComponent.FindProperty("_createFlowSim").boolValue = true;
+            }
+            return "Enable 'Create Flow Sim' option on OceanRenderer component.";
         }
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -23,12 +23,9 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Flow";
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "Create Flow Sim";
+        protected override string FeatureToggleName => "_createFlowSim";
+        protected override string FeatureToggleLabel => "Create Flow Sim";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFlowSim;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
-        {
-            oceanComponent.FindProperty("_createFlowSim").boolValue = true;
-        }
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrFlow.MATERIAL_KEYWORD;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -23,15 +23,11 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Flow";
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => "Create Flow Sim";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFlowSim;
-        protected override string FeatureDisabledErrorMessage => "<i>Create Flow Sim</i> must be enabled on the OceanRenderer component to enable flow on the water surface.";
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            if (oceanComponent != null)
-            {
-                oceanComponent.FindProperty("_createFlowSim").boolValue = true;
-            }
-            return "Enable 'Create Flow Sim' option on OceanRenderer component.";
+            oceanComponent.FindProperty("_createFlowSim").boolValue = true;
         }
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -29,7 +29,9 @@ namespace Crest
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrFlow.MATERIAL_KEYWORD;
-        protected override string KeywordMissingErrorMessage => LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING;
+
+        protected override string MaterialFeatureDisabledError => LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING;
+        protected override string MaterialFeatureDisabledFix => LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -23,6 +23,7 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Foam";
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => "_createFoamSim";
         protected override string FeatureToggleLabel => "Create Foam Sim";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFoamSim;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -25,9 +25,13 @@ namespace Crest
 #if UNITY_EDITOR
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFoamSim;
         protected override string FeatureDisabledErrorMessage => "<i>Create Foam Sim</i> must be enabled on the OceanRenderer component.";
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            oceanComponent.FindProperty("_createFoamSim").boolValue = true;
+            if (oceanComponent != null)
+            {
+                oceanComponent.FindProperty("_createFoamSim").boolValue = true;
+            }
+            return "Enable 'Create Foam Sim' option on OceanRenderer component.";
         }
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -23,15 +23,11 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Foam";
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => "Create Foam Sim";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFoamSim;
-        protected override string FeatureDisabledErrorMessage => "<i>Create Foam Sim</i> must be enabled on the OceanRenderer component.";
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            if (oceanComponent != null)
-            {
-                oceanComponent.FindProperty("_createFoamSim").boolValue = true;
-            }
-            return "Enable 'Create Foam Sim' option on OceanRenderer component.";
+            oceanComponent.FindProperty("_createFoamSim").boolValue = true;
         }
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -28,7 +28,9 @@ namespace Crest
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrFoam.MATERIAL_KEYWORD;
-        protected override string KeywordMissingErrorMessage => LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING;
+
+        protected override string MaterialFeatureDisabledError => LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING;
+        protected override string MaterialFeatureDisabledFix => LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -23,12 +23,8 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Foam";
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "Create Foam Sim";
+        protected override string FeatureToggleLabel => "Create Foam Sim";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFoamSim;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
-        {
-            oceanComponent.FindProperty("_createFoamSim").boolValue = true;
-        }
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrFoam.MATERIAL_KEYWORD;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -258,15 +258,16 @@ namespace Crest
 #if UNITY_EDITOR
     public abstract partial class RegisterLodDataInputBase : IValidated
     {
+        protected virtual string FeatureToggleName => null;
         protected abstract bool FeatureEnabled(OceanRenderer ocean);
+
         protected virtual string RequiredShaderKeyword => null;
         // NOTE: Temporary until shader keywords are the same across pipelines.
         protected virtual string RequiredShaderKeywordProperty => null;
 
-        protected virtual string FeatureDisabledErrorMessage => "Feature must be enabled on the OceanRenderer component.";
         protected virtual string KeywordMissingErrorMessage => "Feature must be enabled on the ocean material.";
 
-        protected abstract string FixOceanFeatureDisabled(SerializedObject oceanComponent);
+        protected abstract void FixOceanFeatureDisabled(SerializedObject oceanComponent);
 
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
@@ -274,13 +275,16 @@ namespace Crest
 
             if (!FeatureEnabled(ocean))
             {
-                showMessage(FeatureDisabledErrorMessage, ValidatedHelper.MessageType.Error, ocean, FixOceanFeatureDisabled);
+                showMessage($"<i>{FeatureToggleName}</i> must be enabled on the OceanRenderer component.",
+                    $"Enable this option on the <i>OceanRenderer</i> component.",
+                    ValidatedHelper.MessageType.Error, ocean, FixOceanFeatureDisabled
+                    );
                 isValid = false;
             }
 
             if (!string.IsNullOrEmpty(RequiredShaderKeyword) && ocean.OceanMaterial.HasProperty(RequiredShaderKeywordProperty) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
             {
-                showMessage(KeywordMissingErrorMessage, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                showMessage(KeywordMissingErrorMessage, KeywordMissingErrorMessage, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 isValid = false;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -258,8 +258,9 @@ namespace Crest
 #if UNITY_EDITOR
     public abstract partial class RegisterLodDataInputBase : IValidated
     {
+        protected virtual string FeatureToggleLabel => null;
         protected virtual string FeatureToggleName => null;
-        protected abstract bool FeatureEnabled(OceanRenderer ocean);
+        protected virtual bool FeatureEnabled(OceanRenderer ocean) => true;
 
         protected virtual string RequiredShaderKeyword => null;
         // NOTE: Temporary until shader keywords are the same across pipelines.
@@ -267,17 +268,15 @@ namespace Crest
 
         protected virtual string KeywordMissingErrorMessage => "Feature must be enabled on the ocean material.";
 
-        protected abstract void FixOceanFeatureDisabled(SerializedObject oceanComponent);
-
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             bool isValid = ValidatedHelper.ValidateRenderer(gameObject, ShaderPrefix, showMessage);
 
             if (!FeatureEnabled(ocean))
             {
-                showMessage($"<i>{FeatureToggleName}</i> must be enabled on the OceanRenderer component.",
-                    $"Enable this option on the <i>OceanRenderer</i> component.",
-                    ValidatedHelper.MessageType.Error, ocean, FixOceanFeatureDisabled
+                showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the OceanRenderer component.",
+                    $"Enable this option on the OceanRenderer component.",
+                    ValidatedHelper.MessageType.Error, ocean, (so) => OceanRenderer.FixSetFeatureEnabled(so, FeatureToggleName, true)
                     );
                 isValid = false;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -266,7 +266,7 @@ namespace Crest
         protected virtual string FeatureDisabledErrorMessage => "Feature must be enabled on the OceanRenderer component.";
         protected virtual string KeywordMissingErrorMessage => "Feature must be enabled on the ocean material.";
 
-        protected abstract void FixOceanFeatureDisabled(SerializedObject oceanComponent);
+        protected abstract string FixOceanFeatureDisabled(SerializedObject oceanComponent);
 
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -266,7 +266,8 @@ namespace Crest
         // NOTE: Temporary until shader keywords are the same across pipelines.
         protected virtual string RequiredShaderKeywordProperty => null;
 
-        protected virtual string KeywordMissingErrorMessage => "Feature must be enabled on the ocean material.";
+        protected virtual string MaterialFeatureDisabledError => null;
+        protected virtual string MaterialFeatureDisabledFix => null;
 
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
@@ -275,15 +276,17 @@ namespace Crest
             if (!FeatureEnabled(ocean))
             {
                 showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the OceanRenderer component.",
-                    $"Enable this option on the OceanRenderer component.",
-                    ValidatedHelper.MessageType.Error, ocean, (so) => OceanRenderer.FixSetFeatureEnabled(so, FeatureToggleName, true)
+                    $"Enable this option on the OceanRenderer component.", ValidatedHelper.MessageType.Error, ocean,
+                    (so) => OceanRenderer.FixSetFeatureEnabled(so, FeatureToggleName, true)
                     );
                 isValid = false;
             }
 
             if (!string.IsNullOrEmpty(RequiredShaderKeyword) && ocean.OceanMaterial.HasProperty(RequiredShaderKeywordProperty) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
             {
-                showMessage(KeywordMissingErrorMessage, KeywordMissingErrorMessage, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                showMessage(MaterialFeatureDisabledError, MaterialFeatureDisabledFix,
+                    ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                    (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, RequiredShaderKeyword, RequiredShaderKeywordProperty, true));
                 isValid = false;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -275,8 +275,8 @@ namespace Crest
 
             if (!FeatureEnabled(ocean))
             {
-                showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the OceanRenderer component.",
-                    $"Enable this option on the OceanRenderer component.",
+                showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the <i>OceanRenderer</i> component.",
+                    $"Enable the <i>{FeatureToggleLabel}</i> option on the <i>OceanRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, ocean,
                     (so) => OceanRenderer.FixSetFeatureEnabled(so, FeatureToggleName, true)
                     );

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -276,7 +276,8 @@ namespace Crest
             if (!FeatureEnabled(ocean))
             {
                 showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the OceanRenderer component.",
-                    $"Enable this option on the OceanRenderer component.", ValidatedHelper.MessageType.Error, ocean,
+                    $"Enable this option on the OceanRenderer component.",
+                    ValidatedHelper.MessageType.Error, ocean,
                     (so) => OceanRenderer.FixSetFeatureEnabled(so, FeatureToggleName, true)
                     );
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -42,9 +42,13 @@ namespace Crest
 #if UNITY_EDITOR
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateSeaFloorDepthData;
         protected override string FeatureDisabledErrorMessage => "<i>Create Sea Floor Depth Data</i> must be enabled on the OceanRenderer component.";
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            oceanComponent.FindProperty("_createSeaFloorDepthData").boolValue = true;
+            if (oceanComponent != null)
+            {
+                oceanComponent.FindProperty("_createSeaFloorDepthData").boolValue = true;
+            }
+            return "Enable 'Create Sea Floor Depth Data' option on OceanRenderer component.";
         }
 #endif // UNITY_EDITOR
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -40,12 +40,9 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "Create Sea Floor Depth Data";
+        protected override string FeatureToggleName => "_createSeaFloorDepthData";
+        protected override string FeatureToggleLabel => "Create Sea Floor Depth Data";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateSeaFloorDepthData;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
-        {
-            oceanComponent.FindProperty("_createSeaFloorDepthData").boolValue = true;
-        }
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -40,15 +40,11 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => "Create Sea Floor Depth Data";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateSeaFloorDepthData;
-        protected override string FeatureDisabledErrorMessage => "<i>Create Sea Floor Depth Data</i> must be enabled on the OceanRenderer component.";
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            if (oceanComponent != null)
-            {
-                oceanComponent.FindProperty("_createSeaFloorDepthData").boolValue = true;
-            }
-            return "Enable 'Create Sea Floor Depth Data' option on OceanRenderer component.";
+            oceanComponent.FindProperty("_createSeaFloorDepthData").boolValue = true;
         }
 #endif // UNITY_EDITOR
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using UnityEditor;
 using UnityEngine;
 
 namespace Crest
@@ -22,7 +23,7 @@ namespace Crest
 
         [Tooltip("Where to obtain ocean shape on CPU for physics / gameplay."), SerializeField]
         CollisionSources _collisionSource = CollisionSources.ComputeShaderQueries;
-        public CollisionSources CollisionSource { get { return _collisionSource; } }
+        public CollisionSources CollisionSource { get { return _collisionSource; } set { _collisionSource = value; } }
 
         [Tooltip("Maximum number of wave queries that can be performed when using ComputeShaderQueries.")]
         [PredicatedField("_collisionSource", true, (int)CollisionSources.ComputeShaderQueries), SerializeField]
@@ -91,7 +92,7 @@ namespace Crest
                     "<i>Gerstner Waves CPU</i> has significant drawbacks. It does not include wave attenuation from " +
                     "water depth or any custom rendered shape. It does not support multiple " +
                     "<i>GerstnerWavesBatched</i> components including cross blending. Please read the user guide for more information.",
-                    "Set collision source to <i>ComputeShaderQueries</i>",
+                    "Set collision source to ComputeShaderQueries",
                     ValidatedHelper.MessageType.Info, this
                 );
             }
@@ -100,12 +101,22 @@ namespace Crest
                 showMessage
                 (
                     "Collision Source in Animated Waves Settings is set to None. The floating objects in the scene will use a flat horizontal plane.",
-                    "Set collision source to <i>ComputeShaderQueries</i>",
-                    ValidatedHelper.MessageType.Warning, this
+                    "Set collision source to ComputeShaderQueries.",
+                    ValidatedHelper.MessageType.Warning, this, FixSetCollisionSourceToCompute
                 );
             }
 
             return isValid;
+        }
+
+        internal static void FixSetCollisionSourceToCompute(SerializedObject settingsObject)
+        {
+            if (OceanRenderer.Instance != null && OceanRenderer.Instance._simSettingsAnimatedWaves != null)
+            {
+                Undo.RecordObject(OceanRenderer.Instance._simSettingsAnimatedWaves, "Set collision source to compute");
+                OceanRenderer.Instance._simSettingsAnimatedWaves.CollisionSource = CollisionSources.ComputeShaderQueries;
+                EditorUtility.SetDirty(OceanRenderer.Instance._simSettingsAnimatedWaves);
+            }
         }
     }
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -102,7 +102,8 @@ namespace Crest
                 (
                     "Collision Source in Animated Waves Settings is set to None. The floating objects in the scene will use a flat horizontal plane.",
                     "Set collision source to ComputeShaderQueries.",
-                    ValidatedHelper.MessageType.Warning, this, FixSetCollisionSourceToCompute
+                    ValidatedHelper.MessageType.Warning, this,
+                    FixSetCollisionSourceToCompute
                 );
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -91,6 +91,7 @@ namespace Crest
                     "<i>Gerstner Waves CPU</i> has significant drawbacks. It does not include wave attenuation from " +
                     "water depth or any custom rendered shape. It does not support multiple " +
                     "<i>GerstnerWavesBatched</i> components including cross blending. Please read the user guide for more information.",
+                    "Set collision source to <i>ComputeShaderQueries</i>",
                     ValidatedHelper.MessageType.Info, this
                 );
             }
@@ -99,6 +100,7 @@ namespace Crest
                 showMessage
                 (
                     "Collision Source in Animated Waves Settings is set to None. The floating objects in the scene will use a flat horizontal plane.",
+                    "Set collision source to <i>ComputeShaderQueries</i>",
                     ValidatedHelper.MessageType.Warning, this
                 );
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -24,8 +24,10 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Shadows";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_SHADOWS_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing must be enabled on the ocean material. Tick the <i>Shadowing</i> option in the <i>Scattering</i> parameter section on the material currently assigned to the OceanRenderer component.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The shadow feature is disabled on this component but is enabled on the ocean material. If this is not intentional, either enable the <i>Create Shadow Data</i> option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing must be enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Shadowing</i> option in the <i>Scattering</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The shadow feature is disabled on this component but is enabled on the ocean material.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Shadow Data</i> option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
 
         public static bool s_processData = true;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -24,10 +24,10 @@ namespace Crest
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Shadows";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_SHADOWS_ON";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing must be enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Shadowing</i> option in the <i>Scattering</i> parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing is not enabled on the ocean material and will not be visible.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the Shadowing option in the Scattering parameter section on the material currently assigned to the OceanRenderer component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The shadow feature is disabled on this component but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Shadow Data</i> option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the Create Shadow Data option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
 
         public static bool s_processData = true;
 
@@ -102,7 +102,7 @@ namespace Crest
                 && OceanRenderer.Instance.OceanMaterial.HasProperty(MATERIAL_KEYWORD_PROPERTY)
                 && !OceanRenderer.Instance.OceanMaterial.IsKeywordEnabled(MATERIAL_KEYWORD))
             {
-                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING, _ocean);
+                Debug.LogWarning(ERROR_MATERIAL_KEYWORD_MISSING + " " + ERROR_MATERIAL_KEYWORD_MISSING_FIX, _ocean);
             }
 #endif
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -25,9 +25,9 @@ namespace Crest
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Shadows";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_SHADOWS_ON";
         internal const string ERROR_MATERIAL_KEYWORD_MISSING = "Shadowing is not enabled on the ocean material and will not be visible.";
-        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the Shadowing option in the Scattering parameter section on the material currently assigned to the OceanRenderer component.";
+        internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Shadowing</i> option in the <i>Scattering<i> parameter section on the material currently assigned to the <i>OceanRenderer</i> component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The shadow feature is disabled on this component but is enabled on the ocean material.";
-        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the Create Shadow Data option on this component to turn it on, or disable the Shadowing feature on the ocean material to save performance.";
+        internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Shadow Data</i> option on this component to turn it on, or disable the <i>Shadowing</i> feature on the ocean material to save performance.";
 
         public static bool s_processData = true;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -25,15 +25,11 @@ namespace Crest
         protected override bool FollowHorizontalMotion => false;
 
 #if UNITY_EDITOR
+        protected override string FeatureToggleName => "Create Shadow Data";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateShadowData;
-        protected override string FeatureDisabledErrorMessage => "<i>Create Shadow Data</i> must be enabled on the OceanRenderer component.";
-        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            if (oceanComponent != null)
-            {
-                oceanComponent.FindProperty("_createShadowData").boolValue = true;
-            }
-            return "Enable 'Create Shadow Data' option on OceanRenderer component.";
+            oceanComponent.FindProperty("_createShadowData").boolValue = true;
         }
 
         protected override string RequiredShaderKeyword => LodDataMgrShadow.MATERIAL_KEYWORD;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -25,12 +25,9 @@ namespace Crest
         protected override bool FollowHorizontalMotion => false;
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "Create Shadow Data";
+        protected override string FeatureToggleName => "_createShadowData";
+        protected override string FeatureToggleLabel => "Create Shadow Data";
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateShadowData;
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
-        {
-            oceanComponent.FindProperty("_createShadowData").boolValue = true;
-        }
 
         protected override string RequiredShaderKeyword => LodDataMgrShadow.MATERIAL_KEYWORD;
         protected override string KeywordMissingErrorMessage => LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -30,7 +30,9 @@ namespace Crest
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateShadowData;
 
         protected override string RequiredShaderKeyword => LodDataMgrShadow.MATERIAL_KEYWORD;
-        protected override string KeywordMissingErrorMessage => LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING;
+
+        protected override string MaterialFeatureDisabledError => LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING;
+        protected override string MaterialFeatureDisabledFix => LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -27,9 +27,13 @@ namespace Crest
 #if UNITY_EDITOR
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateShadowData;
         protected override string FeatureDisabledErrorMessage => "<i>Create Shadow Data</i> must be enabled on the OceanRenderer component.";
-        protected override void FixOceanFeatureDisabled(SerializedObject oceanComponent)
+        protected override string FixOceanFeatureDisabled(SerializedObject oceanComponent)
         {
-            oceanComponent.FindProperty("_createShadowData").boolValue = true;
+            if (oceanComponent != null)
+            {
+                oceanComponent.FindProperty("_createShadowData").boolValue = true;
+            }
+            return "Enable 'Create Shadow Data' option on OceanRenderer component.";
         }
 
         protected override string RequiredShaderKeyword => LodDataMgrShadow.MATERIAL_KEYWORD;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1142,7 +1142,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "A material for the ocean must be assigned on the Material property of the OceanRenderer.",
+                    "No ocean material specified.",
+                    "Assign a valid ocean material to the Material property of the OceanRenderer.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
 
@@ -1154,7 +1155,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "Multiple OceanRenderer scripts detected in open scenes, this is not typical - usually only one OceanRenderer is expected to be present.",
+                    "Multiple OceanRenderer components detected in open scenes, this is not typical - usually only one OceanRenderer is expected to be present.",
+                    "Remove extra OceanRenderer components.",
                     ValidatedHelper.MessageType.Warning, ocean
                 );
             }
@@ -1166,7 +1168,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "No ShapeGerstnerBatched script found, so ocean will appear flat (no waves).",
+                    "No ShapeGerstnerBatched component found, so ocean will appear flat (no waves).",
+                    "Assign a ShapeGerstnerBatched component to a GameObject.",
                     ValidatedHelper.MessageType.Info, ocean
                 );
             }
@@ -1178,7 +1181,7 @@ namespace Crest
             {
                 showMessage
                 (
-                    "Base mesh density is lower than 8. There will be visible gaps in the ocean surface. " +
+                    "Base mesh density is lower than 8. There will be visible gaps in the ocean surface.",
                     "Increase the <i>LOD Data Resolution</i> or decrease the <i>Geometry Down Sample Factor</i>.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
@@ -1187,7 +1190,7 @@ namespace Crest
             {
                 showMessage
                 (
-                    "Base mesh density is lower than 16. There will be visible transitions when traversing the ocean surface. " +
+                    "Base mesh density is lower than 16. There will be visible transitions when traversing the ocean surface. ",
                     "Increase the <i>LOD Data Resolution</i> or decrease the <i>Geometry Down Sample Factor</i>.",
                     ValidatedHelper.MessageType.Warning, ocean
                 );
@@ -1214,9 +1217,8 @@ namespace Crest
                     {
                         showMessage
                         (
-                            "There is no skybox set in the lighting settings window. " +
-                            oceanColourIncorrectText +
-                            alternativesText,
+                            "There is no skybox set in the Lighting window. " + oceanColourIncorrectText,
+                            "Configure a valid skybox. " + alternativesText,
                             ValidatedHelper.MessageType.Warning, ocean
                         );
                     }
@@ -1225,10 +1227,8 @@ namespace Crest
                     {
                         showMessage
                         (
-                            "Lighting data is missing which provides baked spherical harmonics." +
-                            oceanColourIncorrectText +
-                            "Generate lighting or enable Auto Generate from the Lighting window. " +
-                            alternativesText,
+                            "Lighting data is missing which provides baked spherical harmonics." + oceanColourIncorrectText,
+                            "Generate lighting or enable Auto Generate from the Lighting window. " + alternativesText,
                             ValidatedHelper.MessageType.Warning, ocean
                         );
                     }
@@ -1240,10 +1240,8 @@ namespace Crest
                     {
                         showMessage
                         (
-                            "Environmental Reflections is set to Custom, but no cubemap has been provided. " +
-                            oceanColourIncorrectText +
-                            "Assign a cubemap in the lighting settings window. " +
-                            alternativesText,
+                            "Environmental Reflections is set to Custom, but no cubemap has been provided. " + oceanColourIncorrectText,
+                            "Assign a cubemap in the Lighting window. " + alternativesText,
                             ValidatedHelper.MessageType.Warning, ocean
                         );
                     }
@@ -1256,8 +1254,7 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>Override Reflection Cubemap</i> is enabled but no cubemap has been provided. " +
-                    oceanColourIncorrectText +
+                    "<i>Override Reflection Cubemap</i> is enabled but no cubemap has been provided. " + oceanColourIncorrectText,
                     "Assign a cubemap or disable the checkbox on the ocean material.",
                     ValidatedHelper.MessageType.Warning, ocean
                 );
@@ -1274,6 +1271,7 @@ namespace Crest
                 showMessage
                 (
                     $"There must be no rotation on the ocean GameObject, and no rotation on any parent. Currently the rotation Euler angles are {transform.eulerAngles}.",
+                    "Clear this rotation from the GameObject.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
             }
@@ -1288,11 +1286,11 @@ namespace Crest
             {
                 if (ocean.CreateFoamSim)
                 {
-                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
-                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
                 }
             }
 
@@ -1300,11 +1298,12 @@ namespace Crest
             {
                 if (ocean.CreateFlowSim)
                 {
-                    showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
-                    showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
+                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
                 }
             }
 
@@ -1312,11 +1311,13 @@ namespace Crest
             {
                 if (ocean.CreateShadowData)
                 {
-                    showMessage(LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
-                    showMessage(LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
+                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
                 }
             }
 
@@ -1324,11 +1325,11 @@ namespace Crest
             {
                 if (ocean.CreateClipSurfaceData)
                 {
-                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
-                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1286,7 +1286,7 @@ namespace Crest
             {
                 if (ocean.CreateFoamSim)
                 {
-                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage("Foam not enabled on ocean material and will not be visible.", LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1286,11 +1286,13 @@ namespace Crest
             {
                 if (ocean.CreateFoamSim)
                 {
-                    showMessage("Foam not enabled on ocean material and will not be visible.", LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
-                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
+                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
                 }
             }
 
@@ -1298,7 +1300,8 @@ namespace Crest
             {
                 if (ocean.CreateFlowSim)
                 {
-                    showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
@@ -1325,11 +1328,13 @@ namespace Crest
             {
                 if (ocean.CreateClipSurfaceData)
                 {
-                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
                 }
                 else
                 {
-                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
+                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1143,7 +1143,7 @@ namespace Crest
                 showMessage
                 (
                     "No ocean material specified.",
-                    "Assign a valid ocean material to the Material property of the OceanRenderer.",
+                    "Assign a valid ocean material to the Material property of the <i>OceanRenderer</i> component.",
                     ValidatedHelper.MessageType.Error, ocean
                 );
 
@@ -1155,8 +1155,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "Multiple OceanRenderer components detected in open scenes, this is not typical - usually only one OceanRenderer is expected to be present.",
-                    "Remove extra OceanRenderer components.",
+                    "Multiple <i>OceanRenderer</i> components detected in open scenes, this is not typical - usually only one <i>OceanRenderer</i> is expected to be present.",
+                    "Remove extra <i>OceanRenderer</i> components.",
                     ValidatedHelper.MessageType.Warning, ocean
                 );
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1369,6 +1369,11 @@ namespace Crest
                 _lodDataResolution = newLDR;
             }
         }
+
+        internal static void FixSetFeatureEnabled(SerializedObject oceanSO, string paramName, bool enabled)
+        {
+            oceanSO.FindProperty(paramName).boolValue = enabled;
+        }
     }
 
     [CustomEditor(typeof(OceanRenderer))]

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1287,7 +1287,8 @@ namespace Crest
                 if (ocean.CreateFoamSim)
                 {
                     showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
-                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                        (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, LodDataMgrFoam.MATERIAL_KEYWORD, LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY, true));
                 }
                 else
                 {
@@ -1301,7 +1302,8 @@ namespace Crest
                 if (ocean.CreateFlowSim)
                 {
                     showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
-                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                        (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, LodDataMgrFlow.MATERIAL_KEYWORD, LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY, true));
                 }
                 else
                 {
@@ -1315,7 +1317,8 @@ namespace Crest
                 if (ocean.CreateShadowData)
                 {
                     showMessage(LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
-                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                        (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, LodDataMgrShadow.MATERIAL_KEYWORD, LodDataMgrShadow.MATERIAL_KEYWORD_PROPERTY, true));
                 }
                 else
                 {
@@ -1329,7 +1332,8 @@ namespace Crest
                 if (ocean.CreateClipSurfaceData)
                 {
                     showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX,
-                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                        (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, LodDataMgrClipSurface.MATERIAL_KEYWORD, LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY, true));
                 }
                 else
                 {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1293,7 +1293,7 @@ namespace Crest
                 else
                 {
                     showMessage(LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
-                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Info, ocean);
                 }
             }
 
@@ -1308,7 +1308,7 @@ namespace Crest
                 else
                 {
                     showMessage(LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
-                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Info, ocean);
                 }
             }
 
@@ -1323,7 +1323,7 @@ namespace Crest
                 else
                 {
                     showMessage(LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
-                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Info, ocean);
                 }
             }
 
@@ -1338,7 +1338,7 @@ namespace Crest
                 else
                 {
                     showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX,
-                        ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                        ValidatedHelper.MessageType.Info, ocean);
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -8,6 +8,7 @@
 #if UNITY_EDITOR
 
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
 
@@ -224,7 +225,8 @@ namespace Crest
 
                                 if (message._fixDescription != null)
                                 {
-                                    s_fixButtonContent.tooltip = $"Fix: {message._fixDescription}";
+                                    var sanitisedFixDescr = Regex.Replace(message._fixDescription, @"<[^<>]*>", "'");
+                                    s_fixButtonContent.tooltip = $"Apply fix: {sanitisedFixDescr}";
                                 }
                                 else
                                 {

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -51,13 +51,13 @@ namespace Crest
 
         public static void DebugLog(string message, string fixDescription, MessageType type, Object @object = null, ValidationFixFunc action = null)
         {
-            message = $"Validation: {message} Click this message to highlight the problem object.";
+            message = $"Validation: {message} {fixDescription} Click this message to highlight the problem object.";
 
             switch (type)
             {
-                case MessageType.Error: Debug.LogError(message + " " + fixDescription, @object); break;
-                case MessageType.Warning: Debug.LogWarning(message + " " + fixDescription, @object); break;
-                default: Debug.Log(message + " " + fixDescription, @object); break;
+                case MessageType.Error: Debug.LogError(message, @object); break;
+                case MessageType.Warning: Debug.LogWarning(message, @object); break;
+                default: Debug.Log(message, @object); break;
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -102,7 +102,9 @@ namespace Crest
                 showMessage
                 (
                     "A MeshRenderer component is required but none is attached to ocean input.",
-                    "Attach a MeshRenderer component.", MessageType.Error, gameObject, FixAttachComponent<MeshRenderer>
+                    "Attach a <i>MeshRenderer</i> component.",
+                    MessageType.Error, gameObject,
+                    FixAttachComponent<MeshRenderer>
                 );
 
                 return false;

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -217,7 +217,6 @@ namespace Crest
                             // Fix the issue button.
                             if (message._action != null)
                             {
-                                // Call fix function with null argument to retrieve the resolution info
                                 if (s_fixButtonContent == null)
                                 {
                                     s_fixButtonContent = new GUIContent(EditorGUIUtility.FindTexture("SceneViewTools@2x"));

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -233,7 +233,7 @@ namespace Crest
 
                                 if (GUILayout.Button(s_fixButtonContent, GUILayout.ExpandWidth(false), GUILayout.ExpandHeight(true)))
                                 {
-                                    // Fix for real
+                                    // Run fix function
                                     var serializedObject = new SerializedObject(message._object);
                                     message._action.Invoke(serializedObject);
                                     if (serializedObject.ApplyModifiedProperties())

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -78,6 +78,21 @@ namespace Crest
             EditorUtility.SetDirty(gameObject);
         }
 
+        internal static void FixSetMaterialOptionEnabled(SerializedObject material, string keyword, string floatParam, bool enabled)
+        {
+            var mat = material.targetObject as Material;
+            Undo.RecordObject(mat, $"Enable keyword {keyword}");
+            if (enabled)
+            {
+                mat.EnableKeyword(keyword);
+            }
+            else
+            {
+                mat.DisableKeyword(keyword);
+            }
+            mat.SetFloat(floatParam, enabled ? 1f : 0f);
+        }
+
         public static bool ValidateRenderer(GameObject gameObject, string shaderPrefix, ShowMessage showMessage)
         {
             var renderer = gameObject.GetComponent<Renderer>();

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -682,7 +682,7 @@ namespace Crest
             {
                 showMessage
                 (
-                    "A Spline component is attached but it has validation errors.",
+                    "A <i>Spline</i> component is attached but it has validation errors.",
                     "Check this component in the Inspector for issues.",
                     ValidatedHelper.MessageType.Error, this
                 );

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -682,7 +682,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "A Spline component is attached but it has validation errors. Please check this component in the Inspector for issues.",
+                    "A Spline component is attached but it has validation errors.",
+                    "Check this component in the Inspector for issues.",
                     ValidatedHelper.MessageType.Error, this
                 );
             }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -860,7 +860,7 @@ namespace Crest
                 showMessage
                 (
                     "The MeshRenderer component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
-                    "Either remove the MeshRenderer component or set the <i>Mode</i> option to <i>Geometry</i>.",
+                    "Either remove the MeshRenderer component or set the Mode option to Geometry.",
                     ValidatedHelper.MessageType.Warning, this
                 );
             }
@@ -870,7 +870,7 @@ namespace Crest
                 showMessage
                 (
                     "The MeshRenderer component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
-                    "Either remove the MeshRenderer component or set the <i>Mode</i> option to <i>Geometry</i>.",
+                    "Either remove the MeshRenderer component or set the Mode option to Geometry.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 
@@ -882,7 +882,7 @@ namespace Crest
                 showMessage
                 (
                     "There is no spectrum assigned meaning this Gerstner component won't generate any waves.",
-                    "Assign a valid spectrum asset to the <i>Spectrum</i> field.", ValidatedHelper.MessageType.Warning, this
+                    "Assign a valid spectrum asset to the Spectrum field.", ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;
@@ -893,7 +893,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>Components Per Octave</i> set to 0 meaning this Gerstner component won't generate any waves.",
-                    "Increase this value to 8 or 16.", ValidatedHelper.MessageType.Warning, this
+                    "Increase Components Per Octave to 8 or 16.", ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -859,8 +859,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "The MeshRenderer component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
-                    "Either remove the MeshRenderer component or set the Mode option to Geometry.",
+                    "The <i>MeshRenderer</i> component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
+                    "Either remove the <i>MeshRenderer</i> component or set the <i>Mode</i> option to <i>Geometry</i>.",
                     ValidatedHelper.MessageType.Warning, this
                 );
             }
@@ -869,8 +869,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "The MeshRenderer component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
-                    "Either remove the MeshRenderer component or set the Mode option to Geometry.",
+                    "The <i>MeshRenderer</i> component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
+                    "Either remove the <i>MeshRenderer</i> component or set the Mode option to <i>Geometry</i>.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 
@@ -882,7 +882,7 @@ namespace Crest
                 showMessage
                 (
                     "There is no spectrum assigned meaning this Gerstner component won't generate any waves.",
-                    "Assign a valid spectrum asset to the Spectrum field.",
+                    "Assign a valid spectrum asset to the <i>Spectrum</i> field.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 
@@ -894,7 +894,7 @@ namespace Crest
                 showMessage
                 (
                     "<i>Components Per Octave</i> set to 0 meaning this Gerstner component won't generate any waves.",
-                    "Increase Components Per Octave to 8 or 16.",
+                    "Increase <i>Components Per Octave</i> to 8 or 16.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -859,7 +859,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "The MeshRenderer component will be ignored because the Mode is set to Global.",
+                    "The MeshRenderer component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
+                    "Either remove the MeshRenderer component or set the <i>Mode</i> option to <i>Geometry</i>.",
                     ValidatedHelper.MessageType.Warning, this
                 );
             }
@@ -868,7 +869,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "The MeshRenderer component will be ignored because the Mode is set to Global.",
+                    "The MeshRenderer component will be ignored because the <i>Mode</i> is set to <i>Global</i>.",
+                    "Either remove the MeshRenderer component or set the <i>Mode</i> option to <i>Geometry</i>.",
                     ValidatedHelper.MessageType.Warning, this
                 );
 
@@ -880,7 +882,7 @@ namespace Crest
                 showMessage
                 (
                     "There is no spectrum assigned meaning this Gerstner component won't generate any waves.",
-                    ValidatedHelper.MessageType.Warning, this
+                    "Assign a valid spectrum asset to the <i>Spectrum</i> field.", ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;
@@ -890,8 +892,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    "Components Per Octave set to 0 meaning this Gerstner component won't generate any waves.",
-                    ValidatedHelper.MessageType.Warning, this
+                    "<i>Components Per Octave</i> set to 0 meaning this Gerstner component won't generate any waves.",
+                    "Increase this value to 8 or 16.", ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -882,7 +882,8 @@ namespace Crest
                 showMessage
                 (
                     "There is no spectrum assigned meaning this Gerstner component won't generate any waves.",
-                    "Assign a valid spectrum asset to the Spectrum field.", ValidatedHelper.MessageType.Warning, this
+                    "Assign a valid spectrum asset to the Spectrum field.",
+                    ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;
@@ -893,7 +894,8 @@ namespace Crest
                 showMessage
                 (
                     "<i>Components Per Octave</i> set to 0 meaning this Gerstner component won't generate any waves.",
-                    "Increase Components Per Octave to 8 or 16.", ValidatedHelper.MessageType.Warning, this
+                    "Increase Components Per Octave to 8 or 16.",
+                    ValidatedHelper.MessageType.Warning, this
                 );
 
                 isValid = false;

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -49,7 +49,8 @@ namespace Crest.Spline
                 {
                     showMessage
                     (
-                        $"All child GameObjects under <i>Spline</i> must have <i>SplinePoint</i> component added. Object <i>{transform.GetChild(i).gameObject.name}</i> does not and should have one added, or be moved out of the hierarchy.",
+                        $"All child GameObjects under <i>Spline</i> must have <i>SplinePoint</i> component added. Object <i>{transform.GetChild(i).gameObject.name}</i> does not have one.",
+                        $"Add a <i>SplinePoint</i> component to object <i>{transform.GetChild(i).gameObject.name}<i>, or move this object out in the hierarchy.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -66,7 +67,8 @@ namespace Crest.Spline
             {
                 showMessage
                 (
-                    "Spline must have at least 2 spline points. Click the <i>Add point</i> button in the Inspector, or add a child GameObject and attach <i>SplinePoint</i> component to it.",
+                    "Spline must have at least 2 spline points.",
+                    "Click the <i>Add point</i> button in the Inspector, or add a child GameObject and attach <i>SplinePoint</i> component to it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -76,7 +78,8 @@ namespace Crest.Spline
             {
                 showMessage
                 (
-                    "Closed splines must have at least 3 spline points. See the <i>Closed</i> parameter and tooltip. To add a point click the <i>Add point</i> button in the Inspector, or add a child GameObject and attach <i>SplinePoint</i> component to it.",
+                    "Closed splines must have at least 3 spline points. See the <i>Closed</i> parameter and tooltip.",
+                    "Add a point by clicking the <i>Add point</i> button in the Inspector.",
                     ValidatedHelper.MessageType.Error, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -50,7 +50,7 @@ namespace Crest.Spline
                     showMessage
                     (
                         $"All child GameObjects under <i>Spline</i> must have <i>SplinePoint</i> component added. Object <i>{transform.GetChild(i).gameObject.name}</i> does not have one.",
-                        $"Add a SplinePoint component to object {transform.GetChild(i).gameObject.name}, or move this object out in the hierarchy.",
+                        $"Add a <i>SplinePoint</i> component to object {transform.GetChild(i).gameObject.name}, or move this object out in the hierarchy.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -68,7 +68,7 @@ namespace Crest.Spline
                 showMessage
                 (
                     "Spline must have at least 2 spline points.",
-                    "Click the Add Point button in the Inspector, or add a child GameObject and attach SplinePoint component to it.",
+                    "Click the <i>Add Point</i> button in the Inspector, or add a child GameObject and attach <i>SplinePoint</i> component to it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -79,7 +79,7 @@ namespace Crest.Spline
                 showMessage
                 (
                     "Closed splines must have at least 3 spline points. See the <i>Closed</i> parameter and tooltip.",
-                    "Add a point by clicking the Add Point button in the Inspector.",
+                    "Add a point by clicking the <i>Add Point</i> button in the Inspector.",
                     ValidatedHelper.MessageType.Error, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -50,7 +50,7 @@ namespace Crest.Spline
                     showMessage
                     (
                         $"All child GameObjects under <i>Spline</i> must have <i>SplinePoint</i> component added. Object <i>{transform.GetChild(i).gameObject.name}</i> does not have one.",
-                        $"Add a <i>SplinePoint</i> component to object <i>{transform.GetChild(i).gameObject.name}<i>, or move this object out in the hierarchy.",
+                        $"Add a SplinePoint component to object {transform.GetChild(i).gameObject.name}, or move this object out in the hierarchy.",
                         ValidatedHelper.MessageType.Error, this
                     );
 
@@ -68,7 +68,7 @@ namespace Crest.Spline
                 showMessage
                 (
                     "Spline must have at least 2 spline points.",
-                    "Click the <i>Add point</i> button in the Inspector, or add a child GameObject and attach <i>SplinePoint</i> component to it.",
+                    "Click the Add Point button in the Inspector, or add a child GameObject and attach SplinePoint component to it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -79,7 +79,7 @@ namespace Crest.Spline
                 showMessage
                 (
                     "Closed splines must have at least 3 spline points. See the <i>Closed</i> parameter and tooltip.",
-                    "Add a point by clicking the <i>Add point</i> button in the Inspector.",
+                    "Add a point by clicking the Add Point button in the Inspector.",
                     ValidatedHelper.MessageType.Error, this
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -90,7 +90,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    $"Water body <i>{gameObject.name}</i> requires an ocean renderer component to be present. Please create a separate Game Object and add an Ocean Renderer component to it.",
+                    $"Water body <i>{gameObject.name}</i> requires an ocean renderer component to be present.",
+                    "Create a separate Game Object and add an Ocean Renderer component to it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -101,7 +102,8 @@ namespace Crest
             {
                 showMessage
                 (
-                    $"Water body {gameObject.name} has a very small size (the size is set by the X & Z scale of its transform). This will be a very small body of water. Is this intentional?",
+                    $"Water body {gameObject.name} has a very small size (the size is set by the X & Z scale of its transform), and will be a very small body of water.",
+                    "Increase X & Z scale on water body transform (or parents).",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -113,6 +115,7 @@ namespace Crest
                 showMessage
                 (
                     $"There must be no rotation on the WaterBody GameObject, and no rotation on any parent. Currently the rotation Euler angles are {transform.eulerAngles}.",
+                    "Reset the rotations on this GameObject and all parents to 0.",
                     ValidatedHelper.MessageType.Error, this
                 );
             }

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -91,7 +91,7 @@ namespace Crest
                 showMessage
                 (
                     $"Water body <i>{gameObject.name}</i> requires an ocean renderer component to be present.",
-                    "Create a separate Game Object and add an Ocean Renderer component to it.",
+                    "Create a separate GameObject and add an <i>OceanRenderer</i> component to it.",
                     ValidatedHelper.MessageType.Error, this
                 );
 
@@ -114,7 +114,7 @@ namespace Crest
             {
                 showMessage
                 (
-                    $"There must be no rotation on the WaterBody GameObject, and no rotation on any parent. Currently the rotation Euler angles are {transform.eulerAngles}.",
+                    $"There must be no rotation on the water body GameObject, and no rotation on any parent. Currently the rotation Euler angles are {transform.eulerAngles}.",
                     "Reset the rotations on this GameObject and all parents to 0.",
                     ValidatedHelper.MessageType.Error, this
                 );

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -22,6 +22,9 @@ Changed
 ^^^^^^^
 .. bullet_list::
 
+   -  More validation help boxes added to catch a wider range of setup issues.
+   -  Fix buttons in help boxes now describe action that will be taken.
+
    .. only:: hdrp
 
       -  Rearrange some material properties. `[HDRP]`


### PR DESCRIPTION
I realised when clicking the fix button on the depth cache layers validation that its useful to know what the fix will do.

This PR adds a 'mode' to the fix function where it describes the fix action, so the user knows what will change.

Also adds a fix action for material keyword not set, and for dynamic waves disabled errors.