### PR TITLE
Fix-me button for material keywords

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -408,7 +408,8 @@ namespace Crest
 
             if (!string.IsNullOrEmpty(RequiredShaderKeyword) && ocean.OceanMaterial.HasProperty(RequiredShaderKeywordProperty) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
             {
-                showMessage(KeywordMissingErrorMessage, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                showMessage(KeywordMissingErrorMessage, ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                    (so) => OceanRenderer.FixSetMaterialKeywordEnabled(so, RequiredShaderKeyword, true));
                 isValid = false;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1324,15 +1324,32 @@ namespace Crest
             {
                 if (ocean.CreateClipSurfaceData)
                 {
-                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, ValidatedHelper.MessageType.Error, ocean.OceanMaterial);
+                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING, ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                        (so) => FixSetMaterialKeywordEnabled(so, LodDataMgrClipSurface.MATERIAL_KEYWORD, true));
                 }
                 else
                 {
-                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, ValidatedHelper.MessageType.Info, ocean.OceanMaterial);
+                    showMessage(LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF, ValidatedHelper.MessageType.Info, ocean.OceanMaterial,
+                        (so) => FixSetMaterialKeywordEnabled(so, LodDataMgrClipSurface.MATERIAL_KEYWORD, false));
                 }
             }
 
             return isValid;
+        }
+
+        internal static void FixSetMaterialKeywordEnabled(SerializedObject so, string keyword, bool enabled)
+        {
+            Material mat = so.targetObject as Material;
+            Undo.RecordObject(mat, $"Enable keyword {keyword}");
+            // Does apply change in viewport, but does not change shared material asset it seems..
+            if (enabled)
+            {
+                mat.EnableKeyword(keyword);
+            }
+            else
+            {
+                mat.DisableKeyword(keyword);
+            }
         }
 
         void OnValidate()


### PR DESCRIPTION
Helper to enable/disable material keywords.

Works functionaly but unfortunately the material editor does not reflect the changed keyword and i could not work out why. It is changing the asset successfully, so i dont know why the editor does not reflect this. Posting in case you can work it out