### PR TITLE
Add version and RP to HelpURL

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Constants.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Constants.cs
@@ -14,6 +14,16 @@ namespace Crest.Internal
         public const string MENU_PREFIX_SPLINE = MENU_SCRIPTS + "Spline/" + PREFIX;
         public const string MENU_PREFIX_EXAMPLE = MENU_SCRIPTS + "Example/" + PREFIX;
 
-        public const string HELP_URL_GENERAL = "https://crest.readthedocs.io/";
+        // Usage: HelpURL(HELP_URL_BASE_USER + "page.html" + HELP_URL_RP + "#heading")
+        // HELP_URL_VERSION should be updated AFTER a new tag is made. The 404 page for the documentation will redirect
+        // the user to "latest" since the tag for the new version is not published yet.
+        // For example, if 4.9 was just released, so we change HELP_URL_VERSION from 4.9 to 4.10. If a user is using
+        // master, then they will be redirected from crest.readthedocs.io/en/4.10 to crest.readthedocs.io/en/latest when
+        // they land on the 404 page.
+        public const string HELP_URL_VERSION = "4.10";
+        public const string HELP_URL_RP = "?rp=birp";
+        public const string HELP_URL_BASE = "https://crest.readthedocs.io/en/" + HELP_URL_VERSION + "/";
+        public const string HELP_URL_BASE_USER = HELP_URL_BASE + "user/";
+        public const string HELP_URL_GENERAL = HELP_URL_BASE + HELP_URL_RP;
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -37,7 +37,7 @@ namespace Crest
     /// script should normally be attached to the viewpoint, typically the main camera.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Floating Origin")]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/other-features.html#floating-origin")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "other-features.html" + Internal.Constants.HELP_URL_RP + "#floating-origin")]
     public class FloatingOrigin : MonoBehaviour
     {
         [Tooltip("Use a power of 2 to avoid pops in ocean surface geometry."), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -16,7 +16,7 @@ namespace Crest
     /// This should be used for static geometry, dynamic objects should be tagged with the Render Ocean Depth component.
     /// </summary>
     [ExecuteAlways]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/shallows-and-shorelines.html")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "shallows-and-shorelines.html" + Internal.Constants.HELP_URL_RP)]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Depth Cache")]
     public partial class OceanDepthCache : MonoBehaviour
     {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Animated Waves Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#animated-waves")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves")]
     public class RegisterAnimWavesInput : RegisterLodDataInputWithSplineSupport<LodDataMgrAnimWaves>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// clip the surface of the ocean.
     /// </summary>
     [AddComponentMenu(MENU_PREFIX + "Clip Surface Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#clip-surface")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#clip-surface")]
     public class RegisterClipSurfaceInput : RegisterLodDataInput<LodDataMgrClipSurface>
     {
         bool _enabled = true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Dynamic Waves Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#dynamic-waves")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#dynamic-waves")]
     public class RegisterDynWavesInput : RegisterLodDataInput<LodDataMgrDynWaves>
     {
         public override float Wavelength => 0f;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Flow Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#flow")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#flow")]
     public class RegisterFlowInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFlow, SplinePointDataFlow>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Foam Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#foam")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#foam")]
     public class RegisterFoamInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFoam, SplinePointDataFoam>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Sea Floor Depth Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#sea-floor-depth")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#sea-floor-depth")]
     public class RegisterSeaFloorDepthInput : RegisterLodDataInput<LodDataMgrSeaFloorDepth>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
@@ -15,7 +15,7 @@ namespace Crest
     [HelpURL(HELP_URL)]
     public class SimSettingsFoam : SimSettingsBase
     {
-        public const string HELP_URL = "https://crest.readthedocs.io/en/latest/user/ocean-simulation.html#general-settings";
+        public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#id5";
 
         [Header("General settings")]
         [Range(0f, 20f), Tooltip("Speed at which foam fades/dissipates.")]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsWave.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsWave.cs
@@ -11,7 +11,7 @@ namespace Crest
     [HelpURL(HELP_URL)]
     public class SimSettingsWave : SimSettingsBase
     {
-        public const string HELP_URL = "https://crest.readthedocs.io/en/latest/user/ocean-simulation.html#simulation-settings";
+        public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#simulation-settings";
 
         //[Header("Range")]
         [Range(0f, 32f), Tooltip("NOT CURRENTLY WORKING. The wave sim will not run if the simulation grid is smaller in resolution than this size. Useful to limit sim range for performance."),

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Shadow Input")]
-    [HelpURL("https://crest.readthedocs.io/en/stable/user/ocean-simulation.html#shadows")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#shadows")]
     public class RegisterShadowInput : RegisterLodDataInput<LodDataMgrShadow>
     {
         public override bool Enabled => true;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1430,7 +1430,7 @@ namespace Crest
 
             if (GUILayout.Button("Open Material Online Help"))
             {
-                Application.OpenURL("https://crest.readthedocs.io/en/latest/user/configuration.html#material-parameters");
+                Application.OpenURL(Internal.Constants.HELP_URL_BASE_USER + "configuration.html" + Internal.Constants.HELP_URL_RP + "#material-parameters");
             }
 
             DrawMaterialEditor();

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -19,7 +19,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner")]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/wave-conditions.html#shapegerstner-preview")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#shapegerstner-preview")]
     public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin
         , ISplinePointCustomDataSetup
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -17,7 +17,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner Batched")]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/wave-conditions.html#shapegerstnerbatched")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#shapegerstnerbatched")]
     public partial class ShapeGerstnerBatched : MonoBehaviour, ICollProvider, IFloatingOrigin
     {
         public enum GerstnerMode

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -17,7 +17,7 @@ namespace Crest.Spline
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SPLINE + "Spline")]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/wave-conditions.html#wave-splines-preview")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#wave-splines-preview")]
     public partial class Spline : MonoBehaviour
     {
         [Tooltip("Connect start and end point to close spline into a loop. Requires at least 3 spline points.")]

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -16,7 +16,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Water Body")]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/water-bodies.html")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "water-bodies.html")]
     public partial class WaterBody : MonoBehaviour
     {
 #pragma warning disable 414

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,24 @@ When editing static files, generally you will need to do a `make clean html` to 
 
 RTDs will rebuild automatically on git push.
 
+## Versioned Documentation
+
+[Read The Docs documentation](https://docs.readthedocs.io/en/stable/versions.html).
+
+https://crest.readthedocs.io/en/latest/ points to HEAD on master.
+https://crest.readthedocs.io/en/stable/ points to the latest git tag.
+https://crest.readthedocs.io/ redirects to stable.
+https://crest.readthedocs.io/en/4.9/ points to 4.9 git tag.
+
+After a new version is published (new git tag and asset store upload), in the RTDs admin, the new tag must be made active for the version to be visible.
+
+Then the version must be updated in the following two locations:
+[docs/conf.py](https://github.com/wave-harmonic/crest/blob/master/docs/conf.py)
+[crest/Assets/Crest/Crest/Scripts/Constants.cs](https://github.com/wave-harmonic/crest/blob/master/crest/Assets/Crest/Crest/Scripts/Constants.cs)
+
+For example, after the git tag for 4.9 is published and the asset store versions are uploaded, we will open those two files to change 4.9 to 4.10.
+Even though 4.10 doesn't exist yet, this approach removes the need to change the version before publishing, and then having to change it back to latest, which reduces the burden a little.
+
 ## Extensions
 
 - [Furo Theme](https://pradyunsg.me/furo)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -30,6 +30,7 @@ Changed
    -  Rename *Add Water Height From Geometry* to *Set Base Water Height Using Geometry*.
    -  Rename *Set Water Height To Geometry* to *Set Water Height Using Geometry*.
    -  Improved spline gizmo line drawing to highlight selected spline point.
+   -  Add version and render pipeline to help button documentation links.
 
    .. only:: hdrp or urp
 


### PR DESCRIPTION
Adds the version and render pipeline to the help URLs.

Currently, it points to 4.10 which doesn't exist yet. A custom 404 page will redirect users to latest until the 4.10 tag is published. This allows us to change the version once (after publishing a tag). Otherwise, we would have to change it from latest to 4.10, and then back to latest.

The constants are tedious looking, but this can be fixed with a custom help URL attribute similar to [Unity's](https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.core/Runtime/Documentation.cs). We cannot do this now as the HelpURLAttribute is sealed. But it must of been unsealed in 2021 or later.