### PR TITLE
Rewrite multi-property attributes as decorated/decorator attributes

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -18,7 +18,7 @@ public class BoatAlignNormal : FloatingObjectBase
     float _buoyancyCoeff = 1.5f;
     [Tooltip("Strength of torque applied to match boat orientation to water normal."), SerializeField]
     float _boyancyTorque = 8f;
-    [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), SerializeField, Range(0, 1)]
+    [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), SerializeField, Crest.Range(0, 1)]
     float _accelerateDownhill = 0f;
 
     [Header("Engine Power")]

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -34,7 +34,7 @@ public class BoatAlignNormal : FloatingObjectBase
 
     [SerializeField, Tooltip("Computes a separate normal based on boat length to get more accurate orientations, at the cost of an extra collision sample.")]
     bool _useBoatLength = false;
-    [Tooltip("Length dimension of boat. Only used if Use Boat Length is enabled."), SerializeField, PredicatedField("_useBoatLength")]
+    [Tooltip("Length dimension of boat. Only used if Use Boat Length is enabled."), SerializeField, Predicated("_useBoatLength"), DecoratedField]
     float _boatLength = 3f;
 
     [Header("Drag")]

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
@@ -13,7 +13,7 @@ public class OceanSampleDisplacementDemo : MonoBehaviour
 {
     public bool _trackCamera = true;
 
-    [Range(0f, 32f)]
+    [Crest.Range(0f, 32f)]
     public float _minGridSize = 0f;
 
     GameObject[] _markerObjects = new GameObject[3];

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
@@ -11,13 +11,13 @@ namespace Crest
     using UnityEditor;
 #endif
 
-    public class DecoratedEmbeddedFieldAttribute : DecoratedPropertyAttribute
+    public class EmbeddedAttribute : DecoratedPropertyAttribute
     {
 #if UNITY_EDITOR
         internal EmbeddedAssetEditor editor;
 #endif
 
-        public DecoratedEmbeddedFieldAttribute()
+        public EmbeddedAttribute()
         {
 #if UNITY_EDITOR
             editor = new EmbeddedAssetEditor();
@@ -27,7 +27,7 @@ namespace Crest
 #if UNITY_EDITOR
         internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
         {
-            DecoratedEmbeddedFieldAttribute embeddedAttribute = this;
+            EmbeddedAttribute embeddedAttribute = this;
             embeddedAttribute.editor.DrawEditorCombo(label, drawer, property, "asset");
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
@@ -11,13 +11,13 @@ namespace Crest
     using UnityEditor;
 #endif
 
-    public class EmbeddedFieldAttribute : MultiPropertyAttribute
+    public class DecoratedEmbeddedFieldAttribute : DecoratedPropertyAttribute
     {
 #if UNITY_EDITOR
         internal EmbeddedAssetEditor editor;
 #endif
 
-        public EmbeddedFieldAttribute()
+        public DecoratedEmbeddedFieldAttribute()
         {
 #if UNITY_EDITOR
             editor = new EmbeddedAssetEditor();
@@ -25,9 +25,9 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer, bool isLast)
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
         {
-            EmbeddedFieldAttribute embeddedAttribute = this;
+            DecoratedEmbeddedFieldAttribute embeddedAttribute = this;
             embeddedAttribute.editor.DrawEditorCombo(label, drawer, property, "asset");
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -119,7 +119,7 @@ namespace Crest
                     EditorGUI.Slider(position, property, minimum, maximum, label);
                     break;
                 case SerializedPropertyType.Integer:
-                    EditorGUI.Slider(position, property, minimum, maximum, label);
+                    EditorGUI.IntSlider(position, property, (int)minimum, (int)maximum, label);
                     break;
                 default:
                     EditorGUI.LabelField(position, label.text, "DecoratedRange: must be float or integer.");

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -75,7 +75,7 @@ namespace Crest
     /// <summary>
     /// Renders the property using EditorGUI.Delayed*.
     /// </summary>
-    public class DecoratedDelayedFieldAttribute : DecoratedPropertyAttribute
+    public class DelayedAttribute : DecoratedPropertyAttribute
     {
         internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
         {
@@ -91,7 +91,7 @@ namespace Crest
                     EditorGUI.DelayedTextField(position, property, label);
                     break;
                 default:
-                    EditorGUI.LabelField(position, label.text, "DecoratedDelayed: must be float, integer, or string.");
+                    EditorGUI.LabelField(position, label.text, "Delayed: must be float, integer, or string.");
                     break;
             }
         }
@@ -100,12 +100,12 @@ namespace Crest
     /// <summary>
     /// Renders the property using EditorGUI.Slider.
     /// </summary>
-    public class DecoratedRangeFieldAttribute : DecoratedPropertyAttribute
+    public class RangeAttribute : DecoratedPropertyAttribute
     {
         readonly float minimum;
         readonly float maximum;
 
-        public DecoratedRangeFieldAttribute(float minimum, float maximum)
+        public RangeAttribute(float minimum, float maximum)
         {
             this.minimum = minimum;
             this.maximum = maximum;
@@ -122,7 +122,7 @@ namespace Crest
                     EditorGUI.IntSlider(position, property, (int)minimum, (int)maximum, label);
                     break;
                 default:
-                    EditorGUI.LabelField(position, label.text, "DecoratedRange: must be float or integer.");
+                    EditorGUI.LabelField(position, label.text, "Range: must be float or integer.");
                     break;
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -2,22 +2,25 @@
 
 // Adapted from: https://forum.unity.com/threads/drawing-a-field-using-multiple-property-drawers.479377/
 
-// This class allows multiple attributes to be used together providing they inherit from this class. It also eliminates
-// the requirement to create a custom property drawer as the MultiPropertyDrawer class handles all of that for us. The
-// implementation difference when creating a custom attribute is to place the property drawer code in the attribute
-// instead. Also, any change to the GUI state must not be reset so it can be stacked. The MultiPropertyDrawer class
-// resets the GUI state for us.
+// DecoratedPropertyAttribute renders the field and DecoratorAttribute decorates said field. The decorator changes the
+// GUI state so that the decorated field receives that state. The DecoratedDrawer targets DecoratedPropertyAttribute,
+// calls DecoratorAttribute.Decorate for each decorator and reverts GUI state.
 
 namespace Crest
 {
     using UnityEngine;
+    using System;
 
 #if UNITY_EDITOR
     using Crest.EditorHelpers;
     using UnityEditor;
 #endif
 
-    public abstract class MultiPropertyAttribute : PropertyAttribute
+    /// <summary>
+    /// Renders a property field accommodating decorator properties.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public abstract class DecoratedPropertyAttribute : PropertyAttribute
     {
 #if UNITY_EDITOR
         /// <summary>
@@ -28,12 +31,100 @@ namespace Crest
         /// <summary>
         /// Override this method to make your own IMGUI based GUI for the property.
         /// </summary>
-        internal abstract void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer, bool isLast);
+        internal abstract void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer);
 
         /// <summary>
         /// Override this method to specify how tall the GUI for this field is in pixels.
         /// </summary>
         internal virtual float? GetPropertyHeight(SerializedProperty property, GUIContent label) => null;
 #endif
+    }
+
+    /// <summary>
+    /// Decorates a decorator field by changing GUI state.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
+    public abstract class DecoratorAttribute : Attribute
+    {
+        public int order;
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Override this method to customise the label.
+        /// </summary>
+        internal virtual GUIContent BuildLabel(GUIContent label) => label;
+
+        /// <summary>
+        /// Override this method to additively change the appearance of a decorated field.
+        /// </summary>
+        internal abstract void Decorate(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer);
+#endif
+    }
+
+    /// <summary>
+    /// Renders the property using EditorGUI.PropertyField.
+    /// </summary>
+    public class DecoratedFieldAttribute : DecoratedPropertyAttribute
+    {
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
+        {
+            EditorGUI.PropertyField(position, property, label);
+        }
+    }
+
+    /// <summary>
+    /// Renders the property using EditorGUI.Delayed*.
+    /// </summary>
+    public class DecoratedDelayedFieldAttribute : DecoratedPropertyAttribute
+    {
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Float:
+                    EditorGUI.DelayedFloatField(position, property, label);
+                    break;
+                case SerializedPropertyType.Integer:
+                    EditorGUI.DelayedIntField(position, property, label);
+                    break;
+                case SerializedPropertyType.String:
+                    EditorGUI.DelayedTextField(position, property, label);
+                    break;
+                default:
+                    EditorGUI.LabelField(position, label.text, "DecoratedDelayed: must be float, integer, or string.");
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders the property using EditorGUI.Slider.
+    /// </summary>
+    public class DecoratedRangeFieldAttribute : DecoratedPropertyAttribute
+    {
+        readonly float minimum;
+        readonly float maximum;
+
+        public DecoratedRangeFieldAttribute(float minimum, float maximum)
+        {
+            this.minimum = minimum;
+            this.maximum = maximum;
+        }
+
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
+        {
+            switch (property.propertyType)
+            {
+                case SerializedPropertyType.Float:
+                    EditorGUI.Slider(position, property, minimum, maximum, label);
+                    break;
+                case SerializedPropertyType.Integer:
+                    EditorGUI.Slider(position, property, minimum, maximum, label);
+                    break;
+                default:
+                    EditorGUI.LabelField(position, label.text, "DecoratedRange: must be float or integer.");
+                    break;
+            }
+        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
@@ -12,8 +12,7 @@ using UnityEditor;
 
 namespace Crest
 {
-    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-    public class PredicatedFieldAttribute : MultiPropertyAttribute
+    public class PredicatedAttribute : DecoratorAttribute
     {
         public readonly string _propertyName;
         public readonly Type _requiredComponentType;
@@ -22,11 +21,11 @@ namespace Crest
 
         /// <summary>
         /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
-        /// to disable a field if a toggle is false. Limitation - conflicts with other property drawers such as Range().
+        /// to disable a field if a toggle is false.
         /// </summary>
         /// <param name="requiredComponentType">If a component of this type is not attached to this GameObject, disable the GUI (or enable if inverted is true).</param>
         /// <param name="inverted">Flip behaviour - for example disable if a bool field is set to true (instead of false).</param>
-        public PredicatedFieldAttribute(Type requiredComponentType, bool inverted = false)
+        public PredicatedAttribute(Type requiredComponentType, bool inverted = false)
         {
             _requiredComponentType = requiredComponentType;
             _inverted = inverted;
@@ -34,12 +33,12 @@ namespace Crest
 
         /// <summary>
         /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
-        /// to disable a field if a toggle is false. Limitation - conflicts with other property drawers such as Range().
+        /// to disable a field if a toggle is false.
         /// </summary>
         /// <param name="propertyName">The name of the other property whose value dictates whether this field is enabled or not.</param>
         /// <param name="inverted">Flip behaviour - for example disable if a bool field is set to true (instead of false).</param>
         /// <param name="disableIfValueIs">If the field has this value, disable the GUI (or enable if inverted is true).</param>
-        public PredicatedFieldAttribute(string propertyName, bool inverted = false, int disableIfValueIs = 0)
+        public PredicatedAttribute(string propertyName, bool inverted = false, int disableIfValueIs = 0)
         {
             _propertyName = propertyName;
             _inverted = inverted;
@@ -48,13 +47,13 @@ namespace Crest
 
         /// <summary>
         /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
-        /// to disable a field if a toggle is false. Limitation - conflicts with other property drawers such as Range().
+        /// to disable a field if a toggle is false.
         /// </summary>
         /// <param name="propertyName">The name of the other property whose value dictates whether this field is enabled or not.</param>
         /// <param name="requiredComponentType">If a component of this type is not attached to this GameObject, disable the GUI (or enable if inverted is true).</param>
         /// <param name="inverted">Flip behaviour - for example disable if a bool field is set to true (instead of false).</param>
         /// <param name="disableIfValueIs">If the field has this value, disable the GUI (or enable if inverted is true).</param>
-        public PredicatedFieldAttribute(string propertyName, Type requiredComponentType, bool inverted = false, int disableIfValueIs = 0)
+        public PredicatedAttribute(string propertyName, Type requiredComponentType, bool inverted = false, int disableIfValueIs = 0)
         {
             _propertyName = propertyName;
             _requiredComponentType = requiredComponentType;
@@ -91,14 +90,14 @@ namespace Crest
             }
             else
             {
-                Debug.LogError($"PredicatedFieldAttributePropertyDrawer - property type not implemented yet: {prop.type}.", prop.serializedObject.targetObject);
+                Debug.LogError($"PredicatedAttribute - property type not implemented yet: {prop.type}.", prop.serializedObject.targetObject);
                 return true;
             }
 
             return _inverted ? !result : result;
         }
 
-        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, MultiPropertyDrawer drawer, bool isLast)
+        internal override void Decorate(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
         {
             var enabled = true;
 
@@ -121,11 +120,6 @@ namespace Crest
             }
 
             GUI.enabled = enabled;
-
-            if (isLast)
-            {
-                EditorGUI.PropertyField(position, property, label);
-            }
         }
 #endif
     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -45,7 +45,7 @@ namespace Crest
         float _maxDisplacementHorizontal = 0f;
 
         [SerializeField, Tooltip("Use the bounding box of an attached renderer component to determine the max vertical displacement.")]
-        [PredicatedField(typeof(MeshRenderer))]
+        [Predicated(typeof(MeshRenderer)), DecoratedField]
         bool _reportRendererBoundsToOceanSystem = false;
 
         protected override void Update()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -33,7 +33,7 @@ namespace Crest
         float _maxDisplacementVertical = 0f;
 
         [SerializeField, Tooltip("Use the bounding box of an attached renderer component to determine the max vertical displacement.")]
-        [PredicatedField(typeof(MeshRenderer))]
+        [Predicated(typeof(MeshRenderer)), DecoratedField]
         bool _reportRendererBoundsToOceanSystem = false;
 
         protected override void Update()

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -276,9 +276,9 @@ namespace Crest
         bool _overrideSplineSettings = false;
         [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), DecoratedField]
         float _radius = 20f;
-        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), DecoratedDelayedField]
+        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), Delayed]
         int _subdivisions = 1;
-        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), DecoratedDelayedField]
+        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), Delayed]
         int _smoothingIterations = 0;
 
         protected Material _splineMaterial;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -58,7 +58,7 @@ namespace Crest
     {
 #if UNITY_EDITOR
         [SerializeField, Tooltip("Check that the shader applied to this object matches the input type (so e.g. an Animated Waves input object has an Animated Waves input shader.")]
-        [PredicatedField(typeof(MeshRenderer))]
+        [Predicated(typeof(MeshRenderer)), DecoratedField]
         bool _checkShaderName = true;
 #endif
 
@@ -175,7 +175,7 @@ namespace Crest
     {
         protected const string k_displacementCorrectionTooltip = "Whether this input data should displace horizontally with waves. If false, data will not move from side to side with the waves. Adds a small performance overhead when disabled.";
 
-        [SerializeField, PredicatedField(typeof(MeshRenderer))]
+        [SerializeField, Predicated(typeof(MeshRenderer)), DecoratedField]
         bool _disableRenderer = true;
 
         protected abstract Color GizmoColor { get; }
@@ -272,13 +272,13 @@ namespace Crest
         where SplinePointCustomData : MonoBehaviour, ISplinePointCustomData
     {
         [Header("Spline settings")]
-        [SerializeField, PredicatedField(typeof(Spline.Spline))]
+        [SerializeField, Predicated(typeof(Spline.Spline)), DecoratedField]
         bool _overrideSplineSettings = false;
-        [SerializeField, PredicatedField("_overrideSplineSettings", typeof(Spline.Spline))]
+        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), DecoratedField]
         float _radius = 20f;
-        [SerializeField, PredicatedField("_overrideSplineSettings", typeof(Spline.Spline)), Delayed]
+        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), DecoratedDelayedField]
         int _subdivisions = 1;
-        [SerializeField, PredicatedField("_overrideSplineSettings", typeof(Spline.Spline)), Delayed]
+        [SerializeField, Predicated("_overrideSplineSettings", typeof(Spline.Spline)), DecoratedDelayedField]
         int _smoothingIterations = 0;
 
         protected Material _splineMaterial;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -26,7 +26,7 @@ namespace Crest
         public CollisionSources CollisionSource { get { return _collisionSource; } set { _collisionSource = value; } }
 
         [Tooltip("Maximum number of wave queries that can be performed when using ComputeShaderQueries.")]
-        [PredicatedField("_collisionSource", true, (int)CollisionSources.ComputeShaderQueries), SerializeField]
+        [Predicated("_collisionSource", true, (int)CollisionSources.ComputeShaderQueries), SerializeField, DecoratedField]
         int _maxQueryCount = QueryBase.MAX_QUERY_COUNT_DEFAULT;
         public int MaxQueryCount { get { return _maxQueryCount; } }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -132,7 +132,7 @@ namespace Crest
         [Tooltip("The primary directional light. Required if shadowing is enabled.")]
         public Light _primaryLight;
         [Tooltip("If Primary Light is not set, search the scene for all directional lights and pick the brightest to use as the sun light.")]
-        [SerializeField, PredicatedField("_primaryLight", true)]
+        [SerializeField, Predicated("_primaryLight", true), DecoratedField]
         bool _searchForPrimaryLightOnStartup = true;
 
         [Header("Ocean Params")]
@@ -179,7 +179,7 @@ namespace Crest
 
         [Header("Simulation Params")]
 
-        [EmbeddedField]
+        [DecoratedEmbeddedField]
         public SimSettingsAnimatedWaves _simSettingsAnimatedWaves;
 
         [Tooltip("Water depth information used for shallow water, shoreline foam, wave attenuation, among others."), SerializeField]
@@ -189,25 +189,25 @@ namespace Crest
         [Tooltip("Simulation of foam created in choppy water and dissipating over time."), SerializeField]
         bool _createFoamSim = true;
         public bool CreateFoamSim { get { return _createFoamSim; } }
-        [PredicatedField("_createFoamSim", order = 0), EmbeddedField(order = 1)]
+        [Predicated("_createFoamSim"), DecoratedEmbeddedField]
         public SimSettingsFoam _simSettingsFoam;
 
         [Tooltip("Dynamic waves generated from interactions with objects such as boats."), SerializeField]
         bool _createDynamicWaveSim = false;
         public bool CreateDynamicWaveSim { get { return _createDynamicWaveSim; } }
-        [PredicatedField("_createDynamicWaveSim", order = 0), EmbeddedField(order = 1)]
+        [Predicated("_createDynamicWaveSim"), DecoratedEmbeddedField]
         public SimSettingsWave _simSettingsDynamicWaves;
 
         [Tooltip("Horizontal motion of water body, akin to water currents."), SerializeField]
         bool _createFlowSim = false;
         public bool CreateFlowSim { get { return _createFlowSim; } }
-        [PredicatedField("_createFlowSim", order = 0), EmbeddedField(order = 1)]
+        [Predicated("_createFlowSim"), DecoratedEmbeddedField]
         public SimSettingsFlow _simSettingsFlow;
 
         [Tooltip("Shadow information used for lighting water."), SerializeField]
         bool _createShadowData = false;
         public bool CreateShadowData { get { return _createShadowData; } }
-        [PredicatedField("_createShadowData", order = 0), EmbeddedField(order = 1)]
+        [Predicated("_createShadowData"), DecoratedEmbeddedField]
         public SimSettingsShadow _simSettingsShadow;
 
         [Tooltip("Clip surface information for clipping the ocean surface."), SerializeField]
@@ -219,7 +219,7 @@ namespace Crest
             EverythingClipped,
         }
         [Tooltip("Whether to clip nothing by default (and clip inputs remove patches of surface), or to clip everything by default (and clip inputs add patches of surface).")]
-        [PredicatedField("_createClipSurfaceData")]
+        [Predicated("_createClipSurfaceData"), DecoratedField]
         public DefaultClippingState _defaultClippingState = DefaultClippingState.NothingClipped;
 
         [Header("Edit Mode Params")]
@@ -238,7 +238,7 @@ namespace Crest
         float _editModeFPS = 30f;
 #pragma warning restore 414
 
-        [Tooltip("Move ocean with Scene view camera if Scene window is focused."), SerializeField, PredicatedField("_showOceanProxyPlane", true)]
+        [Tooltip("Move ocean with Scene view camera if Scene window is focused."), SerializeField, Predicated("_showOceanProxyPlane", true), DecoratedField]
 #pragma warning disable 414
         bool _followSceneCamera = true;
 #pragma warning restore 414

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -179,7 +179,7 @@ namespace Crest
 
         [Header("Simulation Params")]
 
-        [DecoratedEmbeddedField]
+        [Embedded]
         public SimSettingsAnimatedWaves _simSettingsAnimatedWaves;
 
         [Tooltip("Water depth information used for shallow water, shoreline foam, wave attenuation, among others."), SerializeField]
@@ -189,25 +189,25 @@ namespace Crest
         [Tooltip("Simulation of foam created in choppy water and dissipating over time."), SerializeField]
         bool _createFoamSim = true;
         public bool CreateFoamSim { get { return _createFoamSim; } }
-        [Predicated("_createFoamSim"), DecoratedEmbeddedField]
+        [Predicated("_createFoamSim"), Embedded]
         public SimSettingsFoam _simSettingsFoam;
 
         [Tooltip("Dynamic waves generated from interactions with objects such as boats."), SerializeField]
         bool _createDynamicWaveSim = false;
         public bool CreateDynamicWaveSim { get { return _createDynamicWaveSim; } }
-        [Predicated("_createDynamicWaveSim"), DecoratedEmbeddedField]
+        [Predicated("_createDynamicWaveSim"), Embedded]
         public SimSettingsWave _simSettingsDynamicWaves;
 
         [Tooltip("Horizontal motion of water body, akin to water currents."), SerializeField]
         bool _createFlowSim = false;
         public bool CreateFlowSim { get { return _createFlowSim; } }
-        [Predicated("_createFlowSim"), DecoratedEmbeddedField]
+        [Predicated("_createFlowSim"), Embedded]
         public SimSettingsFlow _simSettingsFlow;
 
         [Tooltip("Shadow information used for lighting water."), SerializeField]
         bool _createShadowData = false;
         public bool CreateShadowData { get { return _createShadowData; } }
-        [Predicated("_createShadowData"), DecoratedEmbeddedField]
+        [Predicated("_createShadowData"), Embedded]
         public SimSettingsShadow _simSettingsShadow;
 
         [Tooltip("Clip surface information for clipping the ocean surface."), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -240,15 +240,15 @@ namespace Crest
             var angle_radians = Mathf.PI * angle / 180f;
             var kx = Mathf.Cos(angle_radians) * wavenumber;
             var kz = Mathf.Sin(angle_radians) * wavenumber;
-            
+
             var k2 = kx * kx + kz * kz;
-            
+
             var windSpeed2 = windSpeed * windSpeed;
             var wx = windDir.x;
             var wz = windDir.y;
-            
+
             var kdotw = (wx * kx + wz * kz);
-            
+
             var a = 0.0081f; // phillips constant ( https://hal.archives-ouvertes.fr/file/index/docid/307938/filename/frechot_realistic_simulation_of_ocean_surface_using_wave_spectra.pdf )
             var L = windSpeed2 / gravity;
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -26,7 +26,7 @@ namespace Crest
         , IReceiveSplinePointOnDrawGizmosSelectedMessages
 #endif
     {
-        [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum."), DecoratedEmbeddedField]
+        [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum."), Embedded]
         public OceanWaveSpectrum _spectrum;
         OceanWaveSpectrum _activeSpectrum = null;
 
@@ -63,9 +63,9 @@ namespace Crest
         bool _overrideSplineSettings = false;
         [SerializeField, Predicated("_overrideSplineSettings"), DecoratedField]
         float _radius = 20f;
-        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedDelayedField]
+        [SerializeField, Predicated("_overrideSplineSettings"), Delayed]
         int _subdivisions = 1;
-        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedDelayedField]
+        [SerializeField, Predicated("_overrideSplineSettings"), Delayed]
         int _smoothingIterations = 0;
 
         [SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -26,7 +26,7 @@ namespace Crest
         , IReceiveSplinePointOnDrawGizmosSelectedMessages
 #endif
     {
-        [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum."), EmbeddedField]
+        [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum."), DecoratedEmbeddedField]
         public OceanWaveSpectrum _spectrum;
         OceanWaveSpectrum _activeSpectrum = null;
 
@@ -61,11 +61,11 @@ namespace Crest
         [Header("Spline settings")]
         [SerializeField]
         bool _overrideSplineSettings = false;
-        [SerializeField, PredicatedField("_overrideSplineSettings")]
+        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedField]
         float _radius = 20f;
-        [SerializeField, PredicatedField("_overrideSplineSettings"), Delayed]
+        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedDelayedField]
         int _subdivisions = 1;
-        [SerializeField, PredicatedField("_overrideSplineSettings"), Delayed]
+        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedDelayedField]
         int _smoothingIterations = 0;
 
         [SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -29,7 +29,7 @@ namespace Crest
         [Tooltip("If set to 'Global', waves will render everywhere. If set to 'Geometry', the geometry on this GameObject will be rendered from a top down perspective to generate the waves. This allows having local wave conditions by placing Quad geometry where desired. The geometry must have one of the Gerstner shaders on it such as 'Crest/Inputs/Animated Waves/Gerstner Batch Geometry'.")]
         public GerstnerMode _mode = GerstnerMode.Global;
 
-        [Tooltip("The spectrum that defines the ocean surface shape. Create asset of type Crest/Ocean Waves Spectrum."), DecoratedEmbeddedField]
+        [Tooltip("The spectrum that defines the ocean surface shape. Create asset of type Crest/Ocean Waves Spectrum."), Embedded]
         public OceanWaveSpectrum _spectrum;
 
         [Tooltip("Wind direction (angle from x axis in degrees)"), Range(-180, 180)]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -29,7 +29,7 @@ namespace Crest
         [Tooltip("If set to 'Global', waves will render everywhere. If set to 'Geometry', the geometry on this GameObject will be rendered from a top down perspective to generate the waves. This allows having local wave conditions by placing Quad geometry where desired. The geometry must have one of the Gerstner shaders on it such as 'Crest/Inputs/Animated Waves/Gerstner Batch Geometry'.")]
         public GerstnerMode _mode = GerstnerMode.Global;
 
-        [Tooltip("The spectrum that defines the ocean surface shape. Create asset of type Crest/Ocean Waves Spectrum."), EmbeddedField]
+        [Tooltip("The spectrum that defines the ocean surface shape. Create asset of type Crest/Ocean Waves Spectrum."), DecoratedEmbeddedField]
         public OceanWaveSpectrum _spectrum;
 
         [Tooltip("Wind direction (angle from x axis in degrees)"), Range(-180, 180)]
@@ -107,13 +107,13 @@ namespace Crest
         // Data for all components
         [Header("Wave data (usually populated at runtime)")]
         public bool _evaluateSpectrumAtRuntime = true;
-        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
+        [Predicated("_evaluateSpectrumAtRuntime", true), DecoratedField]
         public float[] _wavelengths;
-        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
+        [Predicated("_evaluateSpectrumAtRuntime", true), DecoratedField]
         public float[] _amplitudes;
-        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
+        [Predicated("_evaluateSpectrumAtRuntime", true), DecoratedField]
         public float[] _angleDegs;
-        [PredicatedField("_evaluateSpectrumAtRuntime", true)]
+        [Predicated("_evaluateSpectrumAtRuntime", true), DecoratedField]
         public float[] _phases;
 
         [SerializeField, Tooltip("Make waves converge towards a point. Must be set at edit time only, applied on startup."), Header("Direct towards point")]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -118,9 +118,9 @@ namespace Crest
 
         [SerializeField, Tooltip("Make waves converge towards a point. Must be set at edit time only, applied on startup."), Header("Direct towards point")]
         bool _directTowardsPoint = false;
-        [SerializeField, Tooltip("Target point XZ to converge to.")]
+        [SerializeField, Tooltip("Target point XZ to converge to."), Predicated("_directTowardsPoint"), DecoratedField]
         Vector2 _pointPositionXZ = Vector2.zero;
-        [SerializeField, Tooltip("Inner and outer radii. Influence at full strength at inner radius, fades off at outer radius.")]
+        [SerializeField, Tooltip("Inner and outer radii. Influence at full strength at inner radius, fades off at outer radius."), Predicated("_directTowardsPoint"), DecoratedField]
         Vector2 _pointRadii = new Vector2(100f, 200f);
 
         const string DIRECT_TOWARDS_POINT_KEYWORD = "CREST_DIRECT_TOWARDS_POINT_INTERNAL";

--- a/crest/Assets/Development/Editor/AttributeValidator.cs
+++ b/crest/Assets/Development/Editor/AttributeValidator.cs
@@ -1,0 +1,37 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest
+{
+    using System.Reflection;
+    using UnityEditor.Callbacks;
+    using System.Linq;
+    using UnityEngine;
+    using System;
+
+    /// <summary>
+    /// Validates decorator attributes. They need to also have a decorated attribute to work.
+    /// </summary>
+    static class AttributeValidator
+    {
+        [DidReloadScripts]
+        static void OnDidReloadScripts()
+        {
+            // TODO: Try using TypeCache in Unity 2020.
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.FullName.StartsWith("Crest")).ToList();
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    foreach (var property in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+                    {
+                        if (property.GetCustomAttribute<DecoratorAttribute>() == null) continue;
+                        if (property.GetCustomAttribute<DecoratedPropertyAttribute>() != null) continue;
+                        Debug.LogError($"A decorator attribute on {type}.{property.Name} has no attribute which inherits from DecoratedPropertyAttribute. The decorator will be ignored.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crest/Assets/Development/Editor/AttributeValidator.cs.meta
+++ b/crest/Assets/Development/Editor/AttributeValidator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 991d770e0ecfe4b189462f1bbfec2423
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Development/Editor/Crest.Development.Editor.asmdef
+++ b/crest/Assets/Development/Editor/Crest.Development.Editor.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Crest.Development.Editor",
-    "references": [],
-    "optionalUnityReferences": [],
+    "references": [
+        "Crest"
+    ],
     "includePlatforms": [
         "Editor"
     ],
@@ -10,5 +11,7 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -48,6 +48,7 @@ Fixed
    -  Fix spline point delete not being part of undo/redo history.
    -  Fix validation fix buttons that attach components not being part of undo/redo history.
    -  Fix ShapeGerstnerBatched not having default spectrum when using "Reset" and correct undo/redo history.
+   -  Fix properties with embedded asset editors appearing broken for Unity 2020 and 2021.
 
    .. only:: hdrp
 


### PR DESCRIPTION
- Fixes embedded field attribute for 2021
- Nicer architecture
- Added range and delay fields that work with predicated
- More robust and possibly performs better (untested)

Unity changed something in 2021 causing the _MultiPropertyDrawer_ to be called twice when a property had two attributes that inherited from _MultiPropertyAttribute_ and one of those called _EditorGUI.PropertyField_ (looking at you _Embedded_).

The fix was to separate _MultiPropertyAttribute_ into decorators and decorated attributes. A property will have only one decorated field which solves the problem of targeting multiple attributes.

_PredicatedField_ has been changed to _Predicated_ and is now a decorator. It cannot be used by itself as decorators do not call _EditorGUI.PropertyField_ so  I have added a general purpose _DecoratedField_ which calls _EditorGUI.PropertyField_. This is the only drawback.

I have also added ranged and delayed decorated fields which work with decorators like predicated. We had some delayed fields which broke predicated and is now fixed.