### PR TITLE
Validate scene view effects options

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -1,3 +1,21 @@
-﻿{
-	"name": "Crest"
+{
+    "name": "Crest",
+    "references": [
+        "Unity.Postprocessing.Runtime"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.postprocessing",
+            "expression": "",
+            "define": "UNITY_POSTPROCESSING_ENABLED"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1260,6 +1260,55 @@ namespace Crest
                 );
             }
 
+            // Validate scene view effects options.
+            if (SceneView.lastActiveSceneView != null)
+            {
+                var sceneView = SceneView.lastActiveSceneView;
+
+                // Validate "Animated Materials".
+                if (!ocean._showOceanProxyPlane && !sceneView.sceneViewState.showMaterialUpdate)
+                {
+                    showMessage
+                    (
+                        "<i>Animated Materials</i> is not enabled on the scene view. The ocean's framerate will appear low as updates are not real-time.",
+                        "Enable <i>Animated Materials</i> on the scene view.",
+                        ValidatedHelper.MessageType.Info, ocean,
+                        _ =>
+                        {
+                            SceneView.lastActiveSceneView.sceneViewState.showMaterialUpdate = true;
+                            // Required after changing sceneViewState according to:
+                            // https://docs.unity3d.com/ScriptReference/SceneView.SceneViewState.html
+                            SceneView.RepaintAll();
+                        }
+                    );
+                }
+
+#if UNITY_POSTPROCESSING_ENABLED
+                // Validate "Post-Processing".
+                // Only check built-in renderer and Camera.main with enabled PostProcessLayer component.
+                if (GraphicsSettings.currentRenderPipeline == null && Camera.main != null &&
+                    Camera.main.TryGetComponent<UnityEngine.Rendering.PostProcessing.PostProcessLayer>(out var ppLayer)
+                    && ppLayer.enabled && sceneView.sceneViewState.showImageEffects)
+                {
+                    showMessage
+                    (
+                        "<i>Post Processing</i> is enabled on the scene view. " +
+                        "There is a Unity bug where gizmos and grid lines will render over opaque objects. " +
+                        "Please see <i>Known Issues</i> in the documentation for a link to vote on having this issue resolved.",
+                        "Disable <i>Post Processing</i> on the scene view.",
+                        ValidatedHelper.MessageType.Warning, ocean,
+                        _ =>
+                        {
+                            sceneView.sceneViewState.showImageEffects = false;
+                            // Required after changing sceneViewState according to:
+                            // https://docs.unity3d.com/ScriptReference/SceneView.SceneViewState.html
+                            SceneView.RepaintAll();
+                        }
+                    );
+                }
+#endif
+            }
+
             // SimSettingsAnimatedWaves
             if (_simSettingsAnimatedWaves)
             {

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -31,6 +31,7 @@ Changed
    -  Rename *Set Water Height To Geometry* to *Set Water Height Using Geometry*.
    -  Improved spline gizmo line drawing to highlight selected spline point.
    -  Add version and render pipeline to help button documentation links.
+   -  Validate scene view effects toggle options.
 
    .. only:: hdrp or urp
 


### PR DESCRIPTION
Will help with #801

Validates both _Animated Materials_ and _Post-Processing_ options under the scene view effects menu. The former option is an information help box and the latter is a warning help box. Furthermore, the latter is only validated in built-in and if the main camera has an active layer (ie only validate when the bug occurs). See code for help box copy.