### PR TITLE
Don't let queries use last LOD

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -121,7 +121,10 @@ void PosToSliceIndices
 	const float2 offsetFromCenter = abs(worldXZ - _OceanCenterPosWorld.xz);
 	const float taxicab = max(offsetFromCenter.x, offsetFromCenter.y);
 	const float radius0 = oceanScale0;
-	const float sliceNumber = clamp(log2(max(taxicab / radius0, 1.0)), minSlice, _SliceCount - 1.0);
+	float sliceNumber = log2( max( taxicab / radius0, 1.0 ) );
+	// Don't use last slice - this is a 'transition' slice used to cross fade waves between
+	// LOD resolutions to avoid pops.
+	sliceNumber = clamp( sliceNumber, minSlice, _SliceCount - 2.0 );
 
 	lodAlpha = frac(sliceNumber);
 	slice0 = floor(sliceNumber);

--- a/crest/Assets/Crest/Crest/Shaders/Resources/QueryDisplacements.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/QueryDisplacements.compute
@@ -41,7 +41,9 @@ void CSMain(uint3 id : SV_DispatchThreadID)
 	const float minGridSize = data.z;
 
 	const float gridSizeSlice0 = _CrestCascadeData[0]._texelWidth;
-	const float minSlice = clamp(floor(log2(max(minGridSize / gridSizeSlice0, 1.0))), 0.0, _SliceCount - 1.0);
+	// Displacements should not utilize the last slice which is used for transitioning waves between
+	// sampling resolutions
+	const float minSlice = clamp(floor(log2(max(minGridSize / gridSizeSlice0, 1.0))), 0.0, _SliceCount - 2.0);
 	const float baseScale = _CrestCascadeData[0]._scale;
 
 	// Perform iteration to invert the displacement vector field - find position that displaces to query position,

--- a/crest/Assets/Crest/Crest/Shaders/Resources/QueryFlow.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/QueryFlow.compute
@@ -44,7 +44,8 @@ void CSMain(uint3 id : SV_DispatchThreadID)
 	const float minGridSize = data.z;
 
 	const float gridSizeSlice0 = _CrestCascadeData[0]._texelWidth;
-	const float minSlice = clamp(floor(log2(max(minGridSize / gridSizeSlice0, 1.0))), 0.0, _SliceCount - 1.0);
+	// While it would probably be ok to use the last slice, we avoid using it to be consistent with displacements.
+	const float minSlice = clamp(floor(log2(max(minGridSize / gridSizeSlice0, 1.0))), 0.0, _SliceCount - 2.0);
 	const float baseScale = _CrestCascadeData[0]._scale;
 
 	_ResultFlows[id.x] = ComputeFlow(queryPosXZ, minSlice, baseScale);


### PR DESCRIPTION
Potential fix for bugs where a large boat may stop moving when camera is close.

Last LOD is used for transitioning waves across resolutions to avoid pops and is not suitable for use in queries.

I have moderate confidence this won't create other knockons but let me know if you can think of potential issues.