### PR TITLE
Use surface gradients and add overall normal scale

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -10,7 +10,7 @@ Shader "Crest/Ocean"
 		// Strength of the final surface normal (includes both wave normal and normal map)
 		_NormalsStrengthOverall( "Overall Normal Strength", Range( 0.0, 1.0 ) ) = 1.0
 		// Whether to add normal detail from a texture. Can be used to add visual detail to the water surface
-		[Toggle] _ApplyNormalMapping("Enable", Float) = 1
+		[Toggle] _ApplyNormalMapping("Use Normal Map", Float) = 1
 		// Normal map texture (should be set to Normals type in the properties)
 		[NoScaleOffset] _Normals("Normal Map", 2D) = "bump" {}
 		// Scale of normal map texture

--- a/crest/Assets/Crest/Crest/Shaders/OceanNormalMapping.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanNormalMapping.hlsl
@@ -57,7 +57,6 @@ void ApplyNormalMapsWithFlow(float2 worldXZUndisplaced, float2 flow, float lodAl
 	half2 io_n_2 = SampleNormalMaps(worldXZUndisplaced - (flow * sample2_offset), lodAlpha, cascadeData, instanceData);
 	io_n.xz += sample1_weight * io_n_1;
 	io_n.xz += sample2_weight * io_n_2;
-	io_n = normalize(io_n);
 }
 
 #endif // _APPLYNORMALMAPPING_ON

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
@@ -54,6 +54,7 @@ half4 _DepthFogDensity;
 // Normals
 // ----------------------------------------------------------------------------
 
+half _NormalsStrengthOverall;
 #if _APPLYNORMALMAPPING_ON
 half _NormalsStrength;
 half _NormalsScale;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -22,7 +22,7 @@ Changed
 ^^^^^^^
 .. bullet_list::
 
-   - Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
+   -  Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
 
 
 4.10

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -18,7 +18,11 @@ Release Notes
 |version|
 ---------
 
-TODO
+Changed
+^^^^^^^
+.. bullet_list::
+
+   - Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
 
 
 4.10

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -44,10 +44,10 @@ Normals
 .. line_block::
 
    |  **Overall Normal Strength** Strength of the final surface normal (includes both wave normal and normal map)
-   
+
    .. only:: birp or urp
 
-      |  **Enable** Whether to add normal detail from a texture. Can be used to add visual detail to the water surface `[BIRP] [URP]`
+      |  **Use Normal Map** Whether to add normal detail from a texture. Can be used to add visual detail to the water surface `[BIRP] [URP]`
 
    |  **Normal Map** Normal map and caustics distortion texture (should be set to Normals type in the properties)
    |  **Normal Map Scale** Scale of normal map texture

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -38,18 +38,20 @@ When tweaking ocean shape it can be useful to freeze time (from script, set *Tim
 Material Parameters
 -------------------
 
-Normal Mapping
-^^^^^^^^^^^^^^
+Normals
+^^^^^^^
 
 .. line_block::
 
+   |  **Overall Normal Strength** Strength of the final surface normal (includes both wave normal and normal map)
+   
    .. only:: birp or urp
 
       |  **Enable** Whether to add normal detail from a texture. Can be used to add visual detail to the water surface `[BIRP] [URP]`
 
-   |  **Normals** Normal map and caustics distortion texture (should be set to Normals type in the properties)
-   |  **Normals Scale** Scale of normal map texture
-   |  **Normals Strength** Strength of normal map influence
+   |  **Normal Map** Normal map and caustics distortion texture (should be set to Normals type in the properties)
+   |  **Normal Map Scale** Scale of normal map texture
+   |  **Normal Map Strength** Strength of normal map influence
 
 
 Scattering

--- a/docs/user/includes/_hdrp-reflections.rst
+++ b/docs/user/includes/_hdrp-reflections.rst
@@ -11,9 +11,7 @@ See Unity's documentation on :link:`Planar Reflection Probes <{HDRPDocLink}/Plan
 -  Check the documentation linked above for details on individual parameters
 
 `HDRP`'s planar reflection probe is very sensitive to surface normals and often 'leaks' reflections, for example showing the reflection of a boat on the water above the boat.
-If you see these issues we recommend reducing the Normal Strength on the material.
-Unfortunately this currently only affects the normal map normals, not the normals from the wave.
-In a future update we will expose control over the final water normal (including both normal maps and wave normals).
+If you see these issues we recommend reducing the *Overall Normal Strength* parameter on the ocean material.
 
 The planar reflection probe assumes the reflecting surface is a flat plane.
 This is not the case for for a wavey water surface and this can also produce 'leaky' reflections.


### PR DESCRIPTION
A couple of previous support issues would have been helped by having an overall normal strength control for the water surface which this PR adds.

Also wrapped up in these changes - there were unnecessary normalize() calls and other cleanup to do for the pixel normal calculation. This change moves to surface gradient style setup - derivatives are added/scaled, then normalize happens once at the end of the calculation.