### PR TITLE
Server support

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -88,7 +88,7 @@ namespace Crest
 #endif
         static void InitStatics()
         {
-            if (OceanRenderer.Headless)
+            if (OceanRenderer.RunningWithoutGPU)
             {
                 // No texture arrays when no graphics card..
                 return;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -88,6 +88,12 @@ namespace Crest
 #endif
         static void InitStatics()
         {
+            if (OceanRenderer.Headless)
+            {
+                // No texture arrays when no graphics card..
+                return;
+            }
+
             // Init here from 2019.3 onwards
             sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -276,6 +276,13 @@ namespace Crest
                 return;
             }
 
+            if (Application.isBatchMode)
+            {
+                // Don't bake in headless mode
+                Debug.LogWarning("Depth cache will not be populated at runtime when in batched/headless mode. Please pre-bake the cache in the Editor.")
+                return;
+            }
+
             // Make sure we have required objects.
             if (!InitObjects(updateComponents))
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -276,10 +276,10 @@ namespace Crest
                 return;
             }
 
-            if (Application.isBatchMode)
+            if (OceanRenderer.Headless)
             {
                 // Don't bake in headless mode
-                Debug.LogWarning("Depth cache will not be populated at runtime when in batched/headless mode. Please pre-bake the cache in the Editor.")
+                Debug.LogWarning("Crest: Depth cache will not be populated at runtime when in batched/headless mode. Please pre-bake the cache in the Editor.");
                 return;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -276,7 +276,7 @@ namespace Crest
                 return;
             }
 
-            if (OceanRenderer.Headless)
+            if (OceanRenderer.RunningWithoutGPU)
             {
                 // Don't bake in headless mode
                 Debug.LogWarning("Crest: Depth cache will not be populated at runtime when in batched/headless mode. Please pre-bake the cache in the Editor.");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -56,7 +56,7 @@ namespace Crest
                     }
                     else
                     {
-                        Debug.LogError("Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
+                        Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
                     }
                     break;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -50,7 +50,7 @@ namespace Crest
                     result = FindObjectOfType<ShapeGerstnerBatched>();
                     break;
                 case CollisionSources.ComputeShaderQueries:
-                    if (!Application.isBatchMode)
+                    if (!OceanRenderer.Headless)
                     {
                         result = new QueryDisplacements();
                     }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -50,7 +50,14 @@ namespace Crest
                     result = FindObjectOfType<ShapeGerstnerBatched>();
                     break;
                 case CollisionSources.ComputeShaderQueries:
-                    result = new QueryDisplacements();
+                    if (!Application.isBatchMode)
+                    {
+                        result = new QueryDisplacements();
+                    }
+                    else
+                    {
+                        Debug.LogError("Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
+                    }
                     break;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -50,7 +50,7 @@ namespace Crest
                     result = FindObjectOfType<ShapeGerstnerBatched>();
                     break;
                 case CollisionSources.ComputeShaderQueries:
-                    if (!OceanRenderer.Headless)
+                    if (!OceanRenderer.RunningWithoutGPU)
                     {
                         result = new QueryDisplacements();
                     }

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -147,16 +147,6 @@ namespace Crest
             sw.Start();
 #endif
 
-            // create mesh data
-            Mesh[] meshInsts = new Mesh[(int)PatchType.Count];
-            Bounds[] meshBounds = new Bounds[(int)PatchType.Count];
-            // 4 tiles across a LOD, and support lowering density by a factor
-            var tileResolution = Mathf.Round(0.25f * lodDataResolution / geoDownSampleFactor);
-            for (int i = 0; i < (int)PatchType.Count; i++)
-            {
-                meshInsts[i] = BuildOceanPatch((PatchType)i, tileResolution, out meshBounds[i]);
-            }
-
             ClearOutTiles(ocean, tiles);
 
             var root = new GameObject("Root");
@@ -168,9 +158,22 @@ namespace Crest
             root.transform.localRotation = Quaternion.identity;
             root.transform.localScale = Vector3.one;
 
-            for (int i = 0; i < lodCount; i++)
+            if (!OceanRenderer.RunningHeadless && !OceanRenderer.RunningWithoutGPU)
             {
-                CreateLOD(ocean, tiles, root.transform, i, lodCount, meshInsts, meshBounds, lodDataResolution, geoDownSampleFactor, oceanLayer);
+                // create mesh data
+                Mesh[] meshInsts = new Mesh[(int)PatchType.Count];
+                Bounds[] meshBounds = new Bounds[(int)PatchType.Count];
+                // 4 tiles across a LOD, and support lowering density by a factor
+                var tileResolution = Mathf.Round(0.25f * lodDataResolution / geoDownSampleFactor);
+                for (int i = 0; i < (int)PatchType.Count; i++)
+                {
+                    meshInsts[i] = BuildOceanPatch((PatchType)i, tileResolution, out meshBounds[i]);
+                }
+
+                for (int i = 0; i < lodCount; i++)
+                {
+                    CreateLOD(ocean, tiles, root.transform, i, lodCount, meshInsts, meshBounds, lodDataResolution, geoDownSampleFactor, oceanLayer);
+                }
             }
 
 #if PROFILE_CONSTRUCTION

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -243,6 +243,10 @@ namespace Crest
         bool _followSceneCamera = true;
 #pragma warning restore 414
 
+        [Header("Server Settings")]
+        [SerializeField]
+        bool _forceNoGPU = false;
+
         [Header("Debug Params")]
 
         [Tooltip("Attach debug gui that adds some controls and allows to visualise the ocean data."), SerializeField]
@@ -303,7 +307,7 @@ namespace Crest
         /// <summary>
         /// Is runtime environment without graphics card
         /// </summary>
-        public static bool Headless => SystemInfo.graphicsDeviceID == 0;
+        public static bool RunningWithoutGPU => SystemInfo.graphicsDeviceID == 0 || (Instance != null ? Instance._forceNoGPU : false);
 
         // We are computing these values to be optimal based on the base mesh vertex density.
         float _lodAlphaBlackPointFade;
@@ -500,7 +504,7 @@ namespace Crest
 
         void CreateDestroySubSystems()
         {
-            if (!Headless)
+            if (!RunningWithoutGPU)
             {
                 {
                     if (_lodDataAnimWaves == null)
@@ -649,7 +653,7 @@ namespace Crest
 
         bool VerifyRequirements()
         {
-            if (!Headless)
+            if (!RunningWithoutGPU)
             {
                 if (Application.platform == RuntimePlatform.WebGLPlayer)
                 {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -245,6 +245,8 @@ namespace Crest
 
         [Header("Server Settings")]
         [SerializeField]
+        bool _forceBatchMode = false;
+        [SerializeField]
         bool _forceNoGPU = false;
 
         [Header("Debug Params")]
@@ -308,6 +310,11 @@ namespace Crest
         /// Is runtime environment without graphics card
         /// </summary>
         public static bool RunningWithoutGPU => SystemInfo.graphicsDeviceID == 0 || (Instance != null ? Instance._forceNoGPU : false);
+
+        /// <summary>
+        /// Is runtime environment without graphics card
+        /// </summary>
+        public static bool RunningHeadless => Application.isBatchMode || (Instance != null ? Instance._forceBatchMode : false);
 
         // We are computing these values to be optimal based on the base mesh vertex density.
         float _lodAlphaBlackPointFade;
@@ -514,7 +521,7 @@ namespace Crest
                     }
                 }
 
-                if (CreateClipSurfaceData)
+                if (CreateClipSurfaceData && !RunningHeadless)
                 {
                     if (_lodDataClipSurface == null)
                     {
@@ -584,7 +591,7 @@ namespace Crest
                     FlowProvider = _lodDataAnimWaves.Settings.CreateFlowProvider(this);
                 }
 
-                if (CreateFoamSim)
+                if (CreateFoamSim && !RunningHeadless)
                 {
                     if (_lodDataFoam == null)
                     {
@@ -620,7 +627,7 @@ namespace Crest
                     }
                 }
 
-                if (CreateShadowData)
+                if (CreateShadowData && !RunningHeadless)
                 {
                     if (_lodDataShadow == null)
                     {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -309,7 +309,15 @@ namespace Crest
         /// <summary>
         /// Is runtime environment without graphics card
         /// </summary>
-        public static bool RunningWithoutGPU => SystemInfo.graphicsDeviceID == 0 || (Instance != null ? Instance._forceNoGPU : false);
+        public static bool RunningWithoutGPU
+        {
+            get
+            {
+                var noGPU = SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Null;
+                var emulateNoGPU = (Instance != null ? Instance._forceNoGPU : false);
+                return noGPU || emulateNoGPU;
+            }
+        }
 
         /// <summary>
         /// Is runtime environment without graphics card

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -244,9 +244,9 @@ namespace Crest
 #pragma warning restore 414
 
         [Header("Server Settings")]
-        [SerializeField]
+        [Tooltip("Emulate batch mode which models running without a display (but with a GPU available). Equivalent to running standalone build with -batchmode argument. Press Rebuild button below to apply."), SerializeField]
         bool _forceBatchMode = false;
-        [SerializeField]
+        [Tooltip("Emulate running on a client without a GPU. Equivalent to running standalone with -nographics argument. Press Rebuild button below to apply."), SerializeField]
         bool _forceNoGPU = false;
 
         [Header("Debug Params")]

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -650,17 +650,17 @@ namespace Crest
                 return false;
             }
 #endif
-            if (SystemInfo.graphicsShaderLevel < 45)
+            if (SystemInfo.graphicsShaderLevel < 45 && !Application.isBatchMode)
             {
                 Debug.LogError("Crest requires graphics devices that support shader level 4.5 or above.", this);
                 return false;
             }
-            if (!SystemInfo.supportsComputeShaders)
+            if (!SystemInfo.supportsComputeShaders && !Application.isBatchMode)
             {
                 Debug.LogError("Crest requires graphics devices that support compute shaders.", this);
                 return false;
             }
-            if (!SystemInfo.supports2DArrayTextures)
+            if (!SystemInfo.supports2DArrayTextures && !Application.isBatchMode)
             {
                 Debug.LogError("Crest requires graphics devices that support 2D array textures.", this);
                 return false;
@@ -1030,9 +1030,9 @@ namespace Crest
 
             _oceanChunkRenderers.Clear();
 
-            _bufPerCascadeInstanceData.Dispose();
-            _bufCascadeDataTgt.Dispose();
-            _bufCascadeDataSrc.Dispose();
+            _bufPerCascadeInstanceData?.Dispose();
+            _bufCascadeDataTgt?.Dispose();
+            _bufCascadeDataSrc?.Dispose();
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -300,6 +300,11 @@ namespace Crest
 
         public static OceanRenderer Instance { get; private set; }
 
+        /// <summary>
+        /// Is runtime environment without graphics card
+        /// </summary>
+        public static bool Headless => SystemInfo.graphicsDeviceID == 0;
+
         // We are computing these values to be optimal based on the base mesh vertex density.
         float _lodAlphaBlackPointFade;
         float _lodAlphaBlackPointWhitePointFade;
@@ -495,175 +500,186 @@ namespace Crest
 
         void CreateDestroySubSystems()
         {
+            if (!Headless)
             {
-                if (_lodDataAnimWaves == null)
                 {
-                    _lodDataAnimWaves = new LodDataMgrAnimWaves(this);
-                    _lodDatas.Add(_lodDataAnimWaves);
-                }
-            }
-
-            if (CreateClipSurfaceData)
-            {
-                if (_lodDataClipSurface == null)
-                {
-                    _lodDataClipSurface = new LodDataMgrClipSurface(this);
-                    _lodDatas.Add(_lodDataClipSurface);
-                }
-            }
-            else
-            {
-                if (_lodDataClipSurface != null)
-                {
-                    _lodDataClipSurface.OnDisable();
-                    _lodDatas.Remove(_lodDataClipSurface);
-                    _lodDataClipSurface = null;
-                }
-            }
-
-            if (CreateDynamicWaveSim)
-            {
-                if (_lodDataDynWaves == null)
-                {
-                    _lodDataDynWaves = new LodDataMgrDynWaves(this);
-                    _lodDatas.Add(_lodDataDynWaves);
-                }
-            }
-            else
-            {
-                if (_lodDataDynWaves != null)
-                {
-                    _lodDataDynWaves.OnDisable();
-                    _lodDatas.Remove(_lodDataDynWaves);
-                    _lodDataDynWaves = null;
-                }
-            }
-
-            if (CreateFlowSim)
-            {
-                if (_lodDataFlow == null)
-                {
-                    _lodDataFlow = new LodDataMgrFlow(this);
-                    _lodDatas.Add(_lodDataFlow);
+                    if (_lodDataAnimWaves == null)
+                    {
+                        _lodDataAnimWaves = new LodDataMgrAnimWaves(this);
+                        _lodDatas.Add(_lodDataAnimWaves);
+                    }
                 }
 
-                if (FlowProvider != null && !(FlowProvider is QueryFlow))
+                if (CreateClipSurfaceData)
                 {
-                    FlowProvider.CleanUp();
-                    FlowProvider = null;
+                    if (_lodDataClipSurface == null)
+                    {
+                        _lodDataClipSurface = new LodDataMgrClipSurface(this);
+                        _lodDatas.Add(_lodDataClipSurface);
+                    }
                 }
-            }
-            else
-            {
-                if (_lodDataFlow != null)
+                else
                 {
-                    _lodDataFlow.OnDisable();
-                    _lodDatas.Remove(_lodDataFlow);
-                    _lodDataFlow = null;
+                    if (_lodDataClipSurface != null)
+                    {
+                        _lodDataClipSurface.OnDisable();
+                        _lodDatas.Remove(_lodDataClipSurface);
+                        _lodDataClipSurface = null;
+                    }
                 }
 
-                if (FlowProvider != null && FlowProvider is QueryFlow)
+                if (CreateDynamicWaveSim)
                 {
-                    FlowProvider.CleanUp();
-                    FlowProvider = null;
+                    if (_lodDataDynWaves == null)
+                    {
+                        _lodDataDynWaves = new LodDataMgrDynWaves(this);
+                        _lodDatas.Add(_lodDataDynWaves);
+                    }
                 }
-            }
-            if (FlowProvider == null)
-            {
-                FlowProvider = _lodDataAnimWaves.Settings.CreateFlowProvider(this);
-            }
+                else
+                {
+                    if (_lodDataDynWaves != null)
+                    {
+                        _lodDataDynWaves.OnDisable();
+                        _lodDatas.Remove(_lodDataDynWaves);
+                        _lodDataDynWaves = null;
+                    }
+                }
 
-            if (CreateFoamSim)
-            {
-                if (_lodDataFoam == null)
+                if (CreateFlowSim)
                 {
-                    _lodDataFoam = new LodDataMgrFoam(this);
-                    _lodDatas.Add(_lodDataFoam);
-                }
-            }
-            else
-            {
-                if (_lodDataFoam != null)
-                {
-                    _lodDataFoam.OnDisable();
-                    _lodDatas.Remove(_lodDataFoam);
-                    _lodDataFoam = null;
-                }
-            }
+                    if (_lodDataFlow == null)
+                    {
+                        _lodDataFlow = new LodDataMgrFlow(this);
+                        _lodDatas.Add(_lodDataFlow);
+                    }
 
-            if (CreateSeaFloorDepthData)
-            {
-                if (_lodDataSeaDepths == null)
-                {
-                    _lodDataSeaDepths = new LodDataMgrSeaFloorDepth(this);
-                    _lodDatas.Add(_lodDataSeaDepths);
+                    if (FlowProvider != null && !(FlowProvider is QueryFlow))
+                    {
+                        FlowProvider.CleanUp();
+                        FlowProvider = null;
+                    }
                 }
-            }
-            else
-            {
-                if (_lodDataSeaDepths != null)
+                else
                 {
-                    _lodDataSeaDepths.OnDisable();
-                    _lodDatas.Remove(_lodDataSeaDepths);
-                    _lodDataSeaDepths = null;
-                }
-            }
+                    if (_lodDataFlow != null)
+                    {
+                        _lodDataFlow.OnDisable();
+                        _lodDatas.Remove(_lodDataFlow);
+                        _lodDataFlow = null;
+                    }
 
-            if (CreateShadowData)
-            {
-                if (_lodDataShadow == null)
-                {
-                    _lodDataShadow = new LodDataMgrShadow(this);
-                    _lodDatas.Add(_lodDataShadow);
+                    if (FlowProvider != null && FlowProvider is QueryFlow)
+                    {
+                        FlowProvider.CleanUp();
+                        FlowProvider = null;
+                    }
                 }
-            }
-            else
-            {
-                if (_lodDataShadow != null)
+                if (FlowProvider == null)
                 {
-                    _lodDataShadow.OnDisable();
-                    _lodDatas.Remove(_lodDataShadow);
-                    _lodDataShadow = null;
+                    FlowProvider = _lodDataAnimWaves.Settings.CreateFlowProvider(this);
+                }
+
+                if (CreateFoamSim)
+                {
+                    if (_lodDataFoam == null)
+                    {
+                        _lodDataFoam = new LodDataMgrFoam(this);
+                        _lodDatas.Add(_lodDataFoam);
+                    }
+                }
+                else
+                {
+                    if (_lodDataFoam != null)
+                    {
+                        _lodDataFoam.OnDisable();
+                        _lodDatas.Remove(_lodDataFoam);
+                        _lodDataFoam = null;
+                    }
+                }
+
+                if (CreateSeaFloorDepthData)
+                {
+                    if (_lodDataSeaDepths == null)
+                    {
+                        _lodDataSeaDepths = new LodDataMgrSeaFloorDepth(this);
+                        _lodDatas.Add(_lodDataSeaDepths);
+                    }
+                }
+                else
+                {
+                    if (_lodDataSeaDepths != null)
+                    {
+                        _lodDataSeaDepths.OnDisable();
+                        _lodDatas.Remove(_lodDataSeaDepths);
+                        _lodDataSeaDepths = null;
+                    }
+                }
+
+                if (CreateShadowData)
+                {
+                    if (_lodDataShadow == null)
+                    {
+                        _lodDataShadow = new LodDataMgrShadow(this);
+                        _lodDatas.Add(_lodDataShadow);
+                    }
+                }
+                else
+                {
+                    if (_lodDataShadow != null)
+                    {
+                        _lodDataShadow.OnDisable();
+                        _lodDatas.Remove(_lodDataShadow);
+                        _lodDataShadow = null;
+                    }
                 }
             }
 
             // Potential extension - add 'type' field to collprovider and change provider if settings have changed - this would support runtime changes.
             if (CollisionProvider == null)
             {
-                CollisionProvider = _lodDataAnimWaves.Settings.CreateCollisionProvider();
+                var settings = _lodDataAnimWaves != null ? _lodDataAnimWaves.Settings : _simSettingsAnimatedWaves;
+
+                if (settings != null)
+                {
+                    CollisionProvider = settings.CreateCollisionProvider();
+                }
             }
         }
 
         bool VerifyRequirements()
         {
-            if (Application.platform == RuntimePlatform.WebGLPlayer)
+            if (!Headless)
             {
-                Debug.LogError("Crest does not support WebGL backends.", this);
-                return false;
-            }
+                if (Application.platform == RuntimePlatform.WebGLPlayer)
+                {
+                    Debug.LogError("Crest does not support WebGL backends.", this);
+                    return false;
+                }
 #if UNITY_EDITOR
-            if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
-                SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3 ||
-                SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore)
-            {
-                Debug.LogError("Crest does not support OpenGL backends.", this);
-                return false;
-            }
+                if (SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES2 ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLES3 ||
+                    SystemInfo.graphicsDeviceType == GraphicsDeviceType.OpenGLCore)
+                {
+                    Debug.LogError("Crest does not support OpenGL backends.", this);
+                    return false;
+                }
 #endif
-            if (SystemInfo.graphicsShaderLevel < 45 && !Application.isBatchMode)
-            {
-                Debug.LogError("Crest requires graphics devices that support shader level 4.5 or above.", this);
-                return false;
-            }
-            if (!SystemInfo.supportsComputeShaders && !Application.isBatchMode)
-            {
-                Debug.LogError("Crest requires graphics devices that support compute shaders.", this);
-                return false;
-            }
-            if (!SystemInfo.supports2DArrayTextures && !Application.isBatchMode)
-            {
-                Debug.LogError("Crest requires graphics devices that support 2D array textures.", this);
-                return false;
+                if (SystemInfo.graphicsShaderLevel < 45)
+                {
+                    Debug.LogError("Crest requires graphics devices that support shader level 4.5 or above.", this);
+                    return false;
+                }
+                if (!SystemInfo.supportsComputeShaders)
+                {
+                    Debug.LogError("Crest requires graphics devices that support compute shaders.", this);
+                    return false;
+                }
+                if (!SystemInfo.supports2DArrayTextures)
+                {
+                    Debug.LogError("Crest requires graphics devices that support 2D array textures.", this);
+                    return false;
+                }
             }
 
             return true;
@@ -713,8 +729,8 @@ namespace Crest
             if (EditorApplication.isPlaying)
 #endif
             {
-                CollisionProvider.UpdateQueries();
-                FlowProvider.UpdateQueries();
+                CollisionProvider?.UpdateQueries();
+                FlowProvider?.UpdateQueries();
             }
 
             // set global shader params

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -18,7 +18,12 @@ Release Notes
 |version|
 ---------
 
-TODO
+Changed
+^^^^^^^
+.. bullet_list::
+
+   -  Headless support - add support for running without display, with new toggle on OceanRenderer to emulate it in Editor.
+   -  No GPU support - add support for running without GPU, with new toggle on OceanRenderer to emulate it in Editor.
 
 
 4.10


### PR DESCRIPTION
## Intro

To support servers, we need to run fine when `-nographics` is given as a commandline option, and when `-batchmode` is given as a commandline option. We also need to avoid unnecessary work in both.

To run a server instance, run the following from the command line

`CrestBuild.exe -batchmode -nographics -logfile log.log`

I have added two toggles that emulate batch mode and emulate running without a GPU on the OceanRenderer component.

## batchmode

* Does not construct a surface mesh
* Only creates sims required for queries, like wave sim

## nographics

In addition to `batchmode`:

* Does not create any loddata
* Errors if other GPU-dependant features are used, like runtime baking of depth caches
