### PR TITLE
Fix build errors for platforms without XR/VR support

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Crest.Examples.asmdef
+++ b/crest/Assets/Crest/Crest-Examples/Crest.Examples.asmdef
@@ -3,12 +3,24 @@
     "references": [
         "Crest"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.vr",
+            "expression": "1.0.0",
+            "define": "ENABLE_VR_MODULE"
+        },
+        {
+            "name": "com.unity.modules.xr",
+            "expression": "1.0.0",
+            "define": "ENABLE_XR_MODULE"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/CamController.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/CamController.cs
@@ -39,6 +39,7 @@ public class CamController : MonoBehaviour
     {
         _targetTransform = transform;
 
+#if ENABLE_VR && ENABLE_VR_MODULE
         // We cannot change the Camera's transform when XR is enabled. This is not an issue with the new XR plugin.
         if (XRSettings.enabled)
         {
@@ -63,6 +64,7 @@ public class CamController : MonoBehaviour
             XRSettings.useOcclusionMesh = !_debug.disableOcclusionMesh;
             XRSettings.occlusionMaskScale = _debug.occlusionMeshScale;
         }
+#endif
     }
 
     void Update()
@@ -73,6 +75,7 @@ public class CamController : MonoBehaviour
 
         UpdateMovement(dt);
 
+#if ENABLE_VR && ENABLE_VR_MODULE
         // These aren't useful and can break for XR hardware.
         if (!XRSettings.enabled || XRSettings.loadedDeviceName == "MockHMD")
         {
@@ -90,6 +93,7 @@ public class CamController : MonoBehaviour
 
             XRSettings.occlusionMaskScale = _debug.occlusionMeshScale;
         }
+#endif
     }
 
     void UpdateMovement(float dt)

--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -15,6 +15,16 @@
             "name": "com.unity.postprocessing",
             "expression": "",
             "define": "UNITY_POSTPROCESSING_ENABLED"
+        },
+        {
+            "name": "com.unity.modules.vr",
+            "expression": "1.0.0",
+            "define": "ENABLE_VR_MODULE"
+        },
+        {
+            "name": "com.unity.modules.xr",
+            "expression": "1.0.0",
+            "define": "ENABLE_XR_MODULE"
         }
     ],
     "noEngineReferences": false

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -262,6 +262,7 @@ namespace Crest
                         1);
                 }
 
+#if ENABLE_VR && ENABLE_VR_MODULE
                 // Disable single pass double-wide stereo rendering for these commands since we are rendering to
                 // rendering texture. Otherwise, it will render double. Single pass instanced is broken here, but that
                 // appears to be a Unity bug only for the legacy VR system.
@@ -270,6 +271,7 @@ namespace Crest
                     BufCopyShadowMap.SetSinglePassStereo(SinglePassStereoMode.None);
                     BufCopyShadowMap.DisableShaderKeyword("UNITY_SINGLE_PASS_STEREO");
                 }
+#endif
 
                 // Process registered inputs.
                 for (var lodIdx = lt.LodCount - 1; lodIdx >= 0; lodIdx--)
@@ -278,12 +280,14 @@ namespace Crest
                     SubmitDraws(lodIdx, BufCopyShadowMap);
                 }
 
+#if ENABLE_VR && ENABLE_VR_MODULE
                 // Restore single pass double-wide as we cannot rely on remaining pipeline to do it for us.
                 if (camera.stereoEnabled && XRSettings.stereoRenderingMode == XRSettings.StereoRenderingMode.SinglePass)
                 {
                     BufCopyShadowMap.SetSinglePassStereo(SinglePassStereoMode.SideBySide);
                     BufCopyShadowMap.EnableShaderKeyword("UNITY_SINGLE_PASS_STEREO");
                 }
+#endif
             }
 
             // Set the target texture as to make sure we catch the 'pong' each frame

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -24,6 +24,12 @@ Changed
 
    -  Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
 
+Fixed
+^^^^^
+.. bullet_list::
+
+   -  Fix build errors for platforms that do not support XR/VR.
+
 
 4.10
 ----


### PR DESCRIPTION
Xbox throws build errors here in more recent Unity versions according to reports. Easiest way to develop guards against this is to just disable the VR and/or XR modules.