### PR TITLE
Docs: Add sponsorship and roadmap

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,7 +1,7 @@
 # Sphinx
 _build
 # _static
-_templates
+# _templates
 
 # Docs build venv
 build-venv

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -67,7 +67,7 @@ article[role="main"] > .admonition:first-child
 .sidebar-logo
 {
     /* Make the square part of the logo centered for symmetry. */
-    padding-right: 1rem;
+    padding-right: 0.5rem;
 }
 
 .sidebar-brand-text
@@ -323,4 +323,26 @@ article[role="main"] > .admonition:first-child
 {
     -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 19.88V22l-1.8-1.17-4.79-9a4.94 4.94 0 0 0 1.78-1M15 7a3 3 0 0 1-3 3 3.27 3.27 0 0 1-.44 0L5.8 20.83 4 22v-2.12L9.79 9A3 3 0 0 1 12 4V2a1 1 0 0 1 1 1v1.18A3 3 0 0 1 15 7m-2 0a1 1 0 1 0-1 1 1 1 0 0 0 1-1m-8.78 3L6 11.8l-1.44 2.76L2.1 12.1m9.9 5.66l-1.5-1.51L9 19l3 3 3-3-1.47-2.77M19.78 10L18 11.8l1.5 2.76 2.4-2.46z"/></svg>');
     mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20 19.88V22l-1.8-1.17-4.79-9a4.94 4.94 0 0 0 1.78-1M15 7a3 3 0 0 1-3 3 3.27 3.27 0 0 1-.44 0L5.8 20.83 4 22v-2.12L9.79 9A3 3 0 0 1 12 4V2a1 1 0 0 1 1 1v1.18A3 3 0 0 1 15 7m-2 0a1 1 0 1 0-1 1 1 1 0 0 0 1-1m-8.78 3L6 11.8l-1.44 2.76L2.1 12.1m9.9 5.66l-1.5-1.51L9 19l3 3 3-3-1.47-2.77M19.78 10L18 11.8l1.5 2.76 2.4-2.46z"/></svg>');
+}
+
+.admonition.admonition-sponsor
+{
+    border-left-color: #ea4aaa;
+}
+
+.admonition.admonition-sponsor > p.admonition-title
+{
+    background-color: rgba(234, 74, 170, 0.1);
+}
+
+.admonition.admonition-sponsor > p.admonition-title::before
+{
+    background-color: #ea4aaa;
+}
+
+.admonition.admonition-sponsor > p.admonition-title::before
+{
+    /* GitHub's heart. */
+    -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="octicon octicon-heart icon-sponsor text-pink mr-2" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"></path></svg>');
+    mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" class="octicon octicon-heart icon-sponsor text-pink mr-2" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"></path></svg>');
 }

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -117,6 +117,7 @@ if (typeof isPage404 !== 'undefined' && isPage404 && isVersion) {
 if (window.matchMedia) {
     function applyLightOrDarkMode(isDarkMode) {
         const iframes = $("iframe.asset-store")
+        if (iframes.length == 0) return
         // NOTE: Not robust. Will break if we remove the question mark.
         const dark = "/widget-wide?"
         const light = "/widget-wide-light?"

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,32 @@
+{#-
+
+Hi there!
+
+You might be interested in https://pradyunsg.me/furo/customisation/sidebar/
+
+Although if you're reading this, chances are that you're either familiar
+enough with Sphinx that you know what you're doing, or landed here from that
+documentation page.
+
+Hope your day's going well. :)
+
+-#}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+  {% block brand_content %}
+  {%- if logo %}
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
+  </div>
+  {%- endif %}
+  {%- if theme_light_logo and theme_dark_logo %}
+  <div class="sidebar-logo-container">
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+  </div>
+  {%- endif %}
+  {% if not theme_sidebar_hide_name %}
+  <span class="sidebar-brand-text">{{ docstitle }}</span>
+  {%- endif %}
+  {% endblock brand_content %}
+</a>
+<iframe src="{{ sponsor_link }}/button" title="Sponsor {{ organization }}" height="35" width="116" style="border: 0; margin: 0 auto; margin-bottom: 0.25rem; margin-top: -0.25rem;"></iframe>

--- a/docs/about/introduction.rst
+++ b/docs/about/introduction.rst
@@ -65,6 +65,17 @@ It is also highly flexible and allows any custom input to the water shape/foam/d
 
       <iframe class="asset-store" src="https://assetstore.unity.com/linkmaker/embed/package/141674/widget-wide-light?aid=1011lic2K" style="width:600px; height:130px; border:0px;"></iframe>
 
+
+Sponsorship
+-----------
+
+.. sponsor::
+
+   Sponsor Wave Harmonic on :link:`GitHub Sponsors <{SponsorLink}?o=esb>` to increase development time on Crest.
+
+   Throughout the documentation, you will see sponsor admonitions like this one for features where only expanded funding can help cover development costs.
+
+
 Social
 ------
 

--- a/docs/about/roadmap.rst
+++ b/docs/about/roadmap.rst
@@ -1,0 +1,12 @@
+Roadmap
+=======
+
+.. sponsor::
+
+   This will help us expand our roadmap and achieve goals sooner.
+   Certain sponsor tiers allows one to vote on roadmap items to guide our priorities.
+
+
+Visit :link:`our roadmap <{RoadmapLink}>` to see where Crest's development is heading:
+
+.. trello:: https://trello.com/b/L7iejCPI

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,11 +19,13 @@ sys.path.insert(0, os.path.abspath('./extensions'))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Crest"
-author = "Wave Harmonic & Contributors"
+organization = "Wave Harmonic"
+author = f"{organization} & Contributors"
 copyright = f"2021, {author}"
 version = "4.11"
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-release
 release = version
+sponsor_link = "https://github.com/sponsors/wave-harmonic"
 
 # -- General configuration ---------------------------------------------------
 
@@ -44,6 +46,8 @@ extensions = [
 
     # Local packages.
     "youtube",
+    "sponsor",
+    "trello",
     "variables",
     "tags",
     "links",
@@ -111,6 +115,11 @@ html_theme_options = {
     # "announcement": "<em>Important</em> announcement!",
 }
 
+html_context = {
+    "sponsor_link": sponsor_link,
+    "organization": organization,
+}
+
 html_show_sphinx = False
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -126,6 +135,7 @@ html_css_files = [
 
 html_js_files = [
     'https://cdnjs.cloudflare.com/ajax/libs/medium-zoom/1.0.6/medium-zoom.min.js',
+    'https://p.trellocdn.com/embed.min.js',
     'custom.js?v1.2.0',
 ]
 
@@ -174,6 +184,7 @@ default_role = "get"
 rst_prolog = f"""
 .. tags::
 .. set:: AssetVersion {version}
+.. set:: SponsorLink {sponsor_link}
 """
 rst_prolog = rst_prolog + """
 .. set:: RPMinVersion 7.6
@@ -186,6 +197,7 @@ rst_prolog = rst_prolog + """
 .. set:: DocLinkBase https://crest.readthedocs.io/en
 .. set:: GitHubLink \https://github.com/wave-harmonic/crest
 .. set:: WikiLink \{GitHubLink}/wiki
+.. set:: RoadmapLink \https://trello.com/b/L7iejCPI
 
 .. set:: [BIRP] :guilabel:`BIRP`
 .. set:: BIRPNameLong Built-in

--- a/docs/extensions/sponsor.py
+++ b/docs/extensions/sponsor.py
@@ -1,0 +1,42 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from sphinx import addnodes
+
+class Sponsor(SphinxDirective):
+
+    has_content = True
+
+    def run(self):
+        sponsor_link = self.env.config.sponsor_link
+        organization = self.env.config.organization
+
+        admonition_node = nodes.admonition(classes=["admonition-sponsor"])
+        admonition_node += nodes.title(text="Sponsor")
+
+        # Parse admonition body contents.
+        # Needs to use a container here instead of list otherwise exception.
+        node_list = nodes.container()
+        self.state.nested_parse(self.content, self.content_offset, node_list)
+        admonition_node += node_list.children
+
+        # Add sponsor button for HTML and fallback for PDF.
+        html = f"<iframe src=\"{sponsor_link}/button\" title=\"Sponsor {organization}\" height=\"35\" width=\"116\" style=\"border: 0; display: block;\"></iframe>"
+        html_node = nodes.raw(text=html, format="html")
+        only_pdf = addnodes.only(expr="latex")
+        only_pdf_paragraph = nodes.inline()
+        self.state.nested_parse(nodes.inline(text=f":link:`Sponsor Us <{sponsor_link}?o=esb>`"), 0, only_pdf_paragraph)
+        only_pdf += only_pdf_paragraph
+
+        admonition_node += html_node
+        admonition_node += only_pdf
+
+        return [admonition_node]
+
+def setup(app):
+    app.add_config_value("organization", "", "env")
+    app.add_config_value("sponsor_link", "", "env")
+    app.add_directive("sponsor", Sponsor)
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/extensions/trello.py
+++ b/docs/extensions/trello.py
@@ -1,0 +1,38 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from sphinx import addnodes
+
+import inspect
+
+class Trello(SphinxDirective):
+
+    required_arguments = 1
+    has_content = True
+
+    def run(self):
+        link = self.arguments[0]
+        embed_type = "Card" if "/c/" in link else "Board"
+
+        container = nodes.container()
+
+        html = f"""
+        <blockquote class="trello-{embed_type.lower()}-compact">
+            <a href="{link}">Trello {embed_type}</a>
+        </blockquote>"""
+
+        html_node = nodes.raw(text=html, format="html")
+        only_pdf = addnodes.only(expr="latex")
+        # We need to provide a node for nested parsing. And another node for populating the parsed node.
+        only_pdf_paragraph = nodes.inline()
+        self.state.nested_parse(nodes.inline(text=f"`Trello {embed_type} <{link}>`_"), 0, only_pdf_paragraph)
+        only_pdf += only_pdf_paragraph
+        container += html_node
+        container += only_pdf
+        return container.children
+
+def setup(app):
+    app.add_directive("trello", Trello)
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Crest Ocean System
 
    about/introduction
    about/known-issues
+   about/roadmap
    about/history
 
 .. toctree::

--- a/docs/user/collision-shape-for-physics.rst
+++ b/docs/user/collision-shape-for-physics.rst
@@ -22,6 +22,12 @@ Use of these is demonstrated in the example content.
 Compute Shape Queries
 ---------------------
 
+.. sponsor::
+
+   Sponsoring us will help increase our development bandwidth which could work towards using Burst/Jobs for this feature.
+
+   .. trello:: https://trello.com/c/qUvB1aSO
+
 This is the default and recommended choice.
 Query positions are uploaded to a compute shader which then samples the ocean data and returns the
 desired results.

--- a/docs/user/includes/_birp-lighting.rst
+++ b/docs/user/includes/_birp-lighting.rst
@@ -1,6 +1,11 @@
-.. admonition:: TODO
 
-   Work in progress.
+.. sponsor::
+
+   Sponsoring us will help increase our development bandwidth which could work towards improving this feature.
 
 `Crest` `BIRP` does not support additional lights due to bugs in the pipeline and performance concerns.
 Please see :pr:`382` and :pr:`383` for more details.
+
+.. admonition:: TODO
+
+   This section is a work in progress.

--- a/docs/user/includes/_birp-shadows.rst
+++ b/docs/user/includes/_birp-shadows.rst
@@ -2,6 +2,11 @@
 
    Shadows are not supported using Deferred Lighting. Please see :issue:`198` for a workaround.
 
+.. sponsor::
+
+   Sponsoring us will help increase our development bandwidth which could work towards improving this feature.
+
+
 To turn on this feature, enable the *Create Shadow Data* option on the *OceanRenderer* script, and ensure the *Shadowing* option is ticked on the ocean material.
 
 .. TODO: This could be expanded to check required shadow settings.

--- a/docs/user/includes/_urp-lighting.rst
+++ b/docs/user/includes/_urp-lighting.rst
@@ -1,5 +1,9 @@
-.. admonition:: TODO
+.. sponsor::
 
-   Work in progress.
+   Sponsoring us will help increase our development bandwidth which could work towards improving this feature.
 
 `Crest` `URP` currently does not support additional lights.
+
+.. admonition:: TODO
+
+   This section is a work in progress.

--- a/docs/user/other-features.rst
+++ b/docs/user/other-features.rst
@@ -49,6 +49,10 @@ Managing these lists at run-time is left to the user.
 
    Surface details like foam and normals can pop on teleports.
 
+.. sponsor::
+
+   Sponsoring us will help increase our development bandwidth which could work towards improving this feature.
+
 Buoyancy
 --------
 


### PR DESCRIPTION
Adds a sponsor admonition which can be used to highlight features which would need expanded sponsorship to be worked on. Also adds the roadmap with Trello embeds.  

Here are the links for affected sections:

- https://crest.readthedocs.io/en/docs-sponsorship-and-roadmap/about/introduction.html#sponsorship
- https://crest.readthedocs.io/en/docs-sponsorship-and-roadmap/about/roadmap.html
- https://crest.readthedocs.io/en/docs-sponsorship-and-roadmap/user/configuration.html#lighting
- https://crest.readthedocs.io/en/docs-sponsorship-and-roadmap/user/ocean-simulation.html#shadows
- https://crest.readthedocs.io/en/docs-sponsorship-and-roadmap/user/collision-shape-for-physics.html#compute-shape-queries
- sidebar has the sponsor button below the logo

Let me know what you think. Wording could be improved perhaps.