### PR TITLE
Only show enabled spectrums in debug GUI

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/CrestSortedList.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/CrestSortedList.cs
@@ -78,6 +78,12 @@ namespace Crest
             return removed;
         }
 
+        public void Clear()
+        {
+            _backingList.Clear();
+            _needsSorting = false;
+        }
+
         #region GetEnumerator
         public List<KeyValuePair<TKey, TValue>>.Enumerator GetEnumerator()
         {
@@ -104,5 +110,10 @@ namespace Crest
             }
             _needsSorting = false;
         }
+    }
+
+    internal class SiblingIndexComparer : IComparer<int>
+    {
+        public int Compare(int x, int y) => x.CompareTo(y);
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -29,8 +29,6 @@ namespace Crest
         readonly static float _leftPanelWidth = 180f;
         readonly static float _bottomPanelHeight = 25f;
         readonly static Color _guiColor = Color.black * 0.7f;
-        ShapeGerstnerBatched[] _gerstnerBatches;
-        ShapeGerstner[] _gerstners;
 
         static readonly Dictionary<System.Type, string> s_simNames = new Dictionary<System.Type, string>();
 
@@ -136,14 +134,8 @@ namespace Crest
         void OnGUIGerstnerSection(float x, ref float y, float w, float h)
         {
             GUI.Label(new Rect(x, y, w, h), "Gerstner weight(s)"); y += h;
-            if (_gerstnerBatches == null)
-            {
-                _gerstnerBatches = FindObjectsOfType<ShapeGerstnerBatched>();
-                // i am getting the array in the reverse order compared to the hierarchy which bugs me. sort them based on sibling index,
-                // which helps if the Gerstners are on sibling GOs.
-                System.Array.Sort(_gerstnerBatches, (a, b) => a.transform.GetSiblingIndex().CompareTo(b.transform.GetSiblingIndex()));
-            }
-            foreach (var gerstner in _gerstnerBatches)
+
+            foreach (var gerstner in ShapeGerstnerBatched.Instances)
             {
                 var specW = 75f;
                 gerstner._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner._weight, 0f, 1f);
@@ -158,14 +150,8 @@ namespace Crest
 #endif
                 y += h;
             }
-            if (_gerstners == null)
-            {
-                _gerstners = FindObjectsOfType<ShapeGerstner>();
-                // i am getting the array in the reverse order compared to the hierarchy which bugs me. sort them based on sibling index,
-                // which helps if the Gerstners are on sibling GOs.
-                System.Array.Sort(_gerstners, (a, b) => a.transform.GetSiblingIndex().CompareTo(b.transform.GetSiblingIndex()));
-            }
-            foreach (var gerstner in _gerstners)
+
+            foreach (var gerstner in ShapeGerstner.Instances)
             {
                 var specW = 75f;
                 gerstner._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner._weight, 0f, 1f);

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -138,12 +138,12 @@ namespace Crest
             foreach (var gerstner in ShapeGerstnerBatched.Instances)
             {
                 var specW = 75f;
-                gerstner._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner._weight, 0f, 1f);
+                gerstner.Value._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner.Value._weight, 0f, 1f);
 
 #if UNITY_EDITOR
                 if (GUI.Button(new Rect(x + w - specW, y, specW, h), "Spectrum"))
                 {
-                    var path = UnityEditor.AssetDatabase.GetAssetPath(gerstner._spectrum);
+                    var path = UnityEditor.AssetDatabase.GetAssetPath(gerstner.Value._spectrum);
                     var asset = UnityEditor.AssetDatabase.LoadMainAssetAtPath(path);
                     UnityEditor.Selection.activeObject = asset;
                 }
@@ -154,12 +154,12 @@ namespace Crest
             foreach (var gerstner in ShapeGerstner.Instances)
             {
                 var specW = 75f;
-                gerstner._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner._weight, 0f, 1f);
+                gerstner.Value._weight = GUI.HorizontalSlider(new Rect(x, y, w - specW - 5f, h), gerstner.Value._weight, 0f, 1f);
 
 #if UNITY_EDITOR
                 if (GUI.Button(new Rect(x + w - specW, y, specW, h), "Spectrum"))
                 {
-                    var path = UnityEditor.AssetDatabase.GetAssetPath(gerstner._spectrum);
+                    var path = UnityEditor.AssetDatabase.GetAssetPath(gerstner.Value._spectrum);
                     var asset = UnityEditor.AssetDatabase.LoadMainAssetAtPath(path);
                     UnityEditor.Selection.activeObject = asset;
                 }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -183,7 +183,7 @@ namespace Crest
         readonly float _twoPi = 2f * Mathf.PI;
         readonly float _recipTwoPi = 1f / (2f * Mathf.PI);
 
-        internal static readonly List<ShapeGerstner> Instances = new List<ShapeGerstner>();
+        internal static readonly CrestSortedList<int, ShapeGerstner> Instances = new CrestSortedList<int, ShapeGerstner>(new SiblingIndexComparer());
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void InitStatics()
@@ -597,7 +597,7 @@ namespace Crest
 
         private void OnEnable()
         {
-            Instances.Add(this);
+            Instances.Add(transform.GetSiblingIndex(), this);
 
             _firstUpdate = true;
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -7,6 +7,7 @@ using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 using Unity.Collections.LowLevel.Unsafe;
 using Crest.Spline;
+using System.Collections.Generic;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -181,6 +182,14 @@ namespace Crest
 
         readonly float _twoPi = 2f * Mathf.PI;
         readonly float _recipTwoPi = 1f / (2f * Mathf.PI);
+
+        internal static readonly List<ShapeGerstner> Instances = new List<ShapeGerstner>();
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void InitStatics()
+        {
+            Instances.Clear();
+        }
 
         void InitData()
         {
@@ -588,6 +597,8 @@ namespace Crest
 
         private void OnEnable()
         {
+            Instances.Add(this);
+
             _firstUpdate = true;
 
             // Initialise with spectrum
@@ -616,6 +627,8 @@ namespace Crest
 
         void OnDisable()
         {
+            Instances.Remove(this);
+
             LodDataMgrAnimWaves.DeregisterUpdatable(this);
 
             if (_batches != null)

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -152,7 +152,7 @@ namespace Crest
             public readonly static Vector4[] _chopAmpsBatch = new Vector4[BATCH_SIZE / 4];
         }
 
-        internal static readonly List<ShapeGerstnerBatched> Instances = new List<ShapeGerstnerBatched>();
+        internal static readonly CrestSortedList<int, ShapeGerstnerBatched> Instances = new CrestSortedList<int, ShapeGerstnerBatched>(new SiblingIndexComparer());
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void InitStatics()
@@ -172,7 +172,7 @@ namespace Crest
 
         private void OnEnable()
         {
-            Instances.Add(this);
+            Instances.Add(transform.GetSiblingIndex(), this);
 
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && !Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -4,6 +4,7 @@
 
 using UnityEngine;
 using UnityEngine.Rendering;
+using System.Collections.Generic;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -151,6 +152,14 @@ namespace Crest
             public readonly static Vector4[] _chopAmpsBatch = new Vector4[BATCH_SIZE / 4];
         }
 
+        internal static readonly List<ShapeGerstnerBatched> Instances = new List<ShapeGerstnerBatched>();
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void InitStatics()
+        {
+            Instances.Clear();
+        }
+
 #if UNITY_EDITOR
         void Reset()
         {
@@ -163,6 +172,8 @@ namespace Crest
 
         private void OnEnable()
         {
+            Instances.Add(this);
+
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && !Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
             {
@@ -541,6 +552,8 @@ namespace Crest
 
         void OnDisable()
         {
+            Instances.Remove(this);
+
             if (_batches != null)
             {
                 var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));


### PR DESCRIPTION
The spectrum part of the debug GUI doesn't take component enabled/disabled into account. I went with the simplest and lowest overhead route of just having a static list on both ShapeGerstners. Only downsides are that there is an overhead (negligible I think) even if OceanDebugGUI is not used.

In 2020 *FindObjectsOfType* can exclude inactive objects, but we would still have to call this every frame or implement on hierarchy change event if we wanted this to be dynamic. But may be worth it.

Let me know what you think.