### PR TITLE
Add power to range attribute

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -27,7 +27,7 @@ namespace Crest
     [HelpURL(Constants.HELP_URL_GENERAL)]
     public partial class OceanRenderer : MonoBehaviour
     {
-        [Tooltip("Base wind speed in km/h. Controls wave conditions. Can be overridden on ShapeGerstner components."), Range(0, 150f)]
+        [Tooltip("Base wind speed in km/h. Controls wave conditions. Can be overridden on ShapeGerstner components."), Range(0, 150f, power: 2f)]
         public float _globalWindSpeed = 150f;
 
         [Tooltip("The viewpoint which drives the ocean detail. Defaults to the camera."), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -39,7 +39,7 @@ namespace Crest
 
         [Tooltip("When true, uses the wind speed on this component rather than the wind speed from the Ocean Renderer component.")]
         public bool _overrideGlobalWindSpeed = false;
-        [Tooltip("Wind speed in km/h. Controls wave conditions."), Range(0, 150f), Predicated("_overrideGlobalWindSpeed")]
+        [Tooltip("Wind speed in km/h. Controls wave conditions."), Range(0, 150f, power: 2f), Predicated("_overrideGlobalWindSpeed")]
         public float _windSpeed = 20f;
 
         [Tooltip("Multiplier for these waves to scale up/down."), Range(0f, 1f)]


### PR DESCRIPTION
Unity has an internal PowerSlider. So I just grabbed it with reflection. It should be safe to use as I found it in the [C# reference](https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/EditorGUI.cs#L2438) which is for 2020.2. Also, [materials have a PowerSlider attribute](https://docs.unity3d.com/2021.2/Documentation/ScriptReference/MaterialPropertyDrawer.html) available which I believe uses this method too.

I have set the power to 2 for wind speed. I find higher values like 3 has a dead zone at the start. Let me know if you want it changed.