### PR TITLE
Cutscene and Networked Time Providers

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -100,8 +100,8 @@ namespace Crest
 
         public Transform Root { get; private set; }
 
-        [Tooltip("Optional provider for time, can be used to hard-code time for automation, or provide server time. Defaults to local Unity time."), SerializeField]
-        TimeProviderBase _timeProvider = null;
+        [Tooltip("Optional provider for time, can be used to hard-code time for automation, or provide server time. Defaults to local Unity time.")]
+        public TimeProviderBase _timeProvider = null;
         ITimeProvider _timeProviderActive = null;
         public ITimeProvider TimeProvider
         {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -400,6 +400,8 @@ namespace Crest
             float twopi = 2f * Mathf.PI;
             float one_over_2pi = 1f / twopi;
 
+            var time = OceanRenderer.Instance.CurrentTime;
+
             // register any nonzero components
             for (int i = 0; i < numComponents; i++)
             {
@@ -432,7 +434,7 @@ namespace Crest
                         float C = Mathf.Sqrt(wl * gravity * gravityScale * one_over_2pi);
                         float k = twopi / wl;
                         // Repeat every 2pi to keep angle bounded - helps precision on 16bit platforms
-                        UpdateBatchScratchData._phasesBatch[vi][ei] = Mathf.Repeat(_phases[firstComponent + i] + k * C * OceanRenderer.Instance.CurrentTime, Mathf.PI * 2f);
+                        UpdateBatchScratchData._phasesBatch[vi][ei] = Mathf.Repeat(_phases[firstComponent + i] + k * C * time, Mathf.PI * 2f);
 
                         numInBatch++;
                     }

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCustom.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCustom.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using UnityEditor;
 using UnityEngine;
 
 namespace Crest
@@ -9,13 +10,71 @@ namespace Crest
     /// <summary>
     /// This time provider fixes the ocean time at a custom value which is usable for testing/debugging.
     /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Custom Time Provider")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "other-features.html" + Internal.Constants.HELP_URL_RP + "#time-providers")]
     public class TimeProviderCustom : TimeProviderBase
     {
+        /// <summary>
+        /// Freezes the time
+        /// </summary>
+        [Tooltip("Freeze progression of time. Only works properly in Play mode.")]
+        public bool _paused = false;
+
+        [Tooltip("Override time used for ocean simulation to value below.")]
+        public bool _overrideTime = false;
+        [Predicated("_overrideTime"), DecoratedField]
         public float _time = 0f;
+
+        [Tooltip("Override delta time used for ocean simulation to value below.")]
+        public bool _overrideDeltaTime = false;
+        [Predicated("_overrideDeltaTime"), DecoratedField]
         public float _deltaTime = 0f;
 
-        public override float CurrentTime => _time;
-        public override float DeltaTime => _deltaTime;
+        TimeProviderDefault _tpDefault = new TimeProviderDefault();
+
+        float _timeInternal = 0f;
+
+        private void Start()
+        {
+            // May as well start on the same time value as unity
+            _timeInternal = Time.time;
+        }
+
+        private void Update()
+        {
+            // Use default TP delta time to update our time, because this dt works
+            // well in edit mode
+            if (!_paused)
+            {
+                _timeInternal += _tpDefault.DeltaTime;
+            }
+        }
+
+        public override float CurrentTime
+        {
+            get
+            {
+                // Override means override
+                if (_overrideTime)
+                {
+                    return _time;
+                }
+
+                // In edit mode, update is seldom called, so rely on the default TP
+#if UNITY_EDITOR
+                if (!EditorApplication.isPlaying && !_paused)
+                {
+                    return _tpDefault.CurrentTime;
+                }
+#endif
+
+                // Otherwise use our accumulated time
+                return _timeInternal;
+            }
+        }
+
+        // Either use override, or the default TP which works in edit mode
+        public override float DeltaTime => _overrideDeltaTime ? _deltaTime : _tpDefault.DeltaTime;
         public override float DeltaTimeDynamics => DeltaTime;
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCustom.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCustom.cs
@@ -21,12 +21,12 @@ namespace Crest
         public bool _paused = false;
 
         [Tooltip("Override time used for ocean simulation to value below.")]
-        public bool _overrideTime = false;
+        public bool _overrideTime = true;
         [Predicated("_overrideTime"), DecoratedField]
         public float _time = 0f;
 
         [Tooltip("Override delta time used for ocean simulation to value below.")]
-        public bool _overrideDeltaTime = false;
+        public bool _overrideDeltaTime = true;
         [Predicated("_overrideDeltaTime"), DecoratedField]
         public float _deltaTime = 0f;
 

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
@@ -12,6 +12,8 @@ namespace Crest
     /// This time provider feeds a Timeline time to the ocean system, using a Playable Director
     /// </summary>
     [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Cutscene Time Provider")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "other-features.html" + Internal.Constants.HELP_URL_RP + "#time-providers")]
     public class TimeProviderCutscene : TimeProviderBase
     {
         [Tooltip("Playable Director to take time from"), SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
@@ -1,0 +1,143 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace Crest
+{
+    /// <summary>
+    /// This time provider feeds a Timeline time to the ocean system, using a Playable Director
+    /// </summary>
+    [ExecuteAlways]
+    public class TimeProviderCutscene : TimeProviderBase
+    {
+        [Tooltip("Playable Director to take time from"), SerializeField]
+        PlayableDirector _playableDirector;
+
+        [Tooltip("Time offset which will be added to the Timeline time"), SerializeField]
+        float _timeOffset = 0f;
+
+        [Tooltip("Auto-assign this time provider to the ocean system when this component becomes active"), SerializeField]
+        bool _assignToOceanComponentOnEnable = true;
+
+        [Tooltip("Restore whatever time provider was previously assigned to ocean system when this component disables"), SerializeField]
+        bool _restorePreviousTimeProviderOnDisable = true;
+
+        TimeProviderDefault _fallbackTP = new TimeProviderDefault();
+
+        TimeProviderBase _previousTimeProviderComponent;
+        ITimeProvider _previousTimeProvider;
+
+        bool _initialised = false;
+
+        private void OnStart()
+        {
+            Initialise(true);
+        }
+
+        void Initialise(bool showErrors)
+        {
+            if (OceanRenderer.Instance == null)
+            {
+                if (showErrors)
+                {
+                    Debug.LogError("Crest: No ocean present, TimeProviderCutscene will have no effect.", this);
+                }
+#if !UNITY_EDITOR
+                enabled = false;
+#endif
+                return;
+            }
+
+            if (_playableDirector == null)
+            {
+                if (showErrors)
+                {
+                    Debug.LogError("Crest: No Playable Director component assigned, TimeProviderCutscene will have no effect.", this);
+                }
+#if !UNITY_EDITOR
+                enabled = false;
+#endif
+                return;
+            }
+
+            if (_assignToOceanComponentOnEnable)
+            {
+                // Back up both TP refs
+                _previousTimeProviderComponent = OceanRenderer.Instance._timeProvider;
+                _previousTimeProvider = OceanRenderer.Instance.TimeProvider;
+
+                // Clear the 'override' TP before assigning this TP, to avoid error
+                OceanRenderer.Instance._timeProvider = null;
+
+                OceanRenderer.Instance.TimeProvider = this;
+            }
+
+            _initialised = true;
+        }
+
+        private void OnDisable()
+        {
+            if (_restorePreviousTimeProviderOnDisable && OceanRenderer.Instance != null && _initialised)
+            {
+                // Clear the 'override' TP before assigning this TP, to avoid error
+                OceanRenderer.Instance._timeProvider = null;
+                // Restore TPs, first the base TP then the override
+                OceanRenderer.Instance.TimeProvider = _previousTimeProvider;
+                OceanRenderer.Instance._timeProvider = _previousTimeProviderComponent;
+            }
+
+            _initialised = false;
+        }
+
+#if UNITY_EDITOR
+        // Needed to keep up to date while editing. Don't want to display errors when user
+        // is halfway through configuring component, and keep trying to initialise until
+        // everything is there.
+        private void Update()
+        {
+            if (!_initialised)
+            {
+                Initialise(false);
+            }
+        }
+#endif
+
+        // If there is a playable director which is playing, return its time, otherwise
+        // use whatever TP was being used before this component initialised, else fallback
+        // to a default TP.
+        public override float CurrentTime
+        {
+            get
+            {
+                if (_playableDirector != null
+                    && _playableDirector.isActiveAndEnabled
+                    && (!EditorApplication.isPlaying || _playableDirector.state == PlayState.Playing))
+                {
+                    return (float)_playableDirector.time + _timeOffset;
+                }
+
+                // Use the previously assigned override TP
+                if (_previousTimeProviderComponent != null)
+                {
+                    return _previousTimeProviderComponent.CurrentTime;
+                }
+
+                // Use the previously assigned base TP
+                if (_previousTimeProvider != null)
+                {
+                    return _previousTimeProvider.CurrentTime;
+                }
+
+                // Use a fallback TP
+                return _fallbackTP.CurrentTime;
+            }
+        }
+
+        public override float DeltaTime => Time.deltaTime;
+        public override float DeltaTimeDynamics => DeltaTime;
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
@@ -30,9 +30,6 @@ namespace Crest
 
         TimeProviderDefault _fallbackTP = new TimeProviderDefault();
 
-        TimeProviderBase _previousTimeProviderComponent;
-        ITimeProvider _previousTimeProvider;
-
         bool _initialised = false;
 
         private void OnStart()
@@ -68,14 +65,7 @@ namespace Crest
 
             if (_assignToOceanComponentOnEnable)
             {
-                // Back up both TP refs
-                _previousTimeProviderComponent = OceanRenderer.Instance._timeProvider;
-                _previousTimeProvider = OceanRenderer.Instance.TimeProvider;
-
-                // Clear the 'override' TP before assigning this TP, to avoid error
-                OceanRenderer.Instance._timeProvider = null;
-
-                OceanRenderer.Instance.TimeProvider = this;
+                OceanRenderer.Instance.PushTimeProvider(this);
             }
 
             _initialised = true;
@@ -85,11 +75,7 @@ namespace Crest
         {
             if (_restorePreviousTimeProviderOnDisable && OceanRenderer.Instance != null && _initialised)
             {
-                // Clear the 'override' TP before assigning this TP, to avoid error
-                OceanRenderer.Instance._timeProvider = null;
-                // Restore TPs, first the base TP then the override
-                OceanRenderer.Instance.TimeProvider = _previousTimeProvider;
-                OceanRenderer.Instance._timeProvider = _previousTimeProviderComponent;
+                OceanRenderer.Instance.PopTimeProvider(this);
             }
 
             _initialised = false;
@@ -120,18 +106,6 @@ namespace Crest
                     && (!EditorApplication.isPlaying || _playableDirector.state == PlayState.Playing))
                 {
                     return (float)_playableDirector.time + _timeOffset;
-                }
-
-                // Use the previously assigned override TP
-                if (_previousTimeProviderComponent != null)
-                {
-                    return _previousTimeProviderComponent.CurrentTime;
-                }
-
-                // Use the previously assigned base TP
-                if (_previousTimeProvider != null)
-                {
-                    return _previousTimeProvider.CurrentTime;
                 }
 
                 // Use a fallback TP

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
@@ -103,7 +103,7 @@ namespace Crest
             {
                 if (_playableDirector != null
                     && _playableDirector.isActiveAndEnabled
-                    && (!EditorApplication.isPlaying || _playableDirector.state == PlayState.Playing))
+                    && (!Application.isPlaying || _playableDirector.state == PlayState.Playing))
                 {
                     return (float)_playableDirector.time + _timeOffset;
                 }

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 55bd20b393958de4692c662165dbba94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderNetworked.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderNetworked.cs
@@ -1,0 +1,42 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEditor;
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Gives a time to Crest with a custom time offset. Assign this component to the Ocean
+    /// Renderer component and set the TimeOffsetToServer property of this component to the
+    /// delta from this client's time to the shared server time.
+    /// </summary>
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Networked Time Provider")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "other-features.html" + Internal.Constants.HELP_URL_RP + "#time-providers")]
+    public class TimeProviderNetworked : TimeProviderBase
+    {
+        /// <summary>
+        /// If Time.time on this client is 1.5s ahead of the shared/server Time.time, set
+        /// this field to -1.5.
+        /// </summary>
+        public float TimeOffsetToServer { get; set; }
+
+        TimeProviderDefault _tpDefault = new TimeProviderDefault();
+
+        public override float CurrentTime => _tpDefault.CurrentTime + TimeOffsetToServer;
+        public override float DeltaTime => _tpDefault.DeltaTime;
+        public override float DeltaTimeDynamics => DeltaTime;
+    }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(TimeProviderNetworked))]
+    class TimeProviderNetworkedEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.HelpBox("Assign this component to the Ocean Renderer component and set the TimeOffsetToServer property of this component (at runtime from C#) to the delta from this client's time to the shared server time.", MessageType.Info);
+        }
+    }
+#endif // UNITY_EDITOR
+}

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderNetworked.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderNetworked.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d302289fbd31ca459044a54f7483d3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,13 +23,16 @@ Changed
 .. bullet_list::
 
    -  Sponsorship page launched! Asset Store sales only cover fixes and basic support. To support new feature development and give us financial stability please consider sponsoring us, no amount is too small! https://github.com/sponsors/wave-harmonic
-   -  Wind speed added to OceanRenderer component so that wave conditions change naturally for different wind conditions
-   -  Empirical spectra retweaked and use the aforementioned wind speed
+   -  Wind speed added to OceanRenderer component so that wave conditions change naturally for different wind conditions.
+   -  Empirical spectra retweaked and use the aforementioned wind speed.
    -  Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
    -  Headless support - add support for running without display, with new toggle on OceanRenderer to emulate it in Editor.
    -  No GPU support - add support for running without GPU, with new toggle on OceanRenderer to emulate it in Editor.
    -  OceanRenderer usability - system automatically rebuilds when changing settings on the component, 'Rebuild' button removed.
    -  Ocean material can now be set with scripting.
+   -  Custom Time Provider has pause toggle, for easy pausing functionality.
+   -  Network Time Provider added to easily sync water simulation to server time.
+   -  Cutscene Time Provider added to drive water simulation time from Timelines
 
    .. only:: hdrp
 

--- a/docs/user/other-features.rst
+++ b/docs/user/other-features.rst
@@ -23,6 +23,21 @@ Decals
 
         .. include:: includes/_render-alpha-surface.rst
 
+Time Providers
+--------------
+
+By default *Crest* generates waves at the current default Unity time.
+This behaviour can be overridden and an arbitrary time can be used.
+
+This can be useful for ensuring waves are synchronised over a network. TODO add link to the gist, which is probably linked from the FAQ.
+If using *Mirror*, you may create a component that inherits from their *NetworkBehaviour* component and implements the ITimeProvider interface, and then assign this component to the *OceanRenderer.Instance.TimeProvider* field at runtime.
+
+Another use case for this is for cutscenes/timelines when the waves conditions must be known in advance and repeatable.
+For this case you may create a 
+
+The world time that *Crest* uses for the wave state
+
+
 Floating origin
 ---------------
 

--- a/docs/user/other-features.rst
+++ b/docs/user/other-features.rst
@@ -26,17 +26,18 @@ Decals
 Time Providers
 --------------
 
-By default *Crest* generates waves at the current default Unity time.
-This behaviour can be overridden and an arbitrary time can be used.
+By default *Crest* generates waves at the current Unity time (what *Time.time* would return in C#).
+This behaviour can be overridden and a different time can be used instead.
 
-This can be useful for ensuring waves are synchronised over a network. TODO add link to the gist, which is probably linked from the FAQ.
-If using *Mirror*, you may create a component that inherits from their *NetworkBehaviour* component and implements the ITimeProvider interface, and then assign this component to the *OceanRenderer.Instance.TimeProvider* field at runtime.
+One use case for this is for cutscenes/timelines when the waves conditions must be known in advance and repeatable.
+For this case you may attach a *Cutscene Time Provider* component to a GameObject and assign it to the *Ocean Renderer* component.
+This component will take the time from a *Playable Director* component which plays a cutscene *Timeline*.
+Alternatively, a *Time Provider Custom* component can be used to feed any time into the system, and this time value can be keyframed, giving complete control over timing.
 
-Another use case for this is for cutscenes/timelines when the waves conditions must be known in advance and repeatable.
-For this case you may create a 
-
-The world time that *Crest* uses for the wave state
-
+Another common use case is to ensure waves are synchronised over a network.
+For this case attach a *Networked Time Provider* component to a GameObject and assign it to the *Ocean Renderer* component.
+Then at run-time set the *TimeOffsetToServer* property of this component to the delta from this client's time to the shared server time.
+If using the *Mirror* network system, set this property to the :link:`network time offset <https://mirror-networking.com/docs/api/Mirror.NetworkTime.html#Mirror_NetworkTime_offset>`.
 
 Floating origin
 ---------------


### PR DESCRIPTION
**Cutscene Time Provider**

A time provider that `OnEnable` registers itself and drives the Timeline time into the system. `OnDisable` it unregisters itself so cutscenes can be loaded/unloaded on the fly.

To make this push/pop of TPs work elegantly, the runtime TP storage is a list that behaves loosely as a stack. Pushing a TP always moves it to the top of the stack, and popping a TP removes it from anywhere in the stack. This way TPs always activate when they are pushed, and when removed the system has a memory of the previous TP to fallback to. This applies to user-assigned TPs as well.

**Networked Time Provider**

After years of assuming this was a complicated thing, i've realised this probably just needs a time provider with a configurable offset, so just a few lines of code.

**Custom Time Provider - pause support**

Got a support request for how to implement pausing, and realised that using the Custom TP requires unnecessary effort. I've simply added a "pause" option which will freeze time and probably achieve 99% of use cases. I also put the override time/dt on toggles, as specifying an actual fixed time is likely a uncommon scenario. I turned on the overrides by default for now, which makes me a little bit sad, but will mean that everyones existing custom TPs will continue working for them in the heavy handed mode. I'll queue myself a task to turn off the overrides by default for next release.