### PR TITLE
Remove wind speed from analytical spectra, and generally tweak

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -121,7 +121,7 @@ namespace Crest
 #if UNITY_EDITOR
         static MethodInfo _powerSliderMethod;
 
-        static void PowerSlider(Rect position, SerializedProperty property, float minimum, float maximum, float power, GUIContent label)
+        static internal void PowerSlider(Rect position, SerializedProperty property, float minimum, float maximum, float power, GUIContent label)
         {
             if (_powerSliderMethod == null)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -485,11 +485,12 @@ namespace Crest
                 {
                     EditorGUILayout.PropertyField(serializedObject.FindProperty("_smallWavelengthMultiplier"));
 
+                    var maxLin = 4000f;
                     var exponent = 4f;
+                    var maxExp = Mathf.Pow(maxLin, 1f / exponent);
+                    spec._fetch = Mathf.Clamp(EditorGUILayout.FloatField(s_labelFetch, spec._fetch), 0f, maxLin);
                     var fetchNonLin = Mathf.Pow(spec._fetch, 1f / exponent);
-                    var max = Mathf.Pow(4000f, 1f / exponent);
-                    spec._fetch = EditorGUILayout.FloatField(s_labelFetch, spec._fetch);
-                    spec._fetch = Mathf.Pow(GUI.HorizontalSlider(EditorGUILayout.GetControlRect(false), fetchNonLin, 0, max), exponent);
+                    spec._fetch = Mathf.Pow(GUI.HorizontalSlider(EditorGUILayout.GetControlRect(false), fetchNonLin, 0, maxExp), exponent);
                 }
 
                 // Wind speed is taken into account during wave generation, not for the spectrum

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -337,7 +337,7 @@ namespace Crest
             "Fetch limited sea where waves continue to grow.",
         };
 
-        static GUIContent s_labelSWM = new GUIContent("Small Wavelength Modifier", "Modifies parameters for the empirical spectra, tends to boost smaller wavelengths");
+        static GUIContent s_labelSWM = new GUIContent("Small wavelength modifier", "Modifies parameters for the empirical spectra, tends to boost smaller wavelengths");
         static GUIContent s_labelFetch = new GUIContent("Fetch", "Length of area that wind excites waves. Applies only to JONSWAP");
 
         public static void UpgradeSpectrum(SerializedProperty prop, float defaultValue)
@@ -510,10 +510,14 @@ namespace Crest
                         spec.ApplyPhillipsSpectrum(windSpeed, 1f);
                         break;
                     case OceanWaveSpectrum.SpectrumModel.PiersonMoskowitz:
-                        spec.ApplyPiersonMoskowitzSpectrum(windSpeed, 0.42f);
+                        // Magic number that seems to work well
+                        var swm = 0.42f;
+                        spec.ApplyPiersonMoskowitzSpectrum(windSpeed, swm);
                         break;
                     case OceanWaveSpectrum.SpectrumModel.JONSWAP:
-                        spec.ApplyJONSWAPSpectrum(windSpeed, spec._fetch, spec._smallWavelengthMultiplier * 0.0419265f);
+                        // Magic number that seems to work well when user has it set to 1
+                        var smallWavelengthMul = 0.0419265f * spec._smallWavelengthMultiplier;
+                        spec.ApplyJONSWAPSpectrum(windSpeed, spec._fetch, smallWavelengthMul);
                         break;
                 }
             }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -31,7 +31,7 @@ namespace Crest
         [Tooltip("More gravity means faster waves."), Range(0f, 25f)]
         public float _gravityScale = 1f;
 
-        [HideInInspector]
+        [Range(0f, 2f), HideInInspector]
         public float _smallWavelengthMultiplier = 1f;
 
         [Tooltip("Multiplier which scales waves"), Range(0f, 10f), SerializeField]
@@ -481,20 +481,19 @@ namespace Crest
                 // It doesn't seem to matter where this is called.
                 Undo.RecordObject(spec, $"Apply {ObjectNames.NicifyVariableName(spectrumModel.ToString())} Spectrum");
 
-                var labelWidth = 170f;
-
                 if (spectrumModel == OceanWaveSpectrum.SpectrumModel.JONSWAP)
                 {
-                    EditorGUILayout.BeginHorizontal();
-                    EditorGUILayout.LabelField(s_labelSWM, GUILayout.Width(labelWidth));
-                    spec._smallWavelengthMultiplier = EditorGUILayout.Slider(spec._smallWavelengthMultiplier, 0f, 2f);
-                    EditorGUILayout.EndHorizontal();
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty("_smallWavelengthMultiplier"));
 
                     var exponent = 4f;
                     var fetchNonLin = Mathf.Pow(spec._fetch, 1f / exponent);
                     var max = Mathf.Pow(4000f, 1f / exponent);
                     s_labelFetch.text = $"Fetch ({string.Format("{0:0.00}", spec._fetch)}m)";
                     spec._fetch = Mathf.Pow(EditorGUILayout.Slider(s_labelFetch, fetchNonLin, 0f, max), exponent);
+
+                    // Would be nice but quantizes very badly at low end for this range and is useless
+                    //var rect = EditorGUILayout.GetControlRect(true);
+                    //RangeAttribute.PowerSlider(rect, serializedObject.FindProperty("_fetch"), 0f, 4000f, 4f, s_labelFetch);
                 }
 
                 // Wind speed is taken into account during wave generation, not for the spectrum

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -488,12 +488,8 @@ namespace Crest
                     var exponent = 4f;
                     var fetchNonLin = Mathf.Pow(spec._fetch, 1f / exponent);
                     var max = Mathf.Pow(4000f, 1f / exponent);
-                    s_labelFetch.text = $"Fetch ({string.Format("{0:0.00}", spec._fetch)}m)";
-                    spec._fetch = Mathf.Pow(EditorGUILayout.Slider(s_labelFetch, fetchNonLin, 0f, max), exponent);
-
-                    // Would be nice but quantizes very badly at low end for this range and is useless
-                    //var rect = EditorGUILayout.GetControlRect(true);
-                    //RangeAttribute.PowerSlider(rect, serializedObject.FindProperty("_fetch"), 0f, 4000f, 4f, s_labelFetch);
+                    spec._fetch = EditorGUILayout.FloatField(s_labelFetch, spec._fetch);
+                    spec._fetch = Mathf.Pow(GUI.HorizontalSlider(EditorGUILayout.GetControlRect(false), fetchNonLin, 0, max), exponent);
                 }
 
                 // Wind speed is taken into account during wave generation, not for the spectrum

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,8 @@ Changed
 .. bullet_list::
 
    -  Sponsorship page launched! Asset Store sales only cover fixes and basic support. To support new feature development and give us financial stability please consider sponsoring us, no amount is too small! https://github.com/sponsors/wave-harmonic
+   -  Wind speed added to OceanRenderer component so that wave conditions change naturally for different wind conditions
+   -  Empirical spectra retweaked and use the aforementioned wind speed
    -  Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
    -  Headless support - add support for running without display, with new toggle on OceanRenderer to emulate it in Editor.
    -  No GPU support - add support for running without GPU, with new toggle on OceanRenderer to emulate it in Editor.


### PR DESCRIPTION
The wind speed should no longer be baked into the spectrum. The spectrum should give the character of the ocean for any wind speed, and the wind speed is applied based on current wind conditions dynamically.

I removed the wind speed from the analytical spectra which seemed to work.

While doing so i found the 'small wave multiplier' is only really needed for JONSWAP, and have an effect akin to simple scaling for the otehr spectra. Given we already have a multiplier param on the spectrum, its useless and another param that users have to grapple with. I got good results removing params from phillips/moskowitz by tweaking a good default value, and the parameter ranges for jonswap look good now too.

Most of the jonswap tweaking range is exponentially distributed at the low end, so i made the slider exponential. This has the unfortunate side effect of making the automatic value text box show the exponentiated value rather than the linear one. I decided to modify the label which gets us across the line. Dale i have not compared with the exponential slider work you did, let me know if something should change here.