### PR TITLE
Make interaction scripts behave gracefully when dyn wave sim disabled

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/ObjectWaterInteraction.cs
@@ -56,6 +56,13 @@ namespace Crest
             }
 #endif
 
+            if (OceanRenderer.Instance._lodDataDynWaves == null)
+            {
+                // Don't run without a dyn wave sim
+                enabled = false;
+                return;
+            }
+
             _localOffset = transform.localPosition;
             _renderer = GetComponent<Renderer>();
             _mpb = new MaterialPropertyBlock();
@@ -164,13 +171,13 @@ namespace Crest
         {
             var isValid = true;
 
-            if (!ocean.CreateDynamicWaveSim)
+            if (!ocean.CreateDynamicWaveSim && showMessage == ValidatedHelper.HelpBox)
             {
                 showMessage
                 (
                     "<i>ObjectWaterInteraction</i> requires dynamic wave simulation to be enabled.",
                     $"Enable the <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL}</i> option on the <i>OceanRenderer</i> component.",
-                    ValidatedHelper.MessageType.Error, ocean,
+                    ValidatedHelper.MessageType.Warning, ocean,
                     (so) => OceanRenderer.FixSetFeatureEnabled(so, LodDataMgrDynWaves.FEATURE_TOGGLE_NAME, true)
                 );
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -65,6 +65,13 @@ namespace Crest
             }
 #endif
 
+            if (OceanRenderer.Instance._lodDataDynWaves == null)
+            {
+                // Don't run without a dyn wave sim
+                enabled = false;
+                return;
+            }
+
             _renderer = GetComponent<Renderer>();
             _mpb = new MaterialPropertyBlock();
 
@@ -201,17 +208,15 @@ namespace Crest
         {
             var isValid = true;
 
-            if (!ocean.CreateDynamicWaveSim)
+            if (!ocean.CreateDynamicWaveSim && showMessage == ValidatedHelper.HelpBox)
             {
                 showMessage
                 (
                     "<i>SphereWaterInteraction</i> requires dynamic wave simulation to be enabled on <i>OceanRenderer</i>.",
                     $"Enable the <i>{LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL}</i> option on the <i>OceanRenderer</i> component.",
-                    ValidatedHelper.MessageType.Error, ocean,
+                    ValidatedHelper.MessageType.Warning, ocean,
                     (so) => OceanRenderer.FixSetFeatureEnabled(so, LodDataMgrDynWaves.FEATURE_TOGGLE_NAME, true)
                 );
-
-                isValid = false;
             }
 
             if (transform.parent == null)


### PR DESCRIPTION
Right now sphere water interaction and others spew errors if dyn wave sim is disabled.

This change emits a *warning*, only as a helpbox, if the sim is not found, and behaves otherwise gracefully and does not pollute the log.
