### PR TITLE
Mellow out wave attenuation from wind

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -150,8 +150,7 @@ namespace Crest
 
             // Dampen based on wind. Waves travelling faster than wind get dampened. 0.95
             // is arbitrary value to give some 'ramp' in the multiplier.
-            power *= Mathf.Clamp01(Mathf.InverseLerp(windSpeed, windSpeed * 0.95f, c));
-
+            power *= Mathf.SmoothStep(0f, 1f, Mathf.InverseLerp(windSpeed, windSpeed * 0.75f, c));
             var a_2 = 2f * power * domega;
 
             // Amplitude


### PR DESCRIPTION
After more experience and tweaking im finding the way the wind attenuates waves (linear ramp starting at 95%) is quite harsh leading to waves seemingly popping in when wind speed changes, and linear nature of ramp is visible.

This change starts transitioning waves at 75% and uses a ease-in-ease-out curve to soften the transition.