### PR TITLE
Fix null texture bindings

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -138,11 +138,6 @@ namespace Crest
 
                 // Underwater rendering uses displacements for intersecting the waves with the near plane, and ocean depth/shadows for ScatterColour()
                 _mpb.SetInt(LodDataMgr.sp_LD_SliceIndex, 0);
-
-                LodDataMgrAnimWaves.Bind(_mpb);
-                LodDataMgrSeaFloorDepth.Bind(_mpb);
-                LodDataMgrShadow.Bind(_mpb);
-
                 _mpb.SetFloat(sp_HeightOffset, heightOffset);
 
                 _rend.SetPropertyBlock(_mpb.materialPropertyBlock);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -41,6 +41,8 @@ namespace Crest
 
         public RenderTexture DataTexture { get { return _targets; } }
 
+        protected virtual Texture2DArray NullTexture => TextureArrayHelpers.BlackTextureArray;
+
         public static int sp_LD_SliceIndex = Shader.PropertyToID("_LD_SliceIndex");
         protected static int sp_LODChange = Shader.PropertyToID("_LODChange");
 
@@ -213,7 +215,7 @@ namespace Crest
         internal virtual void OnDisable()
         {
             // Unbind from all graphics shaders (not compute)
-            Shader.SetGlobalTexture(GetParamIdSampler(), null);
+            Shader.SetGlobalTexture(GetParamIdSampler(), NullTexture);
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -292,14 +292,10 @@ namespace Crest
                 }
 
                 // Dynamic waves
-                LodDataMgrDynWaves.Bind(_combineMaterial[lodIdx]);
                 if (OceanRenderer.Instance._lodDataDynWaves != null)
                 {
                     OceanRenderer.Instance._lodDataDynWaves.BindCopySettings(_combineMaterial[lodIdx]);
                 }
-
-                // Flow
-                LodDataMgrFlow.Bind((_combineMaterial[lodIdx]));
 
                 _combineMaterial[lodIdx].SetInt(sp_LD_SliceIndex, lodIdx);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -434,11 +434,8 @@ namespace Crest
         }
 
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -78,10 +78,20 @@ namespace Crest
         {
             return ParamIdSampler(sourceLod);
         }
-        public static void BindNull(IPropertyWrapper properties)
+
+        public static void Bind(IPropertyWrapper properties)
         {
-            properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+            if (OceanRenderer.Instance._lodDataClipSurface != null)
+            {
+                properties.SetTexture(ParamIdSampler(), OceanRenderer.Instance._lodDataClipSurface.DataTexture);
+            }
+            else
+            {
+                properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+            }
         }
+
+        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
 
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -73,11 +73,8 @@ namespace Crest
 
         readonly static string s_textureArrayName = "_LD_TexArray_ClipSurface";
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -18,6 +18,8 @@ namespace Crest
         // The clip values only really need 8bits
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8_UNorm;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
+        static Texture2DArray s_nullTexture => TextureArrayHelpers.BlackTextureArray;
+        protected override Texture2DArray NullTexture => s_nullTexture;
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_ClipSurface";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_CLIPSURFACE_ON";
@@ -84,11 +86,11 @@ namespace Crest
             }
             else
             {
-                properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+                properties.SetTexture(ParamIdSampler(), s_nullTexture);
             }
         }
 
-        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+        public static void BindNullToGraphicsShaders() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
 
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -131,11 +131,8 @@ namespace Crest
 
         readonly static string s_textureArrayName = "_LD_TexArray_DynamicWaves";
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -150,6 +150,8 @@ namespace Crest
             }
         }
 
+        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -126,7 +126,6 @@ namespace Crest
         protected override void GetSimSubstepData(float timeToSimulate, out int numSubsteps, out float substepDt)
         {
             numSubsteps = Mathf.FloorToInt(timeToSimulate * Settings._simulationFrequency);
-            
             substepDt = numSubsteps > 0 ? (1f / Settings._simulationFrequency) : 0f;
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -19,6 +19,8 @@ namespace Crest
 
         public override string SimName { get { return "DynamicWaves"; } }
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16G16_SFloat;
+        static Texture2DArray s_nullTexture => TextureArrayHelpers.BlackTextureArray;
+        protected override Texture2DArray NullTexture => s_nullTexture;
 
         public bool _rotateLaplacian = true;
 
@@ -142,11 +144,11 @@ namespace Crest
             }
             else
             {
-                properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+                properties.SetTexture(ParamIdSampler(), s_nullTexture);
             }
         }
 
-        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+        public static void BindNullToGraphicsShaders() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
 
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -124,6 +124,8 @@ namespace Crest
             }
         }
 
+        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -18,6 +18,8 @@ namespace Crest
         public override string SimName { get { return "Flow"; } }
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16G16_SFloat;
         protected override bool NeedToReadWriteTextureData { get { return false; } }
+        static Texture2DArray s_nullTexture => TextureArrayHelpers.BlackTextureArray;
+        protected override Texture2DArray NullTexture => s_nullTexture;
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Flow";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FLOW_ON";
@@ -117,11 +119,11 @@ namespace Crest
             }
             else
             {
-                properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+                properties.SetTexture(ParamIdSampler(), s_nullTexture);
             }
         }
 
-        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+        public static void BindNullToGraphicsShaders() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
 
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -106,11 +106,8 @@ namespace Crest
 
         readonly static string s_textureArrayName = "_LD_TexArray_Flow";
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -18,6 +18,8 @@ namespace Crest
         protected override int krnl_ShaderSim { get { return _shader.FindKernel(ShaderSim); } }
         public override string SimName { get { return "Foam"; } }
         protected override GraphicsFormat RequestedTextureFormat => Settings._renderTextureGraphicsFormat;
+        static Texture2DArray s_nullTexture => TextureArrayHelpers.BlackTextureArray;
+        protected override Texture2DArray NullTexture => s_nullTexture;
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Foam";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_FOAM_ON";
@@ -107,11 +109,11 @@ namespace Crest
             }
             else
             {
-                properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+                properties.SetTexture(ParamIdSampler(), s_nullTexture);
             }
         }
 
-        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+        public static void BindNullToGraphicsShaders() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
 
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -114,6 +114,8 @@ namespace Crest
             }
         }
 
+        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -96,11 +96,8 @@ namespace Crest
 
         readonly static string s_textureArrayName = "_LD_TexArray_Foam";
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -27,6 +27,7 @@ namespace Crest
         // We want the null colour to be the depth where wave attenuation begins (1000 metres)
         readonly static Color s_nullColor = Color.red * 1000f;
         static Texture2DArray s_nullTexture2DArray;
+        protected override Texture2DArray NullTexture => s_nullTexture2DArray;
 
         public LodDataMgrSeaFloorDepth(OceanRenderer ocean) : base(ocean)
         {
@@ -81,6 +82,8 @@ namespace Crest
                 properties.SetTexture(ParamIdSampler(), s_nullTexture2DArray);
             }
         }
+
+        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture2DArray);
 
         static void InitNullTexture()
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -59,11 +59,8 @@ namespace Crest
 
         readonly static string s_textureArrayName = "_LD_TexArray_SeaFloorDepth";
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -16,6 +16,10 @@ namespace Crest
         public override string SimName { get { return "SeaFloorDepth"; } }
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16_SFloat;
         protected override bool NeedToReadWriteTextureData { get { return false; } }
+        // We want the null colour to be the depth where wave attenuation begins (1000 metres)
+        readonly static Color s_nullColor = Color.red * 1000f;
+        static Texture2DArray s_nullTexture;
+        protected override Texture2DArray NullTexture => s_nullTexture;
 
         bool _targetsClear = false;
 
@@ -23,11 +27,6 @@ namespace Crest
         public const string FEATURE_TOGGLE_LABEL = "Create Sea Floor Depth Data";
 
         public const string ShaderName = "Crest/Inputs/Depth/Cached Depths";
-
-        // We want the null colour to be the depth where wave attenuation begins (1000 metres)
-        readonly static Color s_nullColor = Color.red * 1000f;
-        static Texture2DArray s_nullTexture2DArray;
-        protected override Texture2DArray NullTexture => s_nullTexture2DArray;
 
         public LodDataMgrSeaFloorDepth(OceanRenderer ocean) : base(ocean)
         {
@@ -71,23 +70,32 @@ namespace Crest
             else
             {
                 // TextureArrayHelpers prevents use from using this in a static constructor due to blackTexture usage
-                if (s_nullTexture2DArray == null)
+                if (s_nullTexture == null)
                 {
                     InitNullTexture();
                 }
 
-                properties.SetTexture(ParamIdSampler(), s_nullTexture2DArray);
+                properties.SetTexture(ParamIdSampler(), s_nullTexture);
             }
         }
 
-        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture2DArray);
+        public static void BindNullToGraphicsShaders()
+        {
+            // TextureArrayHelpers prevents us from using this in a static constructor due to blackTexture usage.
+            if (s_nullTexture == null)
+            {
+                InitNullTexture();
+            }
+
+            Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
+        }
 
         static void InitNullTexture()
         {
             // Depth textures use HDR values
             var texture = TextureArrayHelpers.CreateTexture2D(s_nullColor, UnityEngine.TextureFormat.RGB9e5Float);
-            s_nullTexture2DArray = TextureArrayHelpers.CreateTexture2DArray(texture);
-            s_nullTexture2DArray.name = "Sea Floor Depth Null Texture";
+            s_nullTexture = TextureArrayHelpers.CreateTexture2DArray(texture);
+            s_nullTexture.name = "Sea Floor Depth Null Texture";
         }
 
 #if UNITY_2019_3_OR_NEWER

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -21,6 +21,8 @@ namespace Crest
         public override string SimName { get { return "Shadow"; } }
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8G8_UNorm;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
+        static Texture2DArray s_nullTexture => TextureArrayHelpers.BlackTextureArray;
+        protected override Texture2DArray NullTexture => s_nullTexture;
 
         internal const string MATERIAL_KEYWORD_PROPERTY = "_Shadows";
         internal const string MATERIAL_KEYWORD = MATERIAL_KEYWORD_PREFIX + "_SHADOWS_ON";
@@ -349,11 +351,11 @@ namespace Crest
             }
             else
             {
-                properties.SetTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+                properties.SetTexture(ParamIdSampler(), s_nullTexture);
             }
         }
 
-        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+        public static void BindNullToGraphicsShaders() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
 
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -338,11 +338,8 @@ namespace Crest
 
         readonly static string s_textureArrayName = "_LD_TexArray_Shadow";
         private static TextureArrayParamIds s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-        public static int ParamIdSampler(bool sourceLod = false) { return s_textureArrayParamIds.GetId(sourceLod); }
-        protected override int GetParamIdSampler(bool sourceLod = false)
-        {
-            return ParamIdSampler(sourceLod);
-        }
+        public static int ParamIdSampler(bool sourceLod = false) => s_textureArrayParamIds.GetId(sourceLod);
+        protected override int GetParamIdSampler(bool sourceLod = false) => ParamIdSampler(sourceLod);
 
         public static void Bind(IPropertyWrapper properties)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -356,6 +356,8 @@ namespace Crest
             }
         }
 
+        public static void BindNull() => Shader.SetGlobalTexture(ParamIdSampler(), TextureArrayHelpers.BlackTextureArray);
+
 #if UNITY_2019_3_OR_NEWER
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
 #endif

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -446,7 +446,15 @@ namespace Crest
 
             Root = OceanBuilder.GenerateMesh(this, _oceanChunkRenderers, _lodDataResolution, _geometryDownSampleFactor, _lodCount);
 
-            CreateDestroySubSystems(isFirst: true);
+            // Make sure we have correct defaults in case simulations are not enabled.
+            LodDataMgrClipSurface.BindNullToGraphicsShaders();
+            LodDataMgrDynWaves.BindNullToGraphicsShaders();
+            LodDataMgrFlow.BindNullToGraphicsShaders();
+            LodDataMgrFoam.BindNullToGraphicsShaders();
+            LodDataMgrSeaFloorDepth.BindNullToGraphicsShaders();
+            LodDataMgrShadow.BindNullToGraphicsShaders();
+
+            CreateDestroySubSystems();
 
             _commandbufferBuilder = new BuildCommandBuffer();
 
@@ -520,7 +528,7 @@ namespace Crest
             }
         }
 
-        void CreateDestroySubSystems(bool isFirst = false)
+        void CreateDestroySubSystems()
         {
             if (!RunningWithoutGPU)
             {
@@ -548,10 +556,6 @@ namespace Crest
                         _lodDatas.Remove(_lodDataClipSurface);
                         _lodDataClipSurface = null;
                     }
-                    else if (isFirst)
-                    {
-                        LodDataMgrClipSurface.BindNullToGraphicsShaders();
-                    }
                 }
 
                 if (CreateDynamicWaveSim)
@@ -569,10 +573,6 @@ namespace Crest
                         _lodDataDynWaves.OnDisable();
                         _lodDatas.Remove(_lodDataDynWaves);
                         _lodDataDynWaves = null;
-                    }
-                    else if (isFirst)
-                    {
-                        LodDataMgrDynWaves.BindNullToGraphicsShaders();
                     }
                 }
 
@@ -597,10 +597,6 @@ namespace Crest
                         _lodDataFlow.OnDisable();
                         _lodDatas.Remove(_lodDataFlow);
                         _lodDataFlow = null;
-                    }
-                    else if (isFirst)
-                    {
-                        LodDataMgrFlow.BindNullToGraphicsShaders();
                     }
 
                     if (FlowProvider != null && FlowProvider is QueryFlow)
@@ -630,10 +626,6 @@ namespace Crest
                         _lodDatas.Remove(_lodDataFoam);
                         _lodDataFoam = null;
                     }
-                    else if (isFirst)
-                    {
-                        LodDataMgrFoam.BindNullToGraphicsShaders();
-                    }
                 }
 
                 if (CreateSeaFloorDepthData)
@@ -652,10 +644,6 @@ namespace Crest
                         _lodDatas.Remove(_lodDataSeaDepths);
                         _lodDataSeaDepths = null;
                     }
-                    else if (isFirst)
-                    {
-                        LodDataMgrSeaFloorDepth.BindNullToGraphicsShaders();
-                    }
                 }
 
                 if (CreateShadowData && !RunningHeadless)
@@ -673,10 +661,6 @@ namespace Crest
                         _lodDataShadow.OnDisable();
                         _lodDatas.Remove(_lodDataShadow);
                         _lodDataShadow = null;
-                    }
-                    else if (isFirst)
-                    {
-                        LodDataMgrShadow.BindNullToGraphicsShaders();
                     }
                 }
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -446,7 +446,7 @@ namespace Crest
 
             Root = OceanBuilder.GenerateMesh(this, _oceanChunkRenderers, _lodDataResolution, _geometryDownSampleFactor, _lodCount);
 
-            CreateDestroySubSystems();
+            CreateDestroySubSystems(isFirst: true);
 
             _commandbufferBuilder = new BuildCommandBuffer();
 
@@ -520,7 +520,7 @@ namespace Crest
             }
         }
 
-        void CreateDestroySubSystems()
+        void CreateDestroySubSystems(bool isFirst = false)
         {
             if (!RunningWithoutGPU)
             {
@@ -548,6 +548,10 @@ namespace Crest
                         _lodDatas.Remove(_lodDataClipSurface);
                         _lodDataClipSurface = null;
                     }
+                    else if (isFirst)
+                    {
+                        LodDataMgrClipSurface.BindNull();
+                    }
                 }
 
                 if (CreateDynamicWaveSim)
@@ -565,6 +569,10 @@ namespace Crest
                         _lodDataDynWaves.OnDisable();
                         _lodDatas.Remove(_lodDataDynWaves);
                         _lodDataDynWaves = null;
+                    }
+                    else if (isFirst)
+                    {
+                        LodDataMgrDynWaves.BindNull();
                     }
                 }
 
@@ -589,6 +597,10 @@ namespace Crest
                         _lodDataFlow.OnDisable();
                         _lodDatas.Remove(_lodDataFlow);
                         _lodDataFlow = null;
+                    }
+                    else if (isFirst)
+                    {
+                        LodDataMgrFlow.BindNull();
                     }
 
                     if (FlowProvider != null && FlowProvider is QueryFlow)
@@ -618,6 +630,10 @@ namespace Crest
                         _lodDatas.Remove(_lodDataFoam);
                         _lodDataFoam = null;
                     }
+                    else if (isFirst)
+                    {
+                        LodDataMgrFoam.BindNull();
+                    }
                 }
 
                 if (CreateSeaFloorDepthData)
@@ -636,6 +652,10 @@ namespace Crest
                         _lodDatas.Remove(_lodDataSeaDepths);
                         _lodDataSeaDepths = null;
                     }
+                    else if (isFirst)
+                    {
+                        LodDataMgrSeaFloorDepth.BindNull();
+                    }
                 }
 
                 if (CreateShadowData && !RunningHeadless)
@@ -653,6 +673,10 @@ namespace Crest
                         _lodDataShadow.OnDisable();
                         _lodDatas.Remove(_lodDataShadow);
                         _lodDataShadow = null;
+                    }
+                    else if (isFirst)
+                    {
+                        LodDataMgrShadow.BindNull();
                     }
                 }
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -550,7 +550,7 @@ namespace Crest
                     }
                     else if (isFirst)
                     {
-                        LodDataMgrClipSurface.BindNull();
+                        LodDataMgrClipSurface.BindNullToGraphicsShaders();
                     }
                 }
 
@@ -572,7 +572,7 @@ namespace Crest
                     }
                     else if (isFirst)
                     {
-                        LodDataMgrDynWaves.BindNull();
+                        LodDataMgrDynWaves.BindNullToGraphicsShaders();
                     }
                 }
 
@@ -600,7 +600,7 @@ namespace Crest
                     }
                     else if (isFirst)
                     {
-                        LodDataMgrFlow.BindNull();
+                        LodDataMgrFlow.BindNullToGraphicsShaders();
                     }
 
                     if (FlowProvider != null && FlowProvider is QueryFlow)
@@ -632,7 +632,7 @@ namespace Crest
                     }
                     else if (isFirst)
                     {
-                        LodDataMgrFoam.BindNull();
+                        LodDataMgrFoam.BindNullToGraphicsShaders();
                     }
                 }
 
@@ -654,7 +654,7 @@ namespace Crest
                     }
                     else if (isFirst)
                     {
-                        LodDataMgrSeaFloorDepth.BindNull();
+                        LodDataMgrSeaFloorDepth.BindNullToGraphicsShaders();
                     }
                 }
 
@@ -676,7 +676,7 @@ namespace Crest
                     }
                     else if (isFirst)
                     {
-                        LodDataMgrShadow.BindNull();
+                        LodDataMgrShadow.BindNullToGraphicsShaders();
                     }
                 }
             }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -483,9 +483,6 @@ namespace Crest
                 mat.SetInt(sp_NumWaveVecs, numVecs);
                 mat.SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx - i);
 
-                LodDataMgrAnimWaves.Bind(mat);
-                LodDataMgrSeaFloorDepth.Bind(mat);
-
                 if (_directTowardsPoint)
                 {
                     mat.SetVector(sp_TargetPointData, new Vector4(_pointPositionXZ.x, _pointPositionXZ.y, _pointRadii.x, _pointRadii.y));

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -274,7 +274,7 @@ namespace Crest
 
             // Calc wind speed in m/s
             var windSpeed = OceanRenderer.Instance._globalWindSpeed / 3.6f;
-            
+
             for (int i = 0; i < _wavelengths.Length; i++)
             {
                 _amplitudes[i] = Random.value * _weight * _spectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave, windSpeed, out _);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -37,6 +37,7 @@ Fixed
 
    -  Fix build errors for platforms that do not support XR/VR.
    -  Fix for bugs where a large boat may stop moving when camera is close.
+   -  Fix bad data being sampled from simulations when they're not enabled.
 
    .. only:: hdrp
 


### PR DESCRIPTION
When a simulation was disabled, null textures weren't being bound for shaders. I have also removed some unnecessary bind calls. I have separated everything by commit. Let me know what you think.