### PR TITLE
Fix ocean tiles moving away from camera when far from zero

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -316,7 +316,7 @@ Shader "Crest/Ocean"
 				const PerCascadeInstanceData instanceData = _CrestPerCascadeInstanceData[_LD_SliceIndex];
 
 				// Move to world space
-				o.worldPos = mul(unity_ObjectToWorld, float4(v.vertex.xyz, 1.0));
+				o.worldPos = mul(UNITY_MATRIX_M, float4(v.vertex.xyz, 1.0));
 
 				// Vertex snapping and lod transition
 				float lodAlpha;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -44,6 +44,11 @@ Fixed
 
       -  Fix shadow data for XR/VR `SPI` from working and breaking builds. `[HDRP]`
 
+   .. only:: urp
+
+      -  Fix ocean tiles disappearing when far from zero. `[URP]`
+
+
 4.10
 ----
 


### PR DESCRIPTION
Only affects URP when _Enable GPU Instancing_ is enabled. Since _UNITY_MATRIX_M_ is the same as _unity_ObjectToWorld_, and we use it already in _SnapAndTransitionVertLayout_, it is a no brainer to apply the fix in built-in.

What was happening was the gap fix was pushing tiles away from camera. Must be a bug with URP.