### PR TITLE
Docs: add Rendering page. Improve lighting

### DIFF
--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -44,6 +44,15 @@ Fixed
 
       -  Fix shadow data for XR/VR `SPI` from working and breaking builds. `[HDRP]`
 
+
+Documentation
+^^^^^^^^^^^^^
+.. bullet_list::
+
+   -  Document issues with transparency in new :ref:`rendering` page.
+   -  Improve :ref:`lighting` section.
+
+
 4.10
 ----
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,7 @@ Crest Ocean System
    user/shallows-and-shorelines
    user/water-bodies
    user/collision-shape-for-physics
+   user/rendering
    user/underwater
    user/other-features
    user/performance

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -301,51 +301,65 @@ Flow
    'Create Flow Sim' must be enabled on the OceanRenderer to generate flow data.
 
 
+Lighting
+--------
+
+General
+^^^^^^^
+
+.. only:: birp
+
+   .. tab:: `BIRP`
+
+      .. include:: includes/_birp-lighting.rst
+
+.. only:: hdrp
+
+   .. tab:: `HDRP`
+
+      .. include:: includes/_hdrp-lighting.rst
+
+.. only:: urp
+
+   .. tab:: `URP`
+
+      .. include:: includes/_urp-lighting.rst
+
+
 Reflections
------------
+^^^^^^^^^^^
 
 Reflections contribute hugely to the appearance of the ocean.
 The look of the ocean will dramatically changed based on the reflection environment.
 
-.. only:: birp
-
-      .. tab:: `BIRP`
-
-            .. include:: includes/_birp-reflections.rst
-
-.. only:: hdrp
-
-      .. tab:: `HDRP`
-
-            .. include:: includes/_hdrp-reflections.rst
-
-.. only:: urp
-
-      .. tab:: `URP`
-
-            .. include:: includes/_urp-reflections.rst
-
-
-Lighting
---------
+The Index of Refraction setting controls how much reflection contributes for different view angles.
 
 .. only:: birp
 
-      .. tab:: `BIRP`
+   .. tab:: `BIRP`
 
-            .. include:: includes/_birp-lighting.rst
+      .. include:: includes/_birp-reflections.rst
 
 .. only:: hdrp
 
-      .. tab:: `HDRP`
+   .. tab:: `HDRP`
 
-            .. include:: includes/_hdrp-lighting.rst
+      .. include:: includes/_hdrp-reflections.rst
 
 .. only:: urp
 
-      .. tab:: `URP`
+   .. tab:: `URP`
 
-            .. include:: includes/_urp-lighting.rst
+      .. include:: includes/_urp-reflections.rst
+
+
+Refractions
+^^^^^^^^^^^
+
+Refractions sample from the camera's colour texture.
+Anything rendered in the transparent pass or higher will not be included in refractions.
+
+See :ref:`transparent-object-before-ocean-surface` for issues with Crest and other refractive materials.
 
 
 .. _orthographic_projection:

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -300,6 +300,7 @@ Flow
 |  **Enable** Flow is horizontal motion in water as demonstrated in the 'whirlpool' example scene.
    'Create Flow Sim' must be enabled on the OceanRenderer to generate flow data.
 
+.. _lighting:
 
 Lighting
 --------

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -113,30 +113,17 @@ As far as we know, existing character controller assets which support swimming d
 We have an efficient API to provide water heights, which the character controller could use instead of a physics volume.
 Please request support for custom water height providers to your favourite character controller asset dev.
 
-Can I render transparent shaders/materials underwater?
-------------------------------------------------------
-This is tricky because the underwater effect uses the opaque scene depths in order to render the water fog, which will not include transparents.
+Can I render transparent objects underwater?
+--------------------------------------------
 
-.. only:: birp
+See :ref:`transparent-object-underwater`.
 
-   .. tab:: `BIRP`
+Can I render transparent objects in front of water?
+---------------------------------------------------
 
-      .. include:: includes/_underwater-curtain-transparents.rst
+See :ref:`transparent-object-before-ocean-surface`.
 
-.. only:: hdrp
+Can I render transparent objects behind the ocean surface?
+----------------------------------------------------------
 
-   .. tab:: `HDRP`
-
-      The Submarine example scene demonstrates an underwater transparent effect - the bubbles from the propellors when the submarine is in motion.
-      This effect is from the *Bubbles Propellor* GameObject, which is assigned a specific layer *TransparentFX*.
-      To drive the rendering, the *CustomPassForUnderwaterParticles* GameObject has a *Custom Pass Volume* component attached which is configured to render the *TransparentFX* layer in the *After Post Process* injection point, i.e. after the underwater postprocess has rendered.
-      Transparents rendered after the underwater postprocess will not have the underwater water fog shading applied to them.
-      The effect of the fog either needs to be faked by simply ramping the opacity down to 0 based on distance from the camera, or the water fog shader code needs included and called from teh transparent shader.
-      The shader *UnderwaterPostProcessHDRP.shader* is a good reference for calculating the underwater effect.
-      This will require various parameters on the shader like fog density and others.
-
-.. only:: urp
-
-   .. tab:: `URP`
-
-      .. include:: includes/_underwater-curtain-transparents.rst
+See :ref:`transparent-object-after-ocean-surface`.

--- a/docs/user/includes/_birp-reflections.rst
+++ b/docs/user/includes/_birp-reflections.rst
@@ -1,5 +1,3 @@
-The Index of Refraction settings control how much reflection contributes for different view angles.
-
 The base reflection comes from a one of these sources:
 
 -  Unity's specular cubemap.

--- a/docs/user/includes/_hdrp-reflections.rst
+++ b/docs/user/includes/_hdrp-reflections.rst
@@ -22,6 +22,3 @@ In such cases it can help to lower the reflection probe below sea level slightly
    If reflections appear wrong, it can be useful to make a simple test shadergraph with our water normal map applied to it, to compare results.
    We provide a simple test shadergraph for debugging purposes - enable the *Apply Test Material* debug option on the *OceanRenderer* component to apply it.
    If you find you are getting good results with a test shadergraph but not with our ocean shader, please report this to us.
-
-.. TODO:
-.. Find out why "Index of Refraction" material options are not in HDRP.

--- a/docs/user/includes/_urp-reflections.rst
+++ b/docs/user/includes/_urp-reflections.rst
@@ -1,5 +1,3 @@
-The Index of Refraction settings control how much reflection contributes for different view angles.
-
 The base reflection comes from a one of these sources:
 
 -  Unity's specular cubemap.

--- a/docs/user/rendering.rst
+++ b/docs/user/rendering.rst
@@ -4,8 +4,10 @@ Rendering
 Transparency
 ------------
 
-`Crest` is rendered in the transparent pass and its transparency is implemented by sampling the camera's colour texture.
-This makes `Crest` mostly incompatible with other transparent objects.
+`Crest` is rendered in a standard way for water shaders - in the transparent pass and refracts the scene.
+The refraction is implemented by sampling the camera's colour texture which has opaque surfaces only.
+It writes to the depth buffer during rendering to ensure overlapping waves are sorted correctly to the camera.
+The rendering of other transparent objects depends on the case, see headings below.
 Knowledge of render pipeline features, rendering order and shaders is required to solving incompatibilities.
 
 .. _transparent-object-before-ocean-surface:
@@ -13,8 +15,9 @@ Knowledge of render pipeline features, rendering order and shaders is required t
 Transparent Object In Front Of Ocean Surface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This will work correctly except for refractive objects.
-`Crest` will not be available in the camera's colour texture when other refractive objects sample from it.
+Normal transparent shaders should blend correctly in front of the water surface.
+However this will not work correctly for refractive objects.
+`Crest` will not be available in the camera's colour texture when other refractive objects sample from it, as the camera colour texture will only contain opaque surfaces.
 The end result is `Crest` not being visible behind the refractive object.
 
 .. _transparent-object-after-ocean-surface:
@@ -22,9 +25,11 @@ The end result is `Crest` not being visible behind the refractive object.
 Transparent Object Behind The Ocean Surface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This will not work.
+Alpha blend and refractive shaders will not render behind the water surface.
 Other transparent objects will not be part of the camera's colour texture when `Crest` samples from it.
 The end result is transparent objects not being visible behind `Crest`.
+
+On the other hand, alpha test / alpha cutout shaders are effectively opaque from a rendering point of view and may be usable in some scenarios.
 
 .. _transparent-object-underwater:
 

--- a/docs/user/rendering.rst
+++ b/docs/user/rendering.rst
@@ -1,0 +1,85 @@
+Rendering
+=========
+
+Transparency
+------------
+
+`Crest` is rendered in the transparent pass and its transparency is implemented by sampling the camera's colour texture.
+This makes `Crest` mostly incompatible with other transparent objects.
+Knowledge of render pipeline features, rendering order and shaders is required to solving incompatibilities.
+
+.. _transparent-object-before-ocean-surface:
+
+Transparent Object In Front Of Ocean Surface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This will work correctly except for refractive objects.
+`Crest` will not be available in the camera's colour texture when other refractive objects sample from it.
+The end result is `Crest` not being visible behind the refractive object.
+
+.. _transparent-object-after-ocean-surface:
+
+Transparent Object Behind The Ocean Surface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This will not work.
+Other transparent objects will not be part of the camera's colour texture when `Crest` samples from it.
+The end result is transparent objects not being visible behind `Crest`.
+
+.. _transparent-object-underwater:
+
+Transparent Object Underwater
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is tricky because the underwater effect uses the opaque scene depths in order to render the water fog, which will not include transparents.
+
+.. only:: birp
+
+   .. tab:: `BIRP`
+
+      .. include:: includes/_underwater-curtain-transparents.rst
+
+.. only:: hdrp
+
+   .. tab:: `HDRP`
+
+      The Submarine example scene demonstrates an underwater transparent effect - the bubbles from the propellors when the submarine is in motion.
+      This effect is from the *Bubbles Propellor* GameObject, which is assigned a specific layer *TransparentFX*.
+      To drive the rendering, the *CustomPassForUnderwaterParticles* GameObject has a *Custom Pass Volume* component attached which is configured to render the *TransparentFX* layer in the *After Post Process* injection point, i.e. after the underwater postprocess has rendered.
+      Transparents rendered after the underwater postprocess will not have the underwater water fog shading applied to them.
+      The effect of the fog either needs to be faked by simply ramping the opacity down to 0 based on distance from the camera, or the water fog shader code needs included and called from teh transparent shader.
+      The shader *UnderwaterPostProcessHDRP.shader* is a good reference for calculating the underwater effect.
+      This will require various parameters on the shader like fog density and others.
+
+.. only:: urp
+
+   .. tab:: `URP`
+
+      .. include:: includes/_underwater-curtain-transparents.rst
+
+.. only:: birp or urp
+
+   Render Order `[BIRP] [URP]`
+   ---------------------------
+
+   A typical render order for a frame is the following:
+
+   -  Opaque geometry is rendered, writes to opaque depth buffer.
+   -  Sky is rendered, probably at zfar with depth test enabled so it only renders outside the opaque surfaces.
+   -  Frame colours and depth are copied out for use later in postprocessing.
+   -  Ocean 'curtain' renders, draws underwater effect from bottom of screen up to water line.
+
+      -  Queue = Geometry+510 `[[BIRP]]`.
+         Queue = Transparent-110 `[[URP]]`.
+      -  It is set to render before ocean in UnderwaterEffect.cs.
+      -  Sky is at zfar and will be fully fogged/obscured by the water volume.
+   -  Ocean renders early in the transparent queue (queue = 2510).
+
+      -  Queue = Geometry+510 `[[BIRP]]`.
+         Queue = Transparent-100 `[[URP]]`.
+      -  It samples the postprocessing colours and depths, to do refraction.
+      -  It reads and writes from the frame depth buffer, to ensure waves are sorted correctly.
+      -  It stomps over the underwater curtain to make a correct final result.
+      -  It stomps over sky - sky is at zfar and will be fully fogged/obscured by the water volume.
+   -  Particles and alpha render. If they have depth test enabled, they will clip against the surface.
+   -  Postprocessing runs with the postprocessing depth and colours.

--- a/docs/user/rendering.rst
+++ b/docs/user/rendering.rst
@@ -1,3 +1,5 @@
+.. _rendering:
+
 Rendering
 =========
 

--- a/docs/user/technical-information.rst
+++ b/docs/user/technical-information.rst
@@ -82,31 +82,3 @@ Finally, it passes the LOD geometry scale and *lodAlpha* to the ocean fragment s
 The fragment shader samples normal and foam maps at 2 different scales, both proportional to the current and next LOD scales, and then interpolates the result using *lodAlpha* for a smooth transition.
 It combines the normal map with surface normals computed directly from the
 displacement texture.
-
-
-.. only:: birp or urp
-
-   Render Order `[BIRP] [URP]`
-   ---------------------------
-
-   A typical render order for a frame is the following:
-
-   -  Opaque geometry is rendered, writes to opaque depth buffer.
-   -  Sky is rendered, probably at zfar with depth test enabled so it only renders outside the opaque surfaces.
-   -  Frame colours and depth are copied out for use later in postprocessing.
-   -  Ocean 'curtain' renders, draws underwater effect from bottom of screen up to water line.
-
-      - Queue = Geometry+510 `[[BIRP]]`.
-        Queue = Transparent-110 `[[URP]]`.
-      -  It is set to render before ocean in UnderwaterEffect.cs.
-      -  Sky is at zfar and will be fully fogged/obscured by the water volume.
-   -  Ocean renders early in the transparent queue (queue = 2510).
-
-      - Queue = Geometry+510 `[[BIRP]]`.
-        Queue = Transparent-100 `[[URP]]`.
-      -  It samples the postprocessing colours and depths, to do refraction.
-      -  It reads and writes from the frame depth buffer, to ensure waves are sorted correctly.
-      -  It stomps over the underwater curtain to make a correct final result.
-      -  It stomps over sky - sky is at zfar and will be fully fogged/obscured by the water volume.
-   -  Particles and alpha render. If they have depth test enabled, they will clip against the surface.
-   -  Postprocessing runs with the postprocessing depth and colours.

--- a/docs/user/underwater.rst
+++ b/docs/user/underwater.rst
@@ -18,6 +18,7 @@ Only the camera rendering the ocean surface will be used.
 
    Use opaque or alpha test materials for underwater surfaces.
    Transparent materials may not render correctly underwater.
+   See :ref:`transparent-object-underwater` for possible workarounds.
 
 .. admonition:: Bug
 


### PR DESCRIPTION
I wanted to add issues with refractive materials after someone asking about the issue with HDRP. I also improved other areas too.

- Add [rendering](https://crest.readthedocs.io/en/docs-rendering-page/user/rendering.html) page which covers transparent material issues
- Updated FAQ questions to refer to said page
- Add refractions section to configuration page
- Nested reflections and refractions under [lighting](https://crest.readthedocs.io/en/docs-rendering-page/user/configuration.html#lighting) heading
- Moved "render order" section to rendering page

Let em know if you can think of any improvements.