### PR TITLE
Fix "fix" helper exception and fix help box not showing

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -74,7 +74,10 @@ namespace Crest
         internal static void FixAttachComponent<ComponentType>(SerializedObject lodInputComponent)
             where ComponentType : Component
         {
-            var gameObject = lodInputComponent.targetObject as GameObject;
+            // We will either get the component or the GameObject it is attached to.
+            var gameObject = lodInputComponent.targetObject is GameObject
+                ? lodInputComponent.targetObject as GameObject
+                : (lodInputComponent.targetObject as Component).gameObject;
             Undo.AddComponent<ComponentType>(gameObject);
         }
 
@@ -95,7 +98,10 @@ namespace Crest
 
         static void FixRemoveRenderer(SerializedObject lodInputComponent)
         {
-            var gameObject = lodInputComponent.targetObject as GameObject;
+            // We will either get the component or the GameObject it is attached to.
+            var gameObject = lodInputComponent.targetObject is GameObject
+                ? lodInputComponent.targetObject as GameObject
+                : (lodInputComponent.targetObject as Component).gameObject;
             var renderer = gameObject.GetComponent<MeshRenderer>();
             Undo.DestroyObjectImmediate(renderer);
             EditorUtility.SetDirty(gameObject);
@@ -144,11 +150,6 @@ namespace Crest
 
         public static bool ValidateInputMesh(bool rendererRequired, GameObject gameObject, ShowMessage showMessage)
         {
-            if (gameObject.TryGetComponent<Spline.Spline>(out _))
-            {
-                return true;
-            }
-
             gameObject.TryGetComponent<MeshRenderer>(out var renderer);
 
             if (!rendererRequired)

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -71,13 +71,13 @@ namespace Crest
         {
         }
 
-        internal static void FixAttachComponent<ComponentType>(SerializedObject lodInputComponent)
+        internal static void FixAttachComponent<ComponentType>(SerializedObject componentOrGameObject)
             where ComponentType : Component
         {
             // We will either get the component or the GameObject it is attached to.
-            var gameObject = lodInputComponent.targetObject is GameObject
-                ? lodInputComponent.targetObject as GameObject
-                : (lodInputComponent.targetObject as Component).gameObject;
+            var gameObject = componentOrGameObject.targetObject is GameObject
+                ? componentOrGameObject.targetObject as GameObject
+                : (componentOrGameObject.targetObject as Component).gameObject;
             Undo.AddComponent<ComponentType>(gameObject);
         }
 
@@ -96,12 +96,12 @@ namespace Crest
             mat.SetFloat(floatParam, enabled ? 1f : 0f);
         }
 
-        static void FixRemoveRenderer(SerializedObject lodInputComponent)
+        static void FixRemoveRenderer(SerializedObject componentOrGameObject)
         {
             // We will either get the component or the GameObject it is attached to.
-            var gameObject = lodInputComponent.targetObject is GameObject
-                ? lodInputComponent.targetObject as GameObject
-                : (lodInputComponent.targetObject as Component).gameObject;
+            var gameObject = componentOrGameObject.targetObject is GameObject
+                ? componentOrGameObject.targetObject as GameObject
+                : (componentOrGameObject.targetObject as Component).gameObject;
             var renderer = gameObject.GetComponent<MeshRenderer>();
             Undo.DestroyObjectImmediate(renderer);
             EditorUtility.SetDirty(gameObject);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -40,6 +40,8 @@ Fixed
    -  Fix build errors for platforms that do not support XR/VR.
    -  Fix for bugs where a large boat may stop moving when camera is close.
    -  Fix bad data being sampled from simulations when they're not enabled.
+   -  Fix null exception for attach renderer help box fix button.
+   -  Fix "remove renderer" help box not showing when it should.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Fixed a bad merge which resulted in the "remove mesh renderer" help box not showing when it should be. Also fixes an exception because we pass in either a component or GO to some of the fix functions.