### PR TITLE
Allow set ocean mat

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -142,7 +142,7 @@ namespace Crest
 
         [SerializeField, Tooltip("Material to use for the ocean surface")]
         internal Material _material = null;
-        public Material OceanMaterial { get { return _material; } }
+        public Material OceanMaterial { get { return _material; } set { _material = value; } }
 
         [SerializeField, Delayed]
         string _layerName = "Water";


### PR DESCRIPTION
From a support request - allow setting ocean material from code.

Changing it at runtime works for me so i think it was probably just waiting for the request ot make it public.

(It was slightly tempting to make the setter apply to all tiles, rather than have the tiles poll the material many times pre frame, but that should probably be a separate change).