### PR TITLE
Replace Layer Names with Layer enum

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/BoatSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/BoatSceneCore.prefab
@@ -228,7 +228,8 @@ MonoBehaviour:
   _primaryLight: {fileID: 0}
   _searchForPrimaryLightOnStartup: 1
   _material: {fileID: 2100000, guid: 9def92ac79181fe41b238e91663f0fad, type: 2}
-  _layerName: Water
+  _layerName: 
+  _layer: 4
   _gravityMultiplier: 1
   _minTexelsPerWave: 3
   _minScale: 8

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/ThreeBoatsSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/ThreeBoatsSceneCore.prefab
@@ -248,7 +248,8 @@ MonoBehaviour:
   _primaryLight: {fileID: 0}
   _searchForPrimaryLightOnStartup: 1
   _material: {fileID: 2100000, guid: 9def92ac79181fe41b238e91663f0fad, type: 2}
-  _layerName: Water
+  _layerName: 
+  _layer: 4
   _gravityMultiplier: 1
   _minTexelsPerWave: 3
   _minScale: 8

--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/Internal/MainSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/Internal/MainSceneCore.prefab
@@ -188,7 +188,8 @@ MonoBehaviour:
   _primaryLight: {fileID: 0}
   _searchForPrimaryLightOnStartup: 1
   _material: {fileID: 2100000, guid: ef94c26e44a36e24a9dcbc5995a2bed1, type: 2}
-  _layerName: Water
+  _layerName: 
+  _layer: 4
   _gravityMultiplier: 1
   _minTexelsPerWave: 3
   _minScale: 4

--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scenes/Internal/WhirlpoolSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scenes/Internal/WhirlpoolSceneCore.prefab
@@ -262,7 +262,8 @@ MonoBehaviour:
   _primaryLight: {fileID: 0}
   _searchForPrimaryLightOnStartup: 1
   _material: {fileID: 2100000, guid: 5cca1e9734badca47a1fff682d3c122b, type: 2}
-  _layerName: Water
+  _layerName: 
+  _layer: 4
   _gravityMultiplier: 1
   _minTexelsPerWave: 3
   _minScale: 8

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/EmbeddedFieldAttribute.cs
@@ -31,8 +31,7 @@ namespace Crest
             embeddedAttribute.editor.DrawEditorCombo(label, drawer, property, "asset");
         }
 
-        // Removes space above embedded editor so the embedded editor replaces this drawer.
-        internal override float? GetPropertyHeight(SerializedProperty property, GUIContent label) => 0f;
+        internal override bool NeedsControlRectangle => false;
 #endif
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/HelpBoxAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/HelpBoxAttribute.cs
@@ -1,0 +1,65 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest
+{
+    using Crest.EditorHelpers;
+    using UnityEditor;
+    using UnityEngine;
+
+    public class HelpBoxAttribute : DecoratorAttribute
+    {
+        public string message;
+        public MessageType messageType;
+        public Visibility visibility;
+
+        public enum Visibility
+        {
+            Always,
+            PropertyEnabled,
+            PropertyDisabled,
+        }
+
+#if UNITY_EDITOR
+        GUIContent guiContent;
+#endif
+
+        public HelpBoxAttribute(string message, MessageType messageType = MessageType.Info, Visibility visibility = Visibility.Always)
+        {
+            this.message = message;
+            this.messageType = messageType;
+            this.visibility = visibility;
+#if UNITY_EDITOR
+            guiContent = new GUIContent(message);
+#endif
+        }
+
+        internal override void Decorate(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
+        {
+            if (visibility == Visibility.PropertyEnabled && !GUI.enabled || visibility == Visibility.PropertyDisabled && GUI.enabled)
+            {
+                return;
+            }
+
+            // Enable rich text in help boxes. Store original so we can revert since this might be a "hack".
+            var style = GUI.skin.GetStyle("HelpBox");
+            var styleRichText = style.richText;
+            style.richText = true;
+
+            var height = style.CalcHeight(guiContent, EditorGUIUtility.currentViewWidth);
+            if (height <= EditorGUIUtility.singleLineHeight)
+            {
+                // This gets internal layout of the help box right but breaks down if multiline.
+                height += style.padding.horizontal + style.lineHeight;
+            }
+
+            // Always get a new control rect so we don't have to deal with positions and offsets.
+            position = EditorGUILayout.GetControlRect(true, height, style);
+            EditorGUI.HelpBox(position, message, messageType);
+
+            // Revert skin since it persists.
+            style.richText = styleRichText;
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/HelpBoxAttribute.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/HelpBoxAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f97cb94a75912425280b5e36761f729e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/LayerAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/LayerAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest
+{
+    using Crest.EditorHelpers;
+    using UnityEditor;
+    using UnityEngine;
+
+    public class LayerAttribute : DecoratedPropertyAttribute
+    {
+#if UNITY_EDITOR
+        internal override void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
+        {
+            property.intValue = EditorGUI.LayerField(position, label, property.intValue);
+        }
+#endif
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/LayerAttribute.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/LayerAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94fbd5fce1b9f49d0a6fdfc1e0b14926
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -35,9 +35,10 @@ namespace Crest
         internal abstract void OnGUI(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer);
 
         /// <summary>
-        /// Override this method to specify how tall the GUI for this field is in pixels.
+        /// A new control rectangle is required. Only override as false if the attribute needs to create it itself.
+        /// See the embedded attribute as an example.
         /// </summary>
-        internal virtual float? GetPropertyHeight(SerializedProperty property, GUIContent label) => null;
+        internal virtual bool NeedsControlRectangle => true;
 #endif
     }
 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
@@ -37,9 +37,8 @@ namespace Crest.EditorHelpers
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            float height = base.GetPropertyHeight(property, label);
-            // NOTE: We could add an additive height here from decorators if it makes sense to do so.
-            return ((DecoratedPropertyAttribute)attribute).GetPropertyHeight(property, label) ?? height;
+            // Make original control rectangle be invisible because we always create our own.
+            return 0;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -55,7 +54,7 @@ namespace Crest.EditorHelpers
             }
 
             var a = (DecoratedPropertyAttribute) attribute;
-            a.OnGUI(position, property, a.BuildLabel(label), this);
+            a.OnGUI(a.NeedsControlRectangle ? EditorGUILayout.GetControlRect(true) : position, property, a.BuildLabel(label), this);
 
             // Handle resetting the GUI state.
             GUI.color = originalColor;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PredicatedFieldAttribute.cs
@@ -17,7 +17,7 @@ namespace Crest
         public readonly string _propertyName;
         public readonly Type _requiredComponentType;
         public readonly bool _inverted;
-        public readonly int _disableIfValueIs;
+        public readonly object _disableIfValueIs;
 
         /// <summary>
         /// The field with this attribute will be drawn enabled/disabled based on another field. For example can be used
@@ -38,7 +38,7 @@ namespace Crest
         /// <param name="propertyName">The name of the other property whose value dictates whether this field is enabled or not.</param>
         /// <param name="inverted">Flip behaviour - for example disable if a bool field is set to true (instead of false).</param>
         /// <param name="disableIfValueIs">If the field has this value, disable the GUI (or enable if inverted is true).</param>
-        public PredicatedAttribute(string propertyName, bool inverted = false, int disableIfValueIs = 0)
+        public PredicatedAttribute(string propertyName, bool inverted = false, object disableIfValueIs = null)
         {
             _propertyName = propertyName;
             _inverted = inverted;
@@ -53,7 +53,7 @@ namespace Crest
         /// <param name="requiredComponentType">If a component of this type is not attached to this GameObject, disable the GUI (or enable if inverted is true).</param>
         /// <param name="inverted">Flip behaviour - for example disable if a bool field is set to true (instead of false).</param>
         /// <param name="disableIfValueIs">If the field has this value, disable the GUI (or enable if inverted is true).</param>
-        public PredicatedAttribute(string propertyName, Type requiredComponentType, bool inverted = false, int disableIfValueIs = 0)
+        public PredicatedAttribute(string propertyName, Type requiredComponentType, bool inverted = false, object disableIfValueIs = null)
         {
             _propertyName = propertyName;
             _requiredComponentType = requiredComponentType;
@@ -69,20 +69,25 @@ namespace Crest
             if (prop.type == "int")
             {
                 // Enable GUI if int value of field is not equal to 0, or whatever the disable-value is set to
-                result = prop.intValue != _disableIfValueIs;
+                result = prop.intValue != ((int?)_disableIfValueIs ?? 0);
             }
             else if (prop.type == "bool")
             {
                 // Enable GUI if disable-value is 0 and field is true, or disable-value is not 0 and field is false
-                result = prop.boolValue ^ (_disableIfValueIs != 0);
+                result = prop.boolValue ^ (((int?)_disableIfValueIs ?? 0) != 0);
             }
             else if (prop.type == "float")
             {
-                result = prop.floatValue != _disableIfValueIs;
+                result = prop.floatValue != ((float?)_disableIfValueIs ?? 0);
+            }
+            else if (prop.type == "string")
+            {
+                // It appears that a string value cannot be null.
+                result = prop.stringValue != ((string)_disableIfValueIs ?? "");
             }
             else if (prop.type == "Enum")
             {
-                result = prop.enumValueIndex != _disableIfValueIs;
+                result = prop.enumValueIndex != ((int?)_disableIfValueIs ?? 0);
             }
             else if (prop.type.StartsWith("PPtr"))
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -135,12 +135,19 @@ namespace Crest
                 return null;
             }
 
-            int oceanLayer = LayerMask.NameToLayer(ocean.LayerName);
-            if (oceanLayer == -1)
+            int oceanLayer = ocean.Layer;
+
+#pragma warning disable 0618
+            if (ocean.LayerName != "")
             {
-                Debug.LogError("Invalid ocean layer: " + ocean.LayerName + " please add this layer.", ocean);
-                oceanLayer = 0;
+                oceanLayer = LayerMask.NameToLayer(ocean.LayerName);
+                if (oceanLayer == -1)
+                {
+                    Debug.LogError("Invalid ocean layer: " + ocean.LayerName + " please add this layer.", ocean);
+                    oceanLayer = 0;
+                }
             }
+#pragma warning restore 0618
 
 #if PROFILE_CONSTRUCTION
             System.Diagnostics.Stopwatch sw = new System.Diagnostics.Stopwatch();

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -144,9 +144,9 @@ namespace Crest
         internal Material _material = null;
         public Material OceanMaterial { get { return _material; } set { _material = value; } }
 
-        [System.Obsolete("Layer Name (string _layerName) is deprecated. Use Layer (int _layer) instead."), HideInInspector, SerializeField]
+        [System.Obsolete("Use the _layer field instead."), HideInInspector, SerializeField]
         string _layerName = "";
-        [System.Obsolete("Layer Name (string LayerName) is deprecated. Use Layer (int Layer) instead.")]
+        [System.Obsolete("Use the Layer property instead.")]
         public string LayerName { get { return _layerName; } }
 
         [HelpBox("The <i>Layer</i> property needs to migrate the deprecated <i>Layer Name</i> property before it can be used. Please see the bottom of this component for a fix button.", MessageType.Warning, HelpBoxAttribute.Visibility.PropertyDisabled, order = 1)]

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -149,7 +149,7 @@ namespace Crest
         [System.Obsolete("Layer Name (string LayerName) is deprecated. Use Layer (int Layer) instead.")]
         public string LayerName { get { return _layerName; } }
 
-        [HelpBox("The <i>Layer</i> property needs to be migrated for it to be used. Please see the bottom of this component for a fix button.", MessageType.Warning, HelpBoxAttribute.Visibility.PropertyDisabled, order = 1)]
+        [HelpBox("The <i>Layer</i> property needs to migrate the deprecated <i>Layer Name</i> property before it can be used. Please see the bottom of this component for a fix button.", MessageType.Warning, HelpBoxAttribute.Visibility.PropertyDisabled, order = 1)]
         [Tooltip("The ocean tile renderers will have this layer.")]
         [SerializeField, Predicated("_layerName", inverted: true), Layer]
         int _layer = 4; // Water
@@ -1530,9 +1530,9 @@ namespace Crest
             {
                 showMessage
                 (
-                    "<i>Layer Name</i> on the <i>Ocean Renderer</i> is obsolete and is no longer used. " +
+                    "<i>Layer Name</i> on the <i>Ocean Renderer</i> is deprecated and will be removed. " +
                     "Use <i>Layer</i> instead.",
-                    "Set layer using the layer name to complete the migration.",
+                    "Set <i>Layer</i> using the <i>Layer Name</i> to complete the migration.",
                     ValidatedHelper.MessageType.Warning, this,
                     (SerializedObject serializedObject) =>
                     {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1532,7 +1532,7 @@ namespace Crest
                 (
                     "<i>Layer Name</i> on the <i>Ocean Renderer</i> is deprecated and will be removed. " +
                     "Use <i>Layer</i> instead.",
-                    "Set <i>Layer</i> using the <i>Layer Name</i> to complete the migration.",
+                    $"Set <i>Layer</i> to <i>{_layerName}</i> using the <i>Layer Name</i> to complete the migration.",
                     ValidatedHelper.MessageType.Warning, this,
                     (SerializedObject serializedObject) =>
                     {

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -252,7 +252,12 @@ namespace Crest
                         foreach (var message in messages)
                         {
                             EditorGUILayout.BeginHorizontal();
-                            EditorGUILayout.HelpBox(message._message + " " + message._fixDescription, messageType);
+                            var fixDescription = message._fixDescription;
+                            if (message._action != null)
+                            {
+                                fixDescription += " Click the fix/repair button on the right to fix.";
+                            }
+                            EditorGUILayout.HelpBox($"{message._message} {fixDescription}", messageType);
 
                             // Jump to object button.
                             if (message._object != null)

--- a/crest/Assets/Development/Editor/AttributeValidator.cs
+++ b/crest/Assets/Development/Editor/AttributeValidator.cs
@@ -26,8 +26,8 @@ namespace Crest
                 {
                     foreach (var property in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
                     {
-                        if (property.GetCustomAttribute<DecoratorAttribute>() == null) continue;
-                        if (property.GetCustomAttribute<DecoratedPropertyAttribute>() != null) continue;
+                        if (property.GetCustomAttributes<DecoratorAttribute>().ToList().Count == 0) continue;
+                        if (property.GetCustomAttributes<DecoratedPropertyAttribute>().ToList().Count > 0) continue;
                         Debug.LogError($"A decorator attribute on {type}.{property.Name} has no attribute which inherits from DecoratedPropertyAttribute. The decorator will be ignored.");
                     }
                 }

--- a/crest/Assets/Development/Scenes/Internal/TestScene.prefab
+++ b/crest/Assets/Development/Scenes/Internal/TestScene.prefab
@@ -9,6 +9,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -24,6 +29,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
         type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
@@ -35,16 +45,6 @@ PrefabInstance:
     - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
-        type: 3}
-      propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5000802075441277900, guid: 8417024b98e064c6ebb7f2d6110da548,
@@ -66,6 +66,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: TestScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 5000802075496966684, guid: 8417024b98e064c6ebb7f2d6110da548,
+        type: 3}
+      propertyPath: _layerName
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 5000802076805766230, guid: 8417024b98e064c6ebb7f2d6110da548,
         type: 3}

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -60,6 +60,7 @@ Fixed
    Deprecated
    ^^^^^^^^^^
    -  The *Refractive Index of Air* on the ocean material will be removed in a future version. `[BIRP] [URP]`
+   -  *Layer Name* on the *Ocean Renderer* has been deprecated. Use *Layer* instead.
 
 Documentation
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Deprecates the _Layer Name_ and adds _Layer_ to supersede it. Since a lot of people are going to hit this, I put a fair bit of effort in making sure the transition is as smooth as possible. This should make things easier in the future.

<img width="2032" alt="layer2" src="https://user-images.githubusercontent.com/5249806/118741130-6d696080-b802-11eb-9acc-1a70c61f6936.png">

I have groups changes into commits for easier digestion. Notable changes are:
- Predicated now works with strings
- Add call-to-action (eg "Click fix button") to help box message
- Add Layer attribute
- Add HelpBox attribute (it uses predicated to show/hide itself)
- Deprecated layer name. It will still be used if data is there
- Add Layer. Cannot be used until migrated

The plan is that in some future version we just remove the Layer Name and ignore the old data. By that time hopefully enough people have migrated.

I have left our scenes alone for testing/reviewing. I will migrate them once reviewed.

TODO
- Migrate our own scenes
- Test on 2020/2021