### PR TITLE
Add FFT waves

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -32,7 +32,7 @@ namespace Crest
 
         static readonly Dictionary<System.Type, string> s_simNames = new Dictionary<System.Type, string>();
 
-        static Material s_textureArrayMaterial = null;
+        static Dictionary<RenderTexture, Material> s_textureArrayMaterials = new Dictionary<RenderTexture, Material>();
 
         public static bool OverGUI(Vector2 screenPosition)
         {
@@ -198,16 +198,16 @@ namespace Crest
         {
             float column = 1f;
 
-            DrawSim<LodDataMgrAnimWaves>(OceanRenderer.Instance._lodDataAnimWaves, _drawLodDatasActualSize, ref _drawAnimWaves, ref column);
-            DrawSim<LodDataMgrDynWaves>(OceanRenderer.Instance._lodDataDynWaves, _drawLodDatasActualSize, ref _drawDynWaves, ref column);
+            DrawSim<LodDataMgrAnimWaves>(OceanRenderer.Instance._lodDataAnimWaves, _drawLodDatasActualSize, ref _drawAnimWaves, ref column, 0.5f);
+            DrawSim<LodDataMgrDynWaves>(OceanRenderer.Instance._lodDataDynWaves, _drawLodDatasActualSize, ref _drawDynWaves, ref column, 0.5f, 2f);
             DrawSim<LodDataMgrFoam>(OceanRenderer.Instance._lodDataFoam, _drawLodDatasActualSize, ref _drawFoam, ref column);
-            DrawSim<LodDataMgrFlow>(OceanRenderer.Instance._lodDataFlow, _drawLodDatasActualSize, ref _drawFlow, ref column);
+            DrawSim<LodDataMgrFlow>(OceanRenderer.Instance._lodDataFlow, _drawLodDatasActualSize, ref _drawFlow, ref column, 0.5f, 2f);
             DrawSim<LodDataMgrShadow>(OceanRenderer.Instance._lodDataShadow, _drawLodDatasActualSize, ref _drawShadow, ref column);
             DrawSim<LodDataMgrSeaFloorDepth>(OceanRenderer.Instance._lodDataSeaDepths, _drawLodDatasActualSize, ref _drawSeaFloorDepth, ref column);
             DrawSim<LodDataMgrClipSurface>(OceanRenderer.Instance._lodDataClipSurface, _drawLodDatasActualSize, ref _drawClipSurface, ref column);
         }
 
-        static void DrawSim<SimType>(LodDataMgr lodData, bool actualSize, ref bool doDraw, ref float offset) where SimType : LodDataMgr
+        static void DrawSim<SimType>(LodDataMgr lodData, bool actualSize, ref bool doDraw, ref float offset, float bias = 0f, float scale = 1f) where SimType : LodDataMgr
         {
             if (lodData == null) return;
 
@@ -238,25 +238,28 @@ namespace Crest
                         float y = idx * h;
                         if (offset == 1f) w += b;
 
-                        if (s_textureArrayMaterial == null)
+                        s_textureArrayMaterials.TryGetValue(lodData.DataTexture, out var material);
+                        if (material == null)
                         {
-                            s_textureArrayMaterial = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
+                            material = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
+                            s_textureArrayMaterials.Add(lodData.DataTexture, material);
                         }
 
                         // Render specific slice of 2D texture array
-                        s_textureArrayMaterial.SetInt("_Depth", idx);
-                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), lodData.DataTexture, s_textureArrayMaterial);
+                        material.SetInt("_Depth", idx);
+                        material.SetFloat("_Scale", scale);
+                        material.SetFloat("_Bias", bias);
+                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), lodData.DataTexture, material);
                     }
                 }
             }
-
 
             doDraw = GUI.Toggle(new Rect(x + b, togglesBegin, w - 2f * b, _bottomPanelHeight), doDraw, s_simNames[type]);
 
             offset++;
         }
 
-        public static void DrawTextureArray(RenderTexture data, int columnOffsetFromRightSide)
+        public static void DrawTextureArray(RenderTexture data, int columnOffsetFromRightSide, float bias = 0f, float scale = 1f)
         {
             int offset = columnOffsetFromRightSide;
 
@@ -280,14 +283,18 @@ namespace Crest
                         float y = idx * h;
                         if (offset == 1f) w += b;
 
-                        if (s_textureArrayMaterial == null)
+                        s_textureArrayMaterials.TryGetValue(data, out var material);
+                        if (material == null)
                         {
-                            s_textureArrayMaterial = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
+                            material = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
+                            s_textureArrayMaterials.Add(data, material);
                         }
 
                         // Render specific slice of 2D texture array
-                        s_textureArrayMaterial.SetInt("_Depth", idx);
-                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), data, s_textureArrayMaterial);
+                        material.SetInt("_Depth", idx);
+                        material.SetFloat("_Scale", scale);
+                        material.SetFloat("_Bias", bias);
+                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), data, material);
                     }
                 }
             }
@@ -305,7 +312,7 @@ namespace Crest
         {
             // Init here from 2019.3 onwards
             s_simNames.Clear();
-            s_textureArrayMaterial = null;
+            s_textureArrayMaterials.Clear();
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -62,9 +62,10 @@ namespace Crest
         public static readonly int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
         const string s_textureArrayName = "_LD_TexArray_AnimatedWaves";
 
-        static List<ShapeGerstner> _gerstners = new List<ShapeGerstner>();
-        public static void RegisterUpdatable(ShapeGerstner updatable) => _gerstners.Add(updatable);
-        public static void DeregisterUpdatable(ShapeGerstner updatable) => _gerstners.RemoveAll(candidate => candidate == updatable);
+        public interface IShapeUpdatable { void CrestUpdate(CommandBuffer buf); }
+        static List<IShapeUpdatable> _updatables = new List<IShapeUpdatable>();
+        public static void RegisterUpdatable(IShapeUpdatable updatable) => _updatables.Add(updatable);
+        public static void DeregisterUpdatable(IShapeUpdatable updatable) => _updatables.RemoveAll(candidate => candidate == updatable);
 
         SettingsType _defaultSettings;
         public SettingsType Settings
@@ -228,7 +229,7 @@ namespace Crest
                 OceanRenderer.Instance._lodTransform._renderData[lodIdx].Validate(0, SimName);
             }
 
-            foreach (var gerstner in _gerstners)
+            foreach (var gerstner in _updatables)
             {
                 gerstner.CrestUpdate(buf);
             }
@@ -454,7 +455,7 @@ namespace Crest
             sp_LD_SliceIndex = Shader.PropertyToID("_LD_SliceIndex");
             sp_LODChange = Shader.PropertyToID("_LODChange");
             s_textureArrayParamIds = new TextureArrayParamIds(s_textureArrayName);
-            _gerstners.Clear();
+            _updatables.Clear();
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1171,6 +1171,18 @@ namespace Crest
                 gerstner.Validate(ocean, ValidatedHelper.DebugLog);
             }
 
+            // ShapeGerstner
+            foreach (var component in FindObjectsOfType<ShapeGerstner>())
+            {
+                component.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
+            // ShapeFFT
+            foreach (var component in FindObjectsOfType<ShapeFFT>())
+            {
+                component.Validate(ocean, ValidatedHelper.DebugLog);
+            }
+
             // UnderwaterEffect
             var underwaters = FindObjectsOfType<UnderwaterEffect>();
             foreach (var underwater in underwaters)
@@ -1237,9 +1249,10 @@ namespace Crest
             }
 
             // ShapeGerstnerBatched
-            var gerstnerBatchs = FindObjectsOfType<ShapeGerstnerBatched>();
+            var gerstnerBatches = FindObjectsOfType<ShapeGerstnerBatched>();
             var gerstners = FindObjectsOfType<ShapeGerstner>();
-            if (gerstnerBatchs.Length == 0 && gerstners.Length == 0)
+            var ffts = FindObjectsOfType<ShapeFFT>();
+            if (gerstnerBatches.Length == 0 && gerstners.Length == 0 && ffts.Length == 0)
             {
                 showMessage
                 (

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 88e82480f13471a4ea0f380c6caa0281
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
@@ -1,0 +1,263 @@
+﻿// Crest Ocean System
+
+// Copyright 2021 Wave Harmonic Ltd
+
+// Inspired by https://github.com/speps/GX-EncinoWaves
+
+using UnityEngine;
+using UnityEngine.Rendering;
+using Object = UnityEngine.Object;
+
+namespace Crest
+{
+    /// <summary>
+    /// Runs FFT to generate water surface displacements
+    /// </summary>
+    public class FFTCompute
+    {
+        // Must match 'SIZE' param of first kernel in FFTCompute.compute
+        const int FFT_KERNEL_0_RESOLUTION = 8;
+
+        // Must match CASCADE_COUNT in FFTCompute.compute
+        const int CASCADE_COUNT = 16;
+
+        bool _isInitialised = false;
+
+        RenderTexture _spectrumInit;
+        RenderTexture _spectrumHeight;
+        RenderTexture _spectrumDisplaceX;
+        RenderTexture _spectrumDisplaceZ;
+        RenderTexture _tempFFT1;
+        RenderTexture _tempFFT2;
+        RenderTexture _tempFFT3;
+
+        Texture2D _texButterfly;
+
+        Texture2D _texSpectrumControls;
+        bool _spectrumInitialised = false;
+        Color[] _spectrumDataScratch = new Color[OceanWaveSpectrum.NUM_OCTAVES];
+
+        ComputeShader _shaderSpectrum;
+        ComputeShader _shaderFFT;
+
+        float _prevWindTurbulence;
+        float _prevWindSpeed;
+        int _prevResolution;
+
+        int _kernelSpectrumInit;
+        int _kernelSpectrumUpdate;
+
+        public void Release()
+        {
+            if (_texButterfly != null) Object.DestroyImmediate(_texButterfly);
+            if (_texSpectrumControls != null) Object.DestroyImmediate(_texSpectrumControls);
+            if (_spectrumInit != null) _spectrumInit.Release();
+            if (_spectrumHeight != null) _spectrumHeight.Release();
+            if (_spectrumDisplaceX != null) _spectrumDisplaceX.Release();
+            if (_spectrumDisplaceZ != null) _spectrumDisplaceZ.Release();
+            if (_tempFFT1 != null) _tempFFT1.Release();
+            if (_tempFFT2 != null) _tempFFT2.Release();
+            if (_tempFFT3 != null) _tempFFT3.Release();
+
+            _prevWindTurbulence = -1;
+            _prevWindSpeed = -1;
+            _prevResolution = -1;
+            _isInitialised = false;
+        }
+
+        void InitializeTextures(int resolution, OceanWaveSpectrum spectrum)
+        {
+            Release();
+
+            _shaderSpectrum = Resources.Load<ComputeShader>("FFT/FFTSpectrum");
+            _kernelSpectrumInit = _shaderSpectrum.FindKernel("SpectrumInitalize");
+            _kernelSpectrumUpdate = _shaderSpectrum.FindKernel("SpectrumUpdate");
+            _shaderFFT = Resources.Load<ComputeShader>("FFT/FFTCompute");
+
+            _texButterfly = new Texture2D(resolution, Mathf.RoundToInt(Mathf.Log(resolution, 2)), TextureFormat.RGBAFloat, false, true);
+
+            _texSpectrumControls = new Texture2D(Crest.OceanWaveSpectrum.NUM_OCTAVES, 1, TextureFormat.RFloat, false, true);
+
+            RenderTextureDescriptor rtd = new RenderTextureDescriptor();
+            rtd.width = rtd.height = resolution;
+            rtd.dimension = TextureDimension.Tex2DArray;
+            rtd.enableRandomWrite = true;
+            rtd.depthBufferBits = 0;
+            rtd.volumeDepth = CASCADE_COUNT;
+            rtd.colorFormat = RenderTextureFormat.ARGBFloat;
+            rtd.msaaSamples = 1;
+
+            _spectrumInit = new RenderTexture(rtd);
+            _spectrumInit.Create();
+
+            rtd.colorFormat = RenderTextureFormat.RGFloat;
+
+            _spectrumHeight = new RenderTexture(rtd);
+            _spectrumHeight.Create();
+            _spectrumDisplaceX = new RenderTexture(rtd);
+            _spectrumDisplaceX.Create();
+            _spectrumDisplaceZ = new RenderTexture(rtd);
+            _spectrumDisplaceZ.Create();
+
+            _tempFFT1 = new RenderTexture(rtd);
+            _tempFFT1.Create();
+            _tempFFT2 = new RenderTexture(rtd);
+            _tempFFT2.Create();
+            _tempFFT3 = new RenderTexture(rtd);
+            _tempFFT3.Create();
+
+            InitializeButterfly(resolution);
+
+            InitialiseSpectrumHandControls(spectrum);
+
+            _isInitialised = true;
+        }
+
+        /// <summary>
+        /// Computes water surface displacement, with wave components split across slices of the output texture array
+        /// </summary>
+        public void GenerateDisplacements(CommandBuffer buf, float windTurbulence, float windSpeed, float time, float chop, OceanWaveSpectrum spectrum, bool updateSpectrum, RenderTexture _outputTextureArray)
+        {
+            Debug.Assert(_outputTextureArray != null, "FFT: No output texture provided.");
+
+            var resolution = _outputTextureArray.width;
+            if (!_isInitialised || _spectrumHeight == null || _spectrumHeight.width != resolution)
+            {
+                InitializeTextures(resolution, spectrum);
+            }
+
+            if (!_spectrumInitialised || updateSpectrum)
+            {
+                InitialiseSpectrumHandControls(spectrum);
+            }
+
+            if (!Mathf.Approximately(_prevWindTurbulence, windTurbulence) ||
+                !Mathf.Approximately(_prevWindSpeed, windSpeed) ||
+                resolution != _prevResolution ||
+                updateSpectrum
+                )
+            {
+                _prevWindTurbulence = windTurbulence;
+                _prevWindSpeed = windSpeed;
+                _prevResolution = resolution;
+
+                InitializeSpectrum(buf, resolution, windSpeed, windTurbulence, spectrum._gravityScale * Mathf.Abs(Physics.gravity.magnitude));
+            }
+
+            UpdateSpectrum(buf, resolution, time);
+
+            DispatchFFT(buf, resolution, chop, _outputTextureArray);
+        }
+
+        /// <summary>
+        /// Computes the offsets used for the FFT calculation
+        /// </summary>
+        void InitializeButterfly(int resolution)
+        {
+            var log2Size = Mathf.RoundToInt(Mathf.Log(resolution, 2));
+            var butterflyColors = new Color[resolution * log2Size];
+
+            int offset = 1, numIterations = resolution >> 1;
+            for (int rowIndex = 0; rowIndex < log2Size; rowIndex++)
+            {
+                int rowOffset = rowIndex * resolution;
+                {
+                    int start = 0, end = 2 * offset;
+                    for (int iteration = 0; iteration < numIterations; iteration++)
+                    {
+                        var bigK = 0f;
+                        for (int K = start; K < end; K += 2)
+                        {
+                            var phase = 2.0f * Mathf.PI * bigK * numIterations / resolution;
+                            var cos = Mathf.Cos(phase);
+                            var sin = Mathf.Sin(phase);
+                            butterflyColors[rowOffset + K / 2] = new Color(cos, -sin, 0, 1);
+                            butterflyColors[rowOffset + K / 2 + offset] = new Color(-cos, sin, 0, 1);
+
+                            bigK += 1f;
+                        }
+                        start += 4 * offset;
+                        end = start + 2 * offset;
+                    }
+                }
+                numIterations >>= 1;
+                offset <<= 1;
+            }
+
+            _texButterfly.SetPixels(butterflyColors);
+            _texButterfly.Apply();
+        }
+
+        void InitialiseSpectrumHandControls(OceanWaveSpectrum spectrum)
+        {
+            for (var i = 0; i < OceanWaveSpectrum.NUM_OCTAVES; i++)
+            {
+                float pow = spectrum._powerDisabled[i] ? 0f : Mathf.Pow(10f, spectrum._powerLog[i]);
+                _spectrumDataScratch[i] = pow * Color.white;
+            }
+
+            _texSpectrumControls.SetPixels(_spectrumDataScratch);
+            _texSpectrumControls.Apply();
+
+            _spectrumInitialised = true;
+        }
+
+        /// <summary>
+        /// Computes base spectrum values based on wind speed & turbulence & spectrum controls
+        /// </summary>
+        void InitializeSpectrum(CommandBuffer buf, int size, float windSpeed, float windTurbulence, float gravity)
+        {
+            buf.SetComputeIntParam(_shaderSpectrum, "_Size", size);
+            buf.SetComputeFloatParam(_shaderSpectrum, "_WindSpeed", windSpeed);
+            buf.SetComputeFloatParam(_shaderSpectrum, "_Turbulence", windTurbulence);
+            buf.SetComputeFloatParam(_shaderSpectrum, "_Gravity", gravity);
+            buf.SetComputeTextureParam(_shaderSpectrum, _kernelSpectrumInit, "_SpectrumControls", _texSpectrumControls);
+            buf.SetComputeTextureParam(_shaderSpectrum, _kernelSpectrumInit, "_ResultInit", _spectrumInit);
+            buf.DispatchCompute(_shaderSpectrum, _kernelSpectrumInit, size / 8, size / 8, CASCADE_COUNT);
+        }
+
+        /// <summary>
+        /// Computes a spectrum for the current time which can be FFT'd into the final surface
+        /// </summary>
+        void UpdateSpectrum(CommandBuffer buf, int size, float time)
+        {
+            buf.SetComputeFloatParam(_shaderSpectrum, "_Time", time);
+            buf.SetComputeTextureParam(_shaderSpectrum, _kernelSpectrumUpdate, "_Init0", _spectrumInit);
+            buf.SetComputeTextureParam(_shaderSpectrum, _kernelSpectrumUpdate, "_ResultHeight", _spectrumHeight);
+            buf.SetComputeTextureParam(_shaderSpectrum, _kernelSpectrumUpdate, "_ResultDisplaceX", _spectrumDisplaceX);
+            buf.SetComputeTextureParam(_shaderSpectrum, _kernelSpectrumUpdate, "_ResultDisplaceZ", _spectrumDisplaceZ);
+            buf.DispatchCompute(_shaderSpectrum, _kernelSpectrumUpdate, size / 8, size / 8, CASCADE_COUNT);
+        }
+
+        /// <summary>
+        /// FFT the spectrum into surface displacements
+        /// </summary>
+        void DispatchFFT(CommandBuffer buf, int resolution, float chop, RenderTexture output)
+        {
+            var kernelOffset = 2 * Mathf.RoundToInt(Mathf.Log(resolution / FFT_KERNEL_0_RESOLUTION, 2f));
+
+            buf.SetComputeFloatParam(_shaderFFT, "_Chop", chop);
+
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_InputH", _spectrumHeight);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_InputX", _spectrumDisplaceX);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_InputZ", _spectrumDisplaceZ);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_InputButterfly", _texButterfly);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_Output1", _tempFFT1);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_Output2", _tempFFT2);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset, "_Output3", _tempFFT3);
+            buf.DispatchCompute(_shaderFFT, kernelOffset, 1, resolution, CASCADE_COUNT);
+
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset + 1, "_InputH", _tempFFT1);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset + 1, "_InputX", _tempFFT2);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset + 1, "_InputZ", _tempFFT3);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset + 1, "_InputButterfly", _texButterfly);
+            buf.SetComputeTextureParam(_shaderFFT, kernelOffset + 1, "_Output", output);
+            buf.DispatchCompute(_shaderFFT, kernelOffset + 1, resolution, 1, CASCADE_COUNT);
+        }
+
+        internal void OnGUI()
+        {
+            GUI.DrawTexture(new Rect(0f, 0f, 100f, 10f), _texSpectrumControls);
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c013b169ad328a41b8f3202d390aefe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -192,7 +192,7 @@ namespace Crest
             UpdateEditorOnly();
 #endif
 
-            if (_compute == null || _waveBuffers == null)
+            if (_compute == null || _waveBuffers == null || _resolution != _waveBuffers.width)
             {
                 InitData();
             }
@@ -202,7 +202,7 @@ namespace Crest
             if (!EditorApplication.isPlaying) updateDataEachFrame = true;
 #endif
             // Ensure batches assigned to correct slots
-            if (_firstUpdate || updateDataEachFrame || (_waveBuffers != null && _resolution != _waveBuffers.width))
+            if (_firstUpdate || updateDataEachFrame || (_waveBuffers != null))
             {
                 InitBatches();
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -42,7 +42,7 @@ namespace Crest
 
         [Tooltip("When true, uses the wind speed on this component rather than the wind speed from the Ocean Renderer component.")]
         public bool _overrideGlobalWindSpeed = false;
-        [Tooltip("Wind speed in km/h. Controls wave conditions."), Range(0, 150f), Predicated("_overrideGlobalWindSpeed")]
+        [Tooltip("Wind speed in km/h. Controls wave conditions."), Range(0, 150f, 2f), Predicated("_overrideGlobalWindSpeed")]
         public float _windSpeed = 20f;
 
         [Tooltip("Multiplier for these waves to scale up/down."), Range(0f, 1f)]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -18,7 +18,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape FFT")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#shapefft")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#shapefft-preview")]
     public partial class ShapeFFT : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
 #if UNITY_EDITOR
         , IReceiveSplinePointOnDrawGizmosSelectedMessages

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -28,9 +28,6 @@ namespace Crest
         [Tooltip("Impacts how aligned waves are with wind.")]
         [Range(0, 1)]
         public float _windTurbulence = 0.145f;
-        [Tooltip("Choppiness of waves.")]
-        [Range(0, 2.5f)]
-        public float _chop = 1f;
 
         [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum."), Embedded]
         public OceanWaveSpectrum _spectrum;
@@ -220,7 +217,7 @@ namespace Crest
             ReportMaxDisplacement();
 
             var windSpeedMPS = (_overrideGlobalWindSpeed ? _windSpeed : OceanRenderer.Instance._globalWindSpeed) / 3.6f;
-            _compute.GenerateDisplacements(buf, _windTurbulence, windSpeedMPS, OceanRenderer.Instance.CurrentTime, _chop, _activeSpectrum, updateDataEachFrame, _waveBuffers);
+            _compute.GenerateDisplacements(buf, _windTurbulence, windSpeedMPS, OceanRenderer.Instance.CurrentTime, _activeSpectrum, updateDataEachFrame, _waveBuffers);
 
             buf.SetGlobalVector(sp_AxisX, PrimaryWaveDirection);
             // Seems to come unbound when editing shaders at runtime, so rebinding here.

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -1,0 +1,422 @@
+﻿// Crest Ocean System
+
+// Copyright 2021 Wave Harmonic Ltd
+
+using UnityEngine;
+using UnityEngine.Rendering;
+using Crest.Spline;
+using UnityEngine.Experimental.Rendering;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Crest
+{
+    /// <summary>
+    /// FFT ocean wave shape
+    /// </summary>
+    [ExecuteAlways]
+    [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape FFT")]
+    [HelpURL("https://crest.readthedocs.io/en/latest/user/wave-conditions.html#shapefft")]
+    public partial class ShapeFFT : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
+#if UNITY_EDITOR
+        , IReceiveSplinePointOnDrawGizmosSelectedMessages
+#endif
+    {
+        [Header("Wave Conditions")]
+        [Tooltip("Impacts how aligned waves are with wind.")]
+        [Range(0, 1)]
+        public float _windTurbulence = 0.145f;
+        [Tooltip("Choppiness of waves.")]
+        [Range(0, 2.5f)]
+        public float _chop = 1f;
+
+        [Tooltip("The spectrum that defines the ocean surface shape. Assign asset of type Crest/Ocean Waves Spectrum."), Embedded]
+        public OceanWaveSpectrum _spectrum;
+        OceanWaveSpectrum _activeSpectrum = null;
+
+        [Tooltip("When true, the wave spectrum is evaluated once on startup in editor play mode and standalone builds, rather than every frame. This is less flexible but reduces the performance cost significantly."), SerializeField]
+        bool _spectrumFixedAtRuntime = true;
+
+        [Tooltip("Primary wave direction heading (deg). This is the angle from x axis in degrees that the waves are oriented towards. If a spline is being used to place the waves, this angle is relative ot the spline."), Range(-180, 180)]
+        public float _waveDirectionHeadingAngle = 0f;
+        public Vector2 PrimaryWaveDirection => new Vector2(Mathf.Cos(Mathf.PI * _waveDirectionHeadingAngle / 180f), Mathf.Sin(Mathf.PI * _waveDirectionHeadingAngle / 180f));
+
+        [Tooltip("When true, uses the wind speed on this component rather than the wind speed from the Ocean Renderer component.")]
+        public bool _overrideGlobalWindSpeed = false;
+        [Tooltip("Wind speed in km/h. Controls wave conditions."), Range(0, 150f), Predicated("_overrideGlobalWindSpeed")]
+        public float _windSpeed = 20f;
+
+        [Tooltip("Multiplier for these waves to scale up/down."), Range(0f, 1f)]
+        public float _weight = 1f;
+
+        [Tooltip("How much these waves respect the shallow water attenuation setting in the Animated Waves Settings. Set to 0 to ignore shallow water."), SerializeField, Range(0f, 1f)]
+        float _respectShallowWaterAttenuation = 1f;
+
+        [HideInInspector]
+        [Delayed, Tooltip("How many wave components to generate in each octave.")]
+        public int _componentsPerOctave = 8;
+
+        [HideInInspector]
+        [Tooltip("Change to get a different set of waves.")]
+        public int _randomSeed = 0;
+
+        [Header("Generation Settings")]
+        [Tooltip("Resolution to use for wave generation buffers. Low resolutions are more efficient but can result in noticeable patterns in the shape."), Delayed]
+        public int _resolution = 32;
+
+        [Tooltip("In Editor, shows the wave generation buffers on screen."), SerializeField]
+#pragma warning disable 414
+        bool _debugDrawSlicesInEditor = false;
+#pragma warning restore 414
+
+        [Header("Spline Settings")]
+        [SerializeField]
+        bool _overrideSplineSettings = false;
+        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedField]
+        float _radius = 50f;
+        [SerializeField, Predicated("_overrideSplineSettings"), Delayed]
+        int _subdivisions = 1;
+        [SerializeField, Predicated("_overrideSplineSettings"), Delayed]
+        int _smoothingIterations = 60;
+
+        [SerializeField]
+        float _featherWaveStart = 0.1f;
+
+        [Header("Culling")]
+        [Tooltip("Maximum amount surface will be displaced vertically from sea level. Increase this if gaps appear at bottom of screen."), SerializeField]
+        float _maxVerticalDisplacement = 10f;
+        [Tooltip("Maximum amount a point on the surface will be displaced horizontally by waves from its rest position. Increase this if gaps appear at sides of screen."), SerializeField]
+        float _maxHorizontalDisplacement = 15f;
+
+        /// <summary>
+        /// 'Raw', uncombined, wave data. Input for putting into AnimWaves data before combine pass.
+        /// </summary>
+        RenderTexture _waveBuffers;
+
+        Mesh _meshForDrawingWaves;
+
+        public class FFTBatch : ILodDataInput
+        {
+            ShapeFFT _shapeFFT;
+
+            Material _material;
+            Mesh _mesh;
+
+            int _waveBufferSliceIndex;
+
+            public FFTBatch(ShapeFFT shapeFFT, float wavelength, int waveBufferSliceIndex, Material material, Mesh mesh)
+            {
+                _shapeFFT = shapeFFT;
+                Wavelength = wavelength;
+                _waveBufferSliceIndex = waveBufferSliceIndex;
+                _mesh = mesh;
+                _material = material;
+            }
+
+            // The ocean input system uses this to decide which lod this batch belongs in
+            public float Wavelength { get; private set; }
+
+            public bool Enabled { get => true; set { } }
+
+            public void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
+            {
+                var finalWeight = weight * _shapeFFT._weight;
+                if (finalWeight > 0f)
+                {
+                    buf.SetGlobalInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
+                    buf.SetGlobalFloat(RegisterLodDataInputBase.sp_Weight, finalWeight);
+                    buf.SetGlobalInt(sp_WaveBufferSliceIndex, _waveBufferSliceIndex);
+                    buf.SetGlobalFloat(sp_AverageWavelength, Wavelength * 1.5f);
+                    // Either use a full screen quad, or a provided mesh renderer to draw the waves
+                    if (_mesh == null)
+                    {
+                        buf.DrawProcedural(Matrix4x4.identity, _material, 0, MeshTopology.Triangles, 3);
+                    }
+                    else if (_material != null)
+                    {
+                        buf.DrawMesh(_mesh, _shapeFFT.transform.localToWorldMatrix, _material);
+                    }
+                }
+            }
+        }
+
+        const int CASCADE_COUNT = 16;
+
+        FFTBatch[] _batches = null;
+        FFTCompute _compute = null;
+
+        // Used to populate data on first frame
+        bool _firstUpdate = true;
+
+        Material _matGenerateWaves;
+
+        static readonly int sp_WaveBuffer = Shader.PropertyToID("_WaveBuffer");
+        static readonly int sp_WaveBufferSliceIndex = Shader.PropertyToID("_WaveBufferSliceIndex");
+        static readonly int sp_AverageWavelength = Shader.PropertyToID("_AverageWavelength");
+        static readonly int sp_RespectShallowWaterAttenuation = Shader.PropertyToID("_RespectShallowWaterAttenuation");
+        static readonly int sp_FeatherWaveStart = Shader.PropertyToID("_FeatherWaveStart");
+        readonly int sp_AxisX = Shader.PropertyToID("_AxisX");
+
+        void InitData()
+        {
+            // Raw wave data buffer
+            _waveBuffers = new RenderTexture(_resolution, _resolution, 0, GraphicsFormat.R16G16B16A16_SFloat);
+            _waveBuffers.wrapMode = TextureWrapMode.Repeat;
+            _waveBuffers.antiAliasing = 1;
+            _waveBuffers.filterMode = FilterMode.Bilinear;
+            _waveBuffers.anisoLevel = 0;
+            _waveBuffers.useMipMap = false;
+            _waveBuffers.name = "FFTCascades";
+            _waveBuffers.dimension = TextureDimension.Tex2DArray;
+            _waveBuffers.volumeDepth = CASCADE_COUNT;
+            _waveBuffers.enableRandomWrite = true;
+            _waveBuffers.Create();
+
+            Debug.Assert(Mathf.NextPowerOfTwo(_resolution) == _resolution, "Resolution must be power of 2");
+            _compute = new FFTCompute();
+        }
+
+        /// <summary>
+        /// Min wavelength for a cascade in the wave buffer. Does not depend on viewpoint.
+        /// </summary>
+        public float MinWavelength(int cascadeIdx)
+        {
+            var diameter = 0.5f * (1 << cascadeIdx);
+            var texelSize = diameter / _resolution;
+            // Nyquist rate
+            return texelSize * 2f;
+        }
+
+        public void CrestUpdate(CommandBuffer buf)
+        {
+#if UNITY_EDITOR
+            UpdateEditorOnly();
+#endif
+
+            if (_compute == null || _waveBuffers == null)
+            {
+                InitData();
+            }
+
+            var updateDataEachFrame = !_spectrumFixedAtRuntime;
+#if UNITY_EDITOR
+            if (!EditorApplication.isPlaying) updateDataEachFrame = true;
+#endif
+            // Ensure batches assigned to correct slots
+            if (_firstUpdate || updateDataEachFrame || (_waveBuffers != null && _resolution != _waveBuffers.width))
+            {
+                InitBatches();
+
+                _firstUpdate = false;
+            }
+
+            _matGenerateWaves.SetFloat(sp_RespectShallowWaterAttenuation, _respectShallowWaterAttenuation);
+            _matGenerateWaves.SetFloat(sp_FeatherWaveStart, _featherWaveStart);
+            // Seems like shader errors cause this to unbind if I don't set it every frame. Could be an editor only issue.
+            _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);
+
+            ReportMaxDisplacement();
+
+            var windSpeedMPS = (_overrideGlobalWindSpeed ? _windSpeed : OceanRenderer.Instance._globalWindSpeed) / 3.6f;
+            _compute.GenerateDisplacements(buf, _windTurbulence, windSpeedMPS, OceanRenderer.Instance.CurrentTime, _chop, _activeSpectrum, updateDataEachFrame, _waveBuffers);
+
+            buf.SetGlobalVector(sp_AxisX, PrimaryWaveDirection);
+            // Seems to come unbound when editing shaders at runtime, so rebinding here.
+            _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);
+        }
+
+#if UNITY_EDITOR
+        void UpdateEditorOnly()
+        {
+            if (_spectrum != null)
+            {
+                _activeSpectrum = _spectrum;
+            }
+
+            if (_activeSpectrum == null)
+            {
+                _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
+                _activeSpectrum.name = "Default Waves (auto)";
+            }
+
+            // Unassign mesh
+            if (_meshForDrawingWaves != null && !TryGetComponent<Spline.Spline>(out _))
+            {
+                _meshForDrawingWaves = null;
+            }
+        }
+#endif
+
+        void ReportMaxDisplacement()
+        {
+            OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxHorizontalDisplacement, _maxVerticalDisplacement, _maxVerticalDisplacement);
+        }
+
+        void InitBatches()
+        {
+            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+
+            if (_batches != null)
+            {
+                foreach (var batch in _batches)
+                {
+                    registered.Remove(batch);
+                }
+            }
+
+            if (TryGetComponent<Spline.Spline>(out var splineForWaves))
+            {
+                var radius = _overrideSplineSettings ? _radius : splineForWaves.Radius;
+                var subdivs = _overrideSplineSettings ? _subdivisions : splineForWaves.Subdivisions;
+                var smooth = _overrideSplineSettings ? _smoothingIterations : splineForWaves.SmoothingIterations;
+                if (ShapeGerstnerSplineHandling.GenerateMeshFromSpline(splineForWaves, transform, subdivs, radius, smooth, Vector2.one, ref _meshForDrawingWaves))
+                {
+                    _meshForDrawingWaves.name = gameObject.name + "_mesh";
+                }
+            }
+
+            if (_meshForDrawingWaves == null)
+            {
+                _matGenerateWaves = new Material(Shader.Find("Hidden/Crest/Inputs/Animated Waves/Gerstner Global"));
+            }
+            else
+            {
+                _matGenerateWaves = new Material(Shader.Find("Crest/Inputs/Animated Waves/Gerstner Geometry"));
+            }
+
+            // Submit draws to create the FFT waves
+            _batches = new FFTBatch[CASCADE_COUNT];
+            for (int i = 0; i < CASCADE_COUNT; i++)
+            {
+                if (i == -1) break;
+                _batches[i] = new FFTBatch(this, MinWavelength(i), i, _matGenerateWaves, _meshForDrawingWaves);
+                registered.Add(0, _batches[i]);
+            }
+        }
+
+        private void OnEnable()
+        {
+            _firstUpdate = true;
+
+            // Initialise with spectrum
+            if (_spectrum != null)
+            {
+                _activeSpectrum = _spectrum;
+            }
+#if UNITY_EDITOR
+            if (_activeSpectrum == null)
+            {
+                _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
+                _activeSpectrum.name = "Default Waves (auto)";
+            }
+
+            if (EditorApplication.isPlaying && !Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
+            {
+                enabled = false;
+                return;
+            }
+
+            _activeSpectrum.Upgrade();
+#endif
+
+            LodDataMgrAnimWaves.RegisterUpdatable(this);
+        }
+
+        void OnDisable()
+        {
+            LodDataMgrAnimWaves.DeregisterUpdatable(this);
+
+            if (_batches != null)
+            {
+                var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
+                foreach (var batch in _batches)
+                {
+                    registered.Remove(batch);
+                }
+
+                _batches = null;
+            }
+
+            if (_compute != null)
+            {
+                _compute.Release();
+                _compute = null;
+            }
+
+            if (_waveBuffers != null)
+            {
+#if UNITY_EDITOR
+                if (!EditorApplication.isPlaying)
+                {
+                    DestroyImmediate(_waveBuffers);
+                }
+                else
+#endif
+                {
+                    Destroy(_waveBuffers);
+                }
+                _waveBuffers = null;
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmosSelected()
+        {
+            DrawMesh();
+        }
+
+        void DrawMesh()
+        {
+            if (_meshForDrawingWaves != null)
+            {
+                Gizmos.color = RegisterAnimWavesInput.s_gizmoColor;
+                Gizmos.DrawWireMesh(_meshForDrawingWaves, 0, transform.position, transform.rotation, transform.lossyScale);
+            }
+        }
+
+        void OnGUI()
+        {
+            if (_debugDrawSlicesInEditor && _compute != null)
+            {
+                OceanDebugGUI.DrawTextureArray(_waveBuffers, 8, 0.5f, 20f);
+                //OceanDebugGUI.DrawTextureArray(_compute.spectrumHeight, 9, 0.5f, 120f);
+
+                _compute.OnGUI();
+            }
+        }
+
+        public void OnSplinePointDrawGizmosSelected(SplinePoint point)
+        {
+            DrawMesh();
+        }
+#endif
+    }
+
+#if UNITY_EDITOR
+    public partial class ShapeFFT : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = true;
+
+            if (TryGetComponent<Spline.Spline>(out var spline) && !spline.Validate(ocean, ValidatedHelper.Suppressed))
+            {
+                showMessage
+                (
+                    "A <i>Spline</i> component is attached but it has validation errors.",
+                    "Check this component in the Inspector for issues.",
+                    ValidatedHelper.MessageType.Error, this
+                );
+            }
+
+            return isValid;
+        }
+    }
+
+    // Here for the help boxes
+    [CustomEditor(typeof(ShapeFFT))]
+    public class ShapeFFTEditor : ValidatedEditor { }
+#endif
+}

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -18,7 +18,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape FFT")]
-    [HelpURL("https://crest.readthedocs.io/en/latest/user/wave-conditions.html#shapefft")]
+    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#shapefft")]
     public partial class ShapeFFT : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
 #if UNITY_EDITOR
         , IReceiveSplinePointOnDrawGizmosSelectedMessages

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -211,6 +211,7 @@ namespace Crest
 
             _matGenerateWaves.SetFloat(sp_RespectShallowWaterAttenuation, _respectShallowWaterAttenuation);
             _matGenerateWaves.SetFloat(sp_FeatherWaveStart, _featherWaveStart);
+            _matGenerateWaves.SetVector(sp_AxisX, PrimaryWaveDirection);
             // Seems like shader errors cause this to unbind if I don't set it every frame. Could be an editor only issue.
             _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);
 
@@ -219,7 +220,6 @@ namespace Crest
             var windSpeedMPS = (_overrideGlobalWindSpeed ? _windSpeed : OceanRenderer.Instance._globalWindSpeed) / 3.6f;
             _compute.GenerateDisplacements(buf, _windTurbulence, windSpeedMPS, OceanRenderer.Instance.CurrentTime, _activeSpectrum, updateDataEachFrame, _waveBuffers);
 
-            buf.SetGlobalVector(sp_AxisX, PrimaryWaveDirection);
             // Seems to come unbound when editing shaders at runtime, so rebinding here.
             _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);
         }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a57126133720c243a7af00a156c9ee8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -45,10 +45,9 @@ namespace Crest
         [Tooltip("Multiplier which scales waves"), Range(0f, 10f), SerializeField]
         float _multiplier = 1f;
 
-        // TODO divide these by log10(25)
         [HideInInspector, SerializeField]
         internal float[] _powerLog = new float[NUM_OCTAVES]
-            { -5.710145f, -5.841546f, -5.17913f, -4.4710717f, -3.480769f, -2.6996124f, -2.615044f, -1.2080691f, -0.53905386f, 0.27448857f, 0.53627354f, 1.0282621f, 1.4403292f, -6f };
+            { -5.71f, -5.03f, -4.54f, -3.88f, -3.28f, -2.32f, -1.78f, -1.21f, -0.54f, 0.28f, 0.54f, 1.03f, 1.44f, -8f };
 
         [HideInInspector, SerializeField]
         internal bool[] _powerDisabled = new bool[NUM_OCTAVES];
@@ -64,6 +63,21 @@ namespace Crest
         [Tooltip("Scales horizontal displacement"), Range(0f, 2f)]
         public float _chop = 1.6f;
 
+        void Reset()
+        {
+            // Auto-upgrade any new data objects directly to v1. This is in lieu of simply
+            // giving _version a default value of 1 to distuingish new data, which we can't do
+            // because _version is not present in the old data at all.
+            // TODO: after a few releases, we can be sure _version will be present in the data.
+            // At this point we can bump _version to a default value of 1 and from that point
+            // onwards know that version is correct, and this auto upgrade path can go away.
+            for (int i = 0; i < _powerLog.Length; i++)
+            {
+                // This is equivalent to power /= 25, in log10 space
+                _powerLog[i] -= 1.39794f;
+            }
+            _version = 1;
+        }
 
 #if UNITY_EDITOR
 #pragma warning disable 414
@@ -162,7 +176,7 @@ namespace Crest
             // Amplitude
             var a = Mathf.Sqrt(a_2);
 
-            // Gerstner fudge - one hack to get Gerstners looking on par with FFT
+            // Gerstner fudge -one hack to get Gerstners looking on par with FFT
             if (_version > 0)
             {
                 a *= 5f;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -16,13 +16,20 @@ namespace Crest
     [CreateAssetMenu(fileName = "OceanWaves", menuName = "Crest/Ocean Wave Spectrum", order = 10000)]
     public class OceanWaveSpectrum : ScriptableObject
     {
+        /// <summary>
+        /// The version of this asset. Can be used to migrate across versions. This value should
+        /// only be changed when the editor upgrades the version.
+        /// </summary>
+        [SerializeField, HideInInspector]
+        int _version = 0;
+
         public const int NUM_OCTAVES = 14;
         public static readonly float SMALLEST_WL_POW_2 = -4f;
 
         [HideInInspector]
         public float _fetch = 500000f;
 
-        public static readonly float MIN_POWER_LOG = -7f;
+        public static readonly float MIN_POWER_LOG = -8f;
         public static readonly float MAX_POWER_LOG = 5f;
 
         [Tooltip("Variance of wave directions, in degrees"), Range(0f, 180f)]
@@ -38,11 +45,11 @@ namespace Crest
         float _multiplier = 1f;
 
         [HideInInspector, SerializeField]
-        float[] _powerLog = new float[NUM_OCTAVES]
+        internal float[] _powerLog = new float[NUM_OCTAVES]
             { -5.710145f, -5.841546f, -5.17913f, -4.4710717f, -3.480769f, -2.6996124f, -2.615044f, -1.2080691f, -0.53905386f, 0.27448857f, 0.53627354f, 1.0282621f, 1.4403292f, -6f };
 
         [HideInInspector, SerializeField]
-        bool[] _powerDisabled = new bool[NUM_OCTAVES];
+        internal bool[] _powerDisabled = new bool[NUM_OCTAVES];
 
         [HideInInspector]
         public float[] _chopScales = new float[NUM_OCTAVES]
@@ -64,9 +71,7 @@ namespace Crest
         public enum SpectrumModel
         {
             None,
-            Phillips,
             PiersonMoskowitz,
-            JONSWAP,
         }
 
 #pragma warning disable 414
@@ -143,15 +148,23 @@ namespace Crest
             power = hasNextIndex ? Mathf.Lerp(thisPower, nextPower, alpha) : thisPower;
             power = Mathf.Pow(10f, power);
 
-            var c = ComputeWaveSpeed(wavelength);
+            // Empirical wind influence based on alpha-beta spectrum that underlies empirical spectra
+            var gravity = _gravityScale * Mathf.Abs(Physics.gravity.y);
+            var B = 1.291f;
+            var wm = 0.87f * gravity / windSpeed;
+            DeepDispersion(2f * Mathf.PI / wavelength, gravity, out var w);
+            power *= Mathf.Exp(-B * Mathf.Pow(wm / w, 4.0f));
 
-            // Dampen based on wind. Waves travelling faster than wind get dampened. 0.75
-            // is arbitrary value to give some 'ramp' in the multiplier.
-            power *= Mathf.SmoothStep(0f, 1f, Mathf.InverseLerp(windSpeed, windSpeed * 0.75f, c));
             var a_2 = 2f * power * domega;
 
             // Amplitude
             var a = Mathf.Sqrt(a_2);
+
+            // Gerstner fudge - one hack to get Gerstners looking on par with FFT
+            if (_version > 0)
+            {
+                a *= 5f;
+            }
 
             return a * _multiplier;
         }
@@ -187,8 +200,8 @@ namespace Crest
                 {
                     var index = octave * componentsPerOctave + i;
 
-                    // stratified random sampling - should give a better range of wavelengths, and also means i can generated the
-                    // wavelengths in sorted order!
+                    // Stratified random sampling - should give a better distribution of wavelengths, and also means i can generate
+                    // the wavelengths in ascending order!
                     var minWavelengthi = minWavelength + invComponentsPerOctave * minWavelength * i;
                     var maxWavelengthi = Mathf.Min(minWavelengthi + invComponentsPerOctave * minWavelength, 2f * minWavelength);
                     wavelengths[index] = Mathf.Lerp(minWavelengthi, maxWavelengthi, Random.value);
@@ -201,116 +214,42 @@ namespace Crest
             }
         }
 
-        public void ApplyPhillipsSpectrum(float windSpeed, float smallWavelengthMultiplier)
+        // This applies the correct PM spectrum powers, validated against a separate implementation
+        public void ApplyPiersonMoskowitzSpectrum()
         {
-            // Angles should usually be relative to wind direction, so setting wind direction to angle=0 should be ok.
-            var windDir = Vector2.right;
+            var gravity = Physics.gravity.magnitude;
 
             for (int octave = 0; octave < NUM_OCTAVES; octave++)
             {
-                // Shift wavelengths based on a magic number of this spectrum which seems to give small waves.
-                var wl = SmallWavelength(octave) * smallWavelengthMultiplier * 1.5f;
+                var wl = SmallWavelength(octave);
 
-                var pow = PhillipsSpectrum(windSpeed, windDir, Mathf.Abs(Physics.gravity.y), wl, 0f);
+                var pow = PiersonMoskowitzSpectrum(gravity, wl);
+
                 // we store power on logarithmic scale. this does not include 0, we represent 0 as min value
                 pow = Mathf.Max(pow, Mathf.Pow(10f, MIN_POWER_LOG));
+
                 _powerLog[octave] = Mathf.Log10(pow);
             }
         }
 
-        public void ApplyPiersonMoskowitzSpectrum(float windSpeed, float smallWavelengthMultiplier)
+        // Alpha-beta spectrum without the beta. Beta represents wind influence and is evaluated at runtime
+        // for 'current' wind conditions
+        static float AlphaSpectrum(float A, float g, float w)
         {
-            for (int octave = 0; octave < NUM_OCTAVES; octave++)
-            {
-                // Shift wavelengths based on a magic number of this spectrum which seems to give small waves.
-                var wl = SmallWavelength(octave) * smallWavelengthMultiplier * 9f;
-
-                var pow = PiersonMoskowitzSpectrum(Mathf.Abs(Physics.gravity.y), windSpeed, wl);
-                // we store power on logarithmic scale. this does not include 0, we represent 0 as min value
-                pow = Mathf.Max(pow, Mathf.Pow(10f, MIN_POWER_LOG));
-                _powerLog[octave] = Mathf.Log10(pow);
-            }
+            return A * g * g / Mathf.Pow(w, 5.0f);
         }
 
-        public void ApplyJONSWAPSpectrum(float windSpeed, float fetch, float smallWavelengthMultiplier)
+        static void DeepDispersion(float k, float gravity, out float w)
         {
-            for (int octave = 0; octave < NUM_OCTAVES; octave++)
-            {
-                // Shift wavelengths based on a magic number of this spectrum which seems to give small waves.
-                var wl = SmallWavelength(octave) * smallWavelengthMultiplier * 9f;
-
-                var pow = JONSWAPSpectrum(Mathf.Abs(Physics.gravity.y), windSpeed, wl, fetch);
-                // we store power on logarithmic scale. this does not include 0, we represent 0 as min value
-                pow = Mathf.Max(pow, Mathf.Pow(10f, MIN_POWER_LOG));
-                _powerLog[octave] = Mathf.Log10(pow);
-            }
+            w = Mathf.Sqrt(gravity * k);
         }
 
-        static float PhillipsSpectrum(float windSpeed, Vector2 windDir, float gravity, float wavelength, float angle)
+        static float PiersonMoskowitzSpectrum(float gravity, float wavelength)
         {
-            var wavenumber = 2f * Mathf.PI / wavelength;
-            var angle_radians = Mathf.PI * angle / 180f;
-            var kx = Mathf.Cos(angle_radians) * wavenumber;
-            var kz = Mathf.Sin(angle_radians) * wavenumber;
-
-            var k2 = kx * kx + kz * kz;
-
-            var windSpeed2 = windSpeed * windSpeed;
-            var wx = windDir.x;
-            var wz = windDir.y;
-
-            var kdotw = (wx * kx + wz * kz);
-
-            var a = 0.0081f; // phillips constant ( https://hal.archives-ouvertes.fr/file/index/docid/307938/filename/frechot_realistic_simulation_of_ocean_surface_using_wave_spectra.pdf )
-            var L = windSpeed2 / gravity;
-
-            // http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.161.9102&rep=rep1&type=pdf
-            return a * kdotw * kdotw * Mathf.Exp(-1f / (k2 * L * L)) / (k2 * k2);
-        }
-
-        // base of modern parametric wave spectrum
-        static float PhilSpectrum(float gravity, float wavelength)
-        {
-            var alpha = 0.0081f; // phillips constant ( https://hal.archives-ouvertes.fr/file/index/docid/307938/filename/frechot_realistic_simulation_of_ocean_surface_using_wave_spectra.pdf )
-            return PhilSpectrum(gravity, alpha, wavelength);
-        }
-        // base of modern parametric wave spectrum
-        static float PhilSpectrum(float gravity, float alpha, float wavelength)
-        {
-            //float alpha = 0.0081f; // phillips constant ( https://hal.archives-ouvertes.fr/file/index/docid/307938/filename/frechot_realistic_simulation_of_ocean_surface_using_wave_spectra.pdf )
-            var wavenumber = 2f * Mathf.PI / wavelength;
-            var frequency = Mathf.Sqrt(gravity * wavenumber); // deep water - depth > wavelength/2
-            return alpha * gravity * gravity / Mathf.Pow(frequency, 5f);
-        }
-
-        static float PiersonMoskowitzSpectrum(float gravity, float windspeed, float wavelength)
-        {
-            var wavenumber = 2f * Mathf.PI / wavelength;
-            var frequency = Mathf.Sqrt(gravity * wavenumber); // deep water - depth > wavelength/2
-            var frequency_peak = 0.855f * gravity / windspeed;
-            return PhilSpectrum(gravity, wavelength) * Mathf.Exp(-Mathf.Pow(frequency_peak / frequency, 4f) * 5f / 4f);
-        }
-        static float PiersonMoskowitzSpectrum(float gravity, float windspeed, float frequency_peak, float alpha, float wavelength)
-        {
-            float wavenumber = 2f * Mathf.PI / wavelength;
-            float frequency = Mathf.Sqrt(gravity * wavenumber); // deep water - depth > wavelength/2
-            return PhilSpectrum(gravity, alpha, wavelength) * Mathf.Exp(-Mathf.Pow(frequency_peak / frequency, 4f) * 5f / 4f);
-        }
-
-        static float JONSWAPSpectrum(float gravity, float windspeed, float wavelength, float fetch)
-        {
-            // fetch distance
-            var F = fetch;
-            var alpha = 0.076f * Mathf.Pow(windspeed * windspeed / (F * gravity), 0.22f);
-
-            var wavenumber = 2f * Mathf.PI / wavelength;
-            var frequency = Mathf.Sqrt(gravity * wavenumber); // deep water - depth > wavelength/2
-            var frequency_peak = 22f * Mathf.Pow(gravity * gravity / (windspeed * F), 1f / 3f);
-            var sigma = frequency <= frequency_peak ? 0.07f : 0.09f;
-            var r = Mathf.Exp(-Mathf.Pow(frequency - frequency_peak, 2f) / (2f * sigma * sigma * frequency_peak * frequency_peak));
-            var gamma = 3.3f;
-
-            return PiersonMoskowitzSpectrum(gravity, windspeed, frequency_peak, alpha, wavelength) * Mathf.Pow(gamma, r);
+            var k = 2f * Mathf.PI / wavelength;
+            DeepDispersion(k, gravity, out var w);
+            var phillipsConstant = 8.1e-3f;
+            return AlphaSpectrum(phillipsConstant, gravity, w);
         }
 
 #if UNITY_EDITOR
@@ -331,13 +270,8 @@ namespace Crest
         readonly static string[] modelDescriptions = new string[]
         {
             "Select an option to author waves using a spectrum model.",
-            "Base of modern parametric wave spectra.",
             "Fully developed sea with infinite fetch.",
-            "Fetch limited sea where waves continue to grow.",
         };
-
-        static GUIContent s_labelSWM = new GUIContent("Small wavelength modifier", "Modifies parameters for the empirical spectra, tends to boost smaller wavelengths");
-        static GUIContent s_labelFetch = new GUIContent("Fetch", "Length of area that wind excites waves. Applies only to JONSWAP");
 
         public static void UpgradeSpectrum(SerializedProperty prop, float defaultValue)
         {
@@ -370,14 +304,41 @@ namespace Crest
             }
         }
 
+        static void Upgrade(SerializedObject soSpectrum)
+        {
+            var spVer = soSpectrum.FindProperty("_version");
+
+            // Upgrade to version 1: Calibrate spectrum power values to make gerstner waves match FFT.
+            if (spVer.intValue == 0)
+            {
+                var powValues = soSpectrum.FindProperty("_powerLog");
+                for (int i = 0; i < powValues.arraySize; i++)
+                {
+                    float pow = powValues.GetArrayElementAtIndex(i).floatValue;
+                    pow = Mathf.Pow(10f, pow);
+                    pow /= 25f;
+                    pow = Mathf.Log10(pow);
+                    powValues.GetArrayElementAtIndex(i).floatValue = pow;
+                }
+                spVer.intValue = spVer.intValue + 1;
+            }
+
+            // Future: Upgrade to version 2: ...
+
+            soSpectrum.ApplyModifiedProperties();
+        }
+
         public override void OnInspectorGUI()
         {
+            Upgrade(serializedObject);
+
             base.OnInspectorGUI();
 
             var showAdvancedControls = serializedObject.FindProperty("_showAdvancedControls").boolValue;
 
             var spSpectrumModel = serializedObject.FindProperty("_model");
-            var spectrumModel = (OceanWaveSpectrum.SpectrumModel)serializedObject.FindProperty("_model").enumValueIndex;
+            var spectraIndex = serializedObject.FindProperty("_model").enumValueIndex;
+            var spectrumModel = (OceanWaveSpectrum.SpectrumModel)Mathf.Min(spectraIndex, 1);
 
             EditorGUILayout.Space();
 
@@ -481,38 +442,14 @@ namespace Crest
                 // It doesn't seem to matter where this is called.
                 Undo.RecordObject(spec, $"Apply {ObjectNames.NicifyVariableName(spectrumModel.ToString())} Spectrum");
 
-                if (spectrumModel == OceanWaveSpectrum.SpectrumModel.JONSWAP)
-                {
-                    EditorGUILayout.PropertyField(serializedObject.FindProperty("_smallWavelengthMultiplier"));
-
-                    var maxLin = 4000f;
-                    var exponent = 4f;
-                    var maxExp = Mathf.Pow(maxLin, 1f / exponent);
-                    spec._fetch = Mathf.Clamp(EditorGUILayout.FloatField(s_labelFetch, spec._fetch), 0f, maxLin);
-                    var fetchNonLin = Mathf.Pow(spec._fetch, 1f / exponent);
-                    spec._fetch = Mathf.Pow(GUI.HorizontalSlider(EditorGUILayout.GetControlRect(false), fetchNonLin, 0, maxExp), exponent);
-                }
-
-                // Wind speed is taken into account during wave generation, not for the spectrum
-                var windSpeed = 10000f;
 
                 // Descriptions from this very useful paper:
                 // https://hal.archives-ouvertes.fr/file/index/docid/307938/filename/frechot_realistic_simulation_of_ocean_surface_using_wave_spectra.pdf
 
                 switch (spectrumModel)
                 {
-                    case OceanWaveSpectrum.SpectrumModel.Phillips:
-                        spec.ApplyPhillipsSpectrum(windSpeed, 1f);
-                        break;
                     case OceanWaveSpectrum.SpectrumModel.PiersonMoskowitz:
-                        // Magic number that seems to work well
-                        var swm = 0.42f;
-                        spec.ApplyPiersonMoskowitzSpectrum(windSpeed, swm);
-                        break;
-                    case OceanWaveSpectrum.SpectrumModel.JONSWAP:
-                        // Magic number that seems to work well when user has it set to 1
-                        var smallWavelengthMul = 0.0419265f * spec._smallWavelengthMultiplier;
-                        spec.ApplyJONSWAPSpectrum(windSpeed, spec._fetch, smallWavelengthMul);
+                        spec.ApplyPiersonMoskowitzSpectrum();
                         break;
                 }
             }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -23,6 +23,7 @@ namespace Crest
         [SerializeField, HideInInspector]
         int _version = 0;
 
+        // These must match corresponding constants in FFTSpectrum.compute
         public const int NUM_OCTAVES = 14;
         public static readonly float SMALLEST_WL_POW_2 = -4f;
 
@@ -44,6 +45,7 @@ namespace Crest
         [Tooltip("Multiplier which scales waves"), Range(0f, 10f), SerializeField]
         float _multiplier = 1f;
 
+        // TODO divide these by log10(25)
         [HideInInspector, SerializeField]
         internal float[] _powerLog = new float[NUM_OCTAVES]
             { -5.710145f, -5.841546f, -5.17913f, -4.4710717f, -3.480769f, -2.6996124f, -2.615044f, -1.2080691f, -0.53905386f, 0.27448857f, 0.53627354f, 1.0282621f, 1.4403292f, -6f };

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -42,8 +42,8 @@ namespace Crest
         [Range(0f, 2f), HideInInspector]
         public float _smallWavelengthMultiplier = 1f;
 
-        [Tooltip("Multiplier which scales waves"), Range(0f, 10f), SerializeField]
-        float _multiplier = 1f;
+        [Tooltip("Multiplier which scales waves"), Range(0f, 10f)]
+        public float _multiplier = 1f;
 
         [HideInInspector, SerializeField]
         internal float[] _powerLog = new float[NUM_OCTAVES]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -33,7 +33,7 @@ namespace Crest
         public static readonly float MIN_POWER_LOG = -8f;
         public static readonly float MAX_POWER_LOG = 5f;
 
-        [Tooltip("Variance of wave directions, in degrees"), Range(0f, 180f)]
+        [Tooltip("Variance of wave directions, in degrees. Gerstner-only - use the Turbulence param on the ShapeFFT component for FFT."), Range(0f, 180f)]
         public float _waveDirectionVariance = 90f;
 
         [Tooltip("More gravity means faster waves."), Range(0f, 25f)]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -21,7 +21,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#shapegerstner-preview")]
-    public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin
+    public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin, LodDataMgrAnimWaves.IShapeUpdatable
         , ISplinePointCustomDataSetup
 #if UNITY_EDITOR
         , IReceiveSplinePointOnDrawGizmosSelectedMessages
@@ -236,7 +236,8 @@ namespace Crest
         {
             var diameter = 0.5f * (1 << cascadeIdx);
             var texelSize = diameter / _resolution;
-            return texelSize * OceanRenderer.Instance.MinTexelsPerWave;
+            // Nyquist rate
+            return texelSize * 2f;
         }
 
         public void CrestUpdate(CommandBuffer buf)
@@ -700,6 +701,21 @@ namespace Crest
             {
                 _bufWaveData.Dispose();
                 _bufWaveData = null;
+            }
+
+            if (_waveBuffers != null)
+            {
+#if UNITY_EDITOR
+                if (!EditorApplication.isPlaying)
+                {
+                    DestroyImmediate(_waveBuffers);
+                }
+                else
+#endif
+                {
+                    Destroy(_waveBuffers);
+                }
+                _waveBuffers = null;
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -7,7 +7,6 @@ using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 using Unity.Collections.LowLevel.Unsafe;
 using Crest.Spline;
-using System.Collections.Generic;
 
 #if UNITY_EDITOR
 using UnityEditor;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/Debug/TextureArray.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/Debug/TextureArray.shader
@@ -35,6 +35,8 @@ Shader "Hidden/Crest/Debug/TextureArray"
 
 			UNITY_DECLARE_TEX2DARRAY(_MainTex);
 			uint _Depth;
+			float _Scale;
+			float _Bias;
 
 			Varyings Vert(Attributes input)
 			{
@@ -46,7 +48,7 @@ Shader "Hidden/Crest/Debug/TextureArray"
 
 			half4 Frag(Varyings input) : SV_TARGET
 			{
-				return UNITY_SAMPLE_TEX2DARRAY(_MainTex, input.uv);
+				return _Scale * UNITY_SAMPLE_TEX2DARRAY(_MainTex, input.uv) + _Bias;
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4cd3be62311738448810fa71f29cfed5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
@@ -23,8 +23,6 @@
 // Must match CASCADE_COUNT in FFTCompute.cs
 #define CASCADE_COUNT 16
 
-float _Chop;
-
 Texture2DArray<float2> _InputH;
 Texture2DArray<float2> _InputX;
 Texture2DArray<float2> _InputZ;
@@ -169,6 +167,6 @@ void ComputeFFT(uint3 id : SV_DispatchThreadID)
 #else
 	const float sign = ((id.x + id.y) % 2) == 1 ? -1.0 : 1.0;
 	const float3 res = float3(sign * resultX.x, sign * resultH.x, sign * resultZ.x);
-	_Output[id] = float3(sign * resultX.x * _Chop, sign * resultH.x, sign * resultZ.x * _Chop);
+	_Output[id] = float3(sign * resultX.x, sign * resultH.x, sign * resultZ.x);
 #endif
 }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
@@ -44,6 +44,19 @@ groupshared float2 _ScratchX[SIZE];
 groupshared float2 _IntermediatesZ[SIZE];
 groupshared float2 _ScratchZ[SIZE];
 
+// reversebits function appears to not make it across to Metal
+#if !defined(reversebits)
+uint reversebits( uint x )
+{
+	x = ((x >> 1) & 0x55555555u) | ((x & 0x55555555u) << 1);
+	x = ((x >> 2) & 0x33333333u) | ((x & 0x33333333u) << 2);
+	x = ((x >> 4) & 0x0f0f0f0fu) | ((x & 0x0f0f0f0fu) << 4);
+	x = ((x >> 8) & 0x00ff00ffu) | ((x & 0x00ff00ffu) << 8);
+	x = ((x >> 16) & 0xffffu) | ((x & 0xffffu) << 16);
+	return x;
+}
+#endif
+
 void ButterflyPass(float2 butterfly, uint coord, uint passIndex, uint cascade)
 {
 	uint indexA, indexB;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
@@ -1,0 +1,161 @@
+// Crest Ocean System
+
+// Copyright 2021 Wave Harmonic Ltd
+
+// Inspired by https://github.com/speps/GX-EncinoWaves
+
+// First SIZE constant must match FFT_KERNEL_0_RESOLUTION in FFTCompute.cs
+#pragma kernel ComputeFFT SIZE=8 PASSES=3 CHANNEL=x TX=8 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=8 PASSES=3 CHANNEL=y TX=1 TY=8 FINAL=1
+#pragma kernel ComputeFFT SIZE=16 PASSES=4 CHANNEL=x TX=16 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=16 PASSES=4 CHANNEL=y TX=1 TY=16 FINAL=1
+#pragma kernel ComputeFFT SIZE=32 PASSES=5 CHANNEL=x TX=32 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=32 PASSES=5 CHANNEL=y TX=1 TY=32 FINAL=1
+#pragma kernel ComputeFFT SIZE=64 PASSES=6 CHANNEL=x TX=64 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=64 PASSES=6 CHANNEL=y TX=1 TY=64 FINAL=1
+#pragma kernel ComputeFFT SIZE=128 PASSES=7 CHANNEL=x TX=128 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=128 PASSES=7 CHANNEL=y TX=1 TY=128 FINAL=1
+#pragma kernel ComputeFFT SIZE=256 PASSES=8 CHANNEL=x TX=256 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=256 PASSES=8 CHANNEL=y TX=1 TY=256 FINAL=1
+#pragma kernel ComputeFFT SIZE=512 PASSES=9 CHANNEL=x TX=512 TY=1 FINAL=0
+#pragma kernel ComputeFFT SIZE=512 PASSES=9 CHANNEL=y TX=1 TY=512 FINAL=1
+
+// Must match CASCADE_COUNT in FFTCompute.cs
+#define CASCADE_COUNT 16
+
+float _Chop;
+
+Texture2DArray<float2> _InputH;
+Texture2DArray<float2> _InputX;
+Texture2DArray<float2> _InputZ;
+Texture2D<float2> _InputButterfly;
+#if !FINAL
+RWTexture2DArray<float2> _Output1;
+RWTexture2DArray<float2> _Output2;
+RWTexture2DArray<float2> _Output3;
+#else
+RWTexture2DArray<float3> _Output;
+#endif
+
+groupshared float2 _IntermediatesH[SIZE];
+groupshared float2 _ScratchH[SIZE];
+groupshared float2 _IntermediatesX[SIZE];
+groupshared float2 _ScratchX[SIZE];
+groupshared float2 _IntermediatesZ[SIZE];
+groupshared float2 _ScratchZ[SIZE];
+
+void ButterflyPass(float2 butterfly, uint coord, uint passIndex, uint cascade)
+{
+	uint indexA, indexB;
+
+	const uint offset = 1 << passIndex;
+	if ((coord / offset) % 2 == 1)
+	{
+		indexA = coord - offset;
+		indexB = coord;
+	}
+	else
+	{
+		indexA = coord;
+		indexB = coord + offset;
+	}
+
+	if (passIndex == 0)
+	{
+		indexA = reversebits(indexA) >> (32 - PASSES);
+		indexB = reversebits(indexB) >> (32 - PASSES);
+	}
+
+	const bool pingpong = (passIndex % 2) == 0;
+
+	float2 valueA_H, valueB_H;
+	float2 valueA_X, valueB_X;
+	float2 valueA_Z, valueB_Z;
+	if (pingpong)
+	{
+		valueA_H = _IntermediatesH[indexA];
+		valueB_H = _IntermediatesH[indexB];
+
+		valueA_X = _IntermediatesX[indexA];
+		valueB_X = _IntermediatesX[indexB];
+
+		valueA_Z = _IntermediatesZ[indexA];
+		valueB_Z = _IntermediatesZ[indexB];
+	}
+	else
+	{
+		valueA_H = _ScratchH[indexA];
+		valueB_H = _ScratchH[indexB];
+
+		valueA_X = _ScratchX[indexA];
+		valueB_X = _ScratchX[indexB];
+
+		valueA_Z = _ScratchZ[indexA];
+		valueB_Z = _ScratchZ[indexB];
+	}
+
+	const float2 weight = butterfly.xy;
+	const float2 weightedValueH = weight * valueB_H.r + weight.gr * valueB_H.g * float2(-1.0, 1.0);
+	const float2 weightedValueX = weight * valueB_X.r + weight.gr * valueB_X.g * float2(-1.0, 1.0);
+	const float2 weightedValueZ = weight * valueB_Z.r + weight.gr * valueB_Z.g * float2(-1.0, 1.0);
+	const float2 resultH = valueA_H + weightedValueH;
+	const float2 resultX = valueA_X + weightedValueX;
+	const float2 resultZ = valueA_Z + weightedValueZ;
+
+	if (pingpong)
+	{
+		_ScratchH[coord] = resultH;
+		_ScratchX[coord] = resultX;
+		_ScratchZ[coord] = resultZ;
+	}
+	else
+	{
+		_IntermediatesH[coord] = resultH;
+		_IntermediatesX[coord] = resultX;
+		_IntermediatesZ[coord] = resultZ;
+	}
+}
+
+float2 conj(float2 v)
+{
+	return float2(v.x, -v.y);
+}
+
+[numthreads(TX,TY,1)]
+void ComputeFFT(uint3 id : SV_DispatchThreadID)
+{
+	const uint coord = id.CHANNEL;
+#if !FINAL
+	_IntermediatesH[coord] = conj(_InputH[id]);
+	_IntermediatesX[coord] = conj(_InputX[id]);
+	_IntermediatesZ[coord] = conj(_InputZ[id]);
+#else
+	_IntermediatesH[coord] = _InputH[id];
+	_IntermediatesX[coord] = _InputX[id];
+	_IntermediatesZ[coord] = _InputZ[id];
+#endif
+
+	[unroll(PASSES)]
+	for (uint passIndex = 0; passIndex < PASSES; ++passIndex)
+	{
+		GroupMemoryBarrierWithGroupSync();
+		ButterflyPass(_InputButterfly[uint2(coord, passIndex)].xy, coord, passIndex, id.z);
+	}
+
+	GroupMemoryBarrierWithGroupSync();
+
+	const bool pingpong = (PASSES % 2) == 0;
+	const float2 resultH = pingpong ? _IntermediatesH[coord] : _ScratchH[coord];
+	const float2 resultX = pingpong ? _IntermediatesX[coord] : _ScratchX[coord];
+	const float2 resultZ = pingpong ? _IntermediatesZ[coord] : _ScratchZ[coord];
+
+#if !FINAL
+	_Output1[id] = resultH;
+	_Output2[id] = resultX;
+	_Output3[id] = resultZ;
+#else
+	const float sign = ((id.x + id.y) % 2) == 1 ? -1.0 : 1.0;
+	const float3 res = float3(sign * resultX.x, sign * resultH.x, sign * resultZ.x);
+	_Output[id] = float3(sign * resultX.x * _Chop, sign * resultH.x, sign * resultZ.x * _Chop);
+#endif
+}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ceb56734be34f9044bdf652bc8c547c3
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -172,6 +172,7 @@ void SpectrumInitalize(uint3 id : SV_DispatchThreadID)
 }
 
 float _Time;
+float _Chop;
 
 Texture2DArray<float4> _Init0;
 RWTexture2DArray<float2> _ResultHeight;
@@ -212,6 +213,6 @@ void SpectrumUpdate(uint3 id : SV_DispatchThreadID)
 	const float2 h = cmul(h0.xy, fwd) + cmul(h0.zw, bkwd);
 
 	_ResultHeight[id] = h;
-	_ResultDisplaceX[id] = float2(-h.y * k.x, h.x * k.x) / (kMag + 0.00001f);
-	_ResultDisplaceZ[id] = float2(-h.y * k.y, h.x * k.y) / (kMag + 0.00001f);
+	_ResultDisplaceX[id] = _Chop * float2(-h.y * k.x, h.x * k.x) / (kMag + 0.00001f);
+	_ResultDisplaceZ[id] = _Chop * float2(-h.y * k.y, h.x * k.y) / (kMag + 0.00001f);
 }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -85,10 +85,10 @@ float PiersonMoskowitzWindTerm( float w )
 
 float PosCosSquaredDirectionalSpreading(float w, float theta, float kMag, float dTheta)
 {
-	if (theta > -HPI && theta < HPI)
+	if( abs( theta ) < HPI )
 	{
 		float ct = cos(theta);
-		return INVPI2 * (ct * ct) * (1 - _Turbulence) + PI4 * _Turbulence;
+		return lerp( INVPI2 * (ct * ct), PI4, _Turbulence );
 	}
 	else
 	{

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -1,0 +1,217 @@
+// Crest Ocean System
+
+// Copyright 2021 Wave Harmonic Ltd
+
+// Inspired by https://github.com/speps/GX-EncinoWaves
+
+#pragma kernel SpectrumInitalize
+#pragma kernel SpectrumUpdate
+
+#define INV2PI	0.15915494309f
+#define PI4		0.33661977236f
+#define INVPI2	0.63661977236f
+#define HPI		1.57079632679f
+#define PI		3.14159265358f
+#define PI2		6.28318530717f
+#define HSQRT2	0.70710678118f
+
+uint _Size;
+float _WindSpeed;
+float _Turbulence;
+float _Gravity;
+
+uint _RngState;
+
+uint WangHash(uint seed)
+{
+	seed = (seed ^ 61) ^ (seed >> 16);
+	seed *= 9;
+	seed = seed ^ (seed >> 4);
+	seed *= 0x27d4eb2d;
+	seed = seed ^ (seed >> 15);
+	return seed;
+}
+
+uint Rand()
+{
+	_RngState ^= (_RngState << 13);
+	_RngState ^= (_RngState >> 17);
+	_RngState ^= (_RngState << 5);
+	return _RngState;
+}
+
+float RandFloat()
+{
+	return Rand() / 4294967296.0f;
+}
+
+float RandGauss()
+{
+	float u1 = RandFloat();
+	float u2 = RandFloat();
+	if (u1 < 1e-6f)
+		u1 = 1e-6f;
+	return sqrt(-2.0f * log(u1)) * cos(PI2 * u2);
+}
+
+void DeepDispersion(float k, out float w, out float dwdk)
+{
+	w = sqrt(abs(_Gravity * k));
+	dwdk = _Gravity / (2.0f * w);
+}
+
+float AlphaBetaSpectrum(float A, float B, float g, float w, float wm)
+{
+	return
+		(A * g * g / pow(w, 5.0f)) *
+		exp(-B * pow(wm / w, 4.0f));
+}
+
+float PiersonMoskowitzSpectrum(float w)
+{
+	float wm = 0.87f * _Gravity / _WindSpeed;
+	return AlphaBetaSpectrum(8.1e-3f, 1.291f, _Gravity, w, wm);
+}
+
+float PiersonMoskowitzWindTerm( float w )
+{
+	float wm = 0.87f * _Gravity / _WindSpeed;
+	return exp( -1.291 * pow( wm / w, 4.0f ) );
+}
+
+float PosCosSquaredDirectionalSpreading(float w, float theta, float kMag, float dTheta)
+{
+	if (theta > -HPI && theta < HPI)
+	{
+		float ct = cos(theta);
+		return INVPI2 * (ct * ct) * (1 - _Turbulence) + PI4 * _Turbulence;
+	}
+	else
+	{
+		return PI4 * _Turbulence;
+	}
+}
+
+RWTexture2DArray<float4> _ResultInit;
+Texture2D<float> _SpectrumControls;
+SamplerState linear_clamp_sampler;
+
+[numthreads(8,8,1)]
+void SpectrumInitalize(uint3 id : SV_DispatchThreadID)
+{
+	const int2 center = _Size.xx / 2;
+	const int2 coord = id.xy - center;
+
+	uint depth;
+	{
+		uint width, height;
+		_ResultInit.GetDimensions( width, height, depth );
+	}
+
+	if( id.z < (depth - 1) && max( abs( coord.x ), abs( coord.y ) ) < _Size / 4 )
+	{
+		_ResultInit[id] = 0.0;
+		return;
+	}
+
+	if (coord.x == 0 && coord.y == 0)
+	{
+		_ResultInit[id] = float4(0, 0, 0, 0);
+		return;
+	}
+
+	const float worldSize = 0.5f * (1 << id.z);
+
+	// Find wave vector and number
+	const float2 k = PI2 * coord / worldSize;
+	const float kMag = length(k);
+
+	// Init seed
+	_RngState = WangHash(id.z * _Size * _Size + id.y * _Size + id.x);
+
+	// Dispersion
+	float w; float dwdk;
+	DeepDispersion(kMag, w, dwdk);
+
+	// Spectrum
+	float spectrum = PiersonMoskowitzSpectrum( w );
+
+	float wl = PI2 / kMag;
+	float SMALLEST_WL_POW_2 = -4.0;
+	uint NUM_OCTAVES = 14;
+	float index = log2( wl ) - SMALLEST_WL_POW_2;
+	spectrum = _SpectrumControls.SampleLevel( linear_clamp_sampler, float2((index + 0.5) / NUM_OCTAVES, 0.5), 0.0 )
+		* PiersonMoskowitzWindTerm( w )
+		;
+
+	float deltaSPos = spectrum;
+	float deltaSNeg = spectrum;
+
+	// Directional spreading
+	const float dK = PI2 / worldSize;
+	const float thetaPos = atan2(-k.y, k.x);
+	const float thetaNeg = atan2(k.y, -k.x);
+	const float dTheta = abs(atan2(dK, kMag));
+	deltaSPos *= PosCosSquaredDirectionalSpreading(w, thetaPos, kMag, dTheta);
+	deltaSNeg *= PosCosSquaredDirectionalSpreading(w, thetaNeg, kMag, dTheta);
+	deltaSPos *= (dK * dK) * dwdk / kMag;
+	deltaSNeg *= (dK * dK) * dwdk / kMag;
+
+	// Amplitude
+	const float ampPos = RandGauss() * sqrt(abs(deltaSPos) * 2.0f);
+	const float ampNeg = RandGauss() * sqrt(abs(deltaSNeg) * 2.0f);
+	
+	// Output
+	const float phasePos = RandFloat() * PI2;
+	const float phaseNeg = RandFloat() * PI2;
+
+	//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+	const float spiceyMultiplier = 1.5;
+	_ResultInit[id] = float4(ampPos * float2(cos(phasePos), -sin(phasePos)), ampNeg * float2(cos(phaseNeg), -sin(phaseNeg)))
+		* spiceyMultiplier;
+}
+
+float _Time;
+
+Texture2DArray<float4> _Init0;
+RWTexture2DArray<float2> _ResultHeight;
+RWTexture2DArray<float2> _ResultDisplaceX;
+RWTexture2DArray<float2> _ResultDisplaceZ;
+
+float2 cmul(float2 lhs, float2 rhs)
+{
+	return float2(
+		lhs.x * rhs.x - lhs.y * rhs.y,
+		lhs.x * rhs.y + lhs.y * rhs.x
+	);
+}
+
+[numthreads(8, 8, 1)]
+void SpectrumUpdate(uint3 id : SV_DispatchThreadID)
+{
+	const int2 center = _Size.xx / 2;
+	const int2 coord = id.xy - center;
+	
+	// Find wave vector and number
+	const float worldSize = 0.5 * (1 << id.z);
+	const float2 k = PI2 * coord / worldSize;
+	const float kMag = length(k);
+
+	// Dispersion
+	float w; float dwdk;
+	DeepDispersion(kMag, w, dwdk);
+
+	// Advance time
+	float sw; float cw;
+	sincos(w * _Time, sw, cw);
+
+	const float2 fwd = float2(cw, -sw);
+	const float2 bkwd = float2(cw, sw);
+
+	const float4 h0 = _Init0[id];
+	const float2 h = cmul(h0.xy, fwd) + cmul(h0.zw, bkwd);
+
+	_ResultHeight[id] = h;
+	_ResultDisplaceX[id] = float2(-h.y * k.x, h.x * k.x) / (kMag + 0.00001f);
+	_ResultDisplaceZ[id] = float2(-h.y * k.y, h.x * k.y) / (kMag + 0.00001f);
+}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -108,7 +108,7 @@ void SpectrumInitalize(uint3 id : SV_DispatchThreadID)
 		_ResultInit.GetDimensions( width, height, depth );
 	}
 
-	if( id.z < (depth - 1) && max( abs( coord.x ), abs( coord.y ) ) < _Size / 4 )
+	if( id.z < uint(depth - 1) && max( abs( coord.x ), abs( coord.y ) ) < _Size / 4 )
 	{
 		_ResultInit[id] = 0.0;
 		return;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -15,6 +15,10 @@
 #define PI2		6.28318530717f
 #define HSQRT2	0.70710678118f
 
+// These must match corresponding constants in OceanWaveSpectrum.cs
+#define SPECTRUM_OCTAVE_COUNT		14.0
+#define SPECTRUM_SMALLEST_WL_POW_2	-4.0
+
 uint _Size;
 float _WindSpeed;
 float _Turbulence;
@@ -133,16 +137,12 @@ void SpectrumInitalize(uint3 id : SV_DispatchThreadID)
 	float w; float dwdk;
 	DeepDispersion(kMag, w, dwdk);
 
-	// Spectrum
-	float spectrum = PiersonMoskowitzSpectrum( w );
-
-	float wl = PI2 / kMag;
-	float SMALLEST_WL_POW_2 = -4.0;
-	uint NUM_OCTAVES = 14;
-	float index = log2( wl ) - SMALLEST_WL_POW_2;
-	spectrum = _SpectrumControls.SampleLevel( linear_clamp_sampler, float2((index + 0.5) / NUM_OCTAVES, 0.5), 0.0 )
-		* PiersonMoskowitzWindTerm( w )
-		;
+	// Spectrum - use power values from users spectrum, but borrow wind term from PM
+	const float wavelength = PI2 / kMag;
+	const float octaveIndex = log2( wavelength ) - SPECTRUM_SMALLEST_WL_POW_2;
+	const float spectrumUV = float2((octaveIndex + 0.5) / SPECTRUM_OCTAVE_COUNT, 0.5);
+	const float spectrum = _SpectrumControls.SampleLevel( linear_clamp_sampler, spectrumUV, 0.0 ) *
+		PiersonMoskowitzWindTerm( w );
 
 	float deltaSPos = spectrum;
 	float deltaSNeg = spectrum;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bba9d2de3b619a46a6d0b3637e88c90
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 4
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,7 @@ Changed
 .. bullet_list::
 
    -  Sponsorship page launched! Asset Store sales only cover fixes and basic support. To support new feature development and give us financial stability please consider sponsoring us, no amount is too small! https://github.com/sponsors/wave-harmonic
+   -  FFT wave simulation added via new Shape FFT component, in preview.
    -  Wind speed added to OceanRenderer component so that wave conditions change naturally for different wind conditions.
    -  Empirical spectra retweaked and use the aforementioned wind speed.
    -  Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
@@ -32,8 +33,8 @@ Changed
    -  Ocean material can now be set with scripting.
    -  Custom Time Provider has pause toggle, for easy pausing functionality.
    -  Network Time Provider added to easily sync water simulation to server time.
-   -  Cutscene Time Provider added to drive water simulation time from Timelines
-   -  Fix bug where wind direction could not be set per ShapeGerstner component
+   -  Cutscene Time Provider added to drive water simulation time from Timelines.
+   -  Fix bug where wind direction could not be set per ShapeGerstner component.
 
    .. only:: hdrp
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -35,7 +35,6 @@ Changed
    -  Network Time Provider added to easily sync water simulation to server time.
    -  Cutscene Time Provider added to drive water simulation time from Timelines.
    -  Made many fields scriptable (public) on *BoatProbes*, *BoatAlignNormal* and *SimpleFloatingObject*.
-   -  Fix bug where wind direction could not be set per ShapeGerstner component.
 
    .. only:: hdrp
 

--- a/docs/about/known-issues.rst
+++ b/docs/about/known-issues.rst
@@ -30,10 +30,12 @@ Unity Bugs
 ----------
 
 There are some Unity issues that affect `Crest`.
+Some of these may even be blocking new features from being developed.
 If you could vote on these issues, that would be greatly appreciated:
 
 -  :link:`Gizmos render over opaque objects with Post-Processing stack. <{UnityIssueLink}/1124862>` `[[BIRP]]`
 -  :link:`Opaque texture is black in right eye if both depth and opaque texture enabled for multi-pass rendering mode. <{UnityIssueLink}/1256604>` `[[URP]]`
+-  :link:`Game view is rendered grey for left eye and black for right eye when using XR {SPI} and render feature. <{UnityIssueLink}/1335524>` `[[URP]]`
 
 
 Unity Features

--- a/docs/user/wave-conditions.rst
+++ b/docs/user/wave-conditions.rst
@@ -17,11 +17,11 @@ The following sections describe how to define the wave conditions.
 Authoring
 ---------
 
-To add waves, add the *ShapeGerstnerBatched* component to a GameObject.
+To add waves, add the *ShapeGerstner* component to a GameObject.
 
 The appearance and shape of the waves is determined by a *Wave Spectrum*.
 A default wave spectrum will be created if none is specified.
-To change the waves, right click in the Project view and select *Create/Crest/Ocean Wave Spectrum*, and assign the new asset to the *Spectrum* property of the *ShapeGerstnerBatched* script.
+To change the waves, right click in the Project view and select *Create/Crest/Ocean Wave Spectrum*, and assign the new asset to the *Spectrum* property of the *ShapeGerstner* script.
 
 The spectrum has sliders for each wavelength to control contribution of different scales of waves.
 To control the contribution of 2m wavelengths, use the slider labelled '2'.
@@ -88,6 +88,18 @@ The new system has the following advantages:
 
 After more testing we will switch over to this new system and deprecate the *ShapeGerstnerBatched* component.
 
+
+.. _shape-gerstner-section:
+
+ShapeFFT (preview)
+------------------
+
+A wave simulation based on the *FFT* technique.
+
+The usage is very similar to the *ShapeGerstner* component.
+Add the *ShapeFFT* component to a GameObject, and follow the authoring instructions above to modify the wave conditions.
+
+This simulation type adds more wave components together than the *ShapeGerstner* component and can produce more realistic water waves, at a similar performance cost.
 
 .. _wave-splines-section:
 


### PR DESCRIPTION
**Status**: This is a transfer over from our private repos and is ready to merge from my POV

* Adds multi-scale FFT. Wave generation in this setup takes 28us on my 1060
* Generalises debug gui texture view to allow drawing any texture array
* Generalise debug gui texture view to allow scale/bias to data. Useful when data can go negative, or has a large or small range
* Supports spectrum control over FFT. Further, Pierson Moskowitz was used to calibrate our gerstner spectrum with the same spectrum using FFT.
* The calibration changed the gerstner spectrum. I've introduced a new pattern for migrating the spectrum data.

**Testing**:

Add ShapeFFT to a GameObject in the scene and it will add FFT waves.