### PR TITLE
Fix bug where all ShapeGerstners used one wind heading

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -271,6 +271,7 @@ namespace Crest
 
             _matGenerateWaves.SetFloat(sp_RespectShallowWaterAttenuation, _respectShallowWaterAttenuation);
             _matGenerateWaves.SetFloat(sp_FeatherWaveStart, _featherWaveStart);
+            _matGenerateWaves.SetVector(sp_AxisX, PrimaryWaveDirection);
             // Seems like shader errors cause this to unbind if I don't set it every frame. Could be an editor only issue.
             _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);
 
@@ -282,7 +283,6 @@ namespace Crest
                 UpdateGenerateWaves(buf);
             }
 
-            buf.SetGlobalVector(sp_AxisX, PrimaryWaveDirection);
             // Seems to come unbound when editing shaders at runtime, so rebinding here.
             _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);
         }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -33,6 +33,7 @@ Changed
    -  Custom Time Provider has pause toggle, for easy pausing functionality.
    -  Network Time Provider added to easily sync water simulation to server time.
    -  Cutscene Time Provider added to drive water simulation time from Timelines
+   -  Fix bug where wind direction could not be set per ShapeGerstner component
 
    .. only:: hdrp
 


### PR DESCRIPTION
Have no idea why this was set globally instead of per-material.
