### PR TITLE
Make hashy functions type explicit

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Hashy.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Hashy.cs
@@ -11,22 +11,22 @@ namespace Crest
     {
         public static int CreateHash() => 0x19384567;
 
-        public static void Add(float value, ref int hash)
+        public static void AddFloat(float value, ref int hash)
         {
             hash ^= value.GetHashCode();
         }
 
-        public static void Add(int value, ref int hash)
+        public static void AddInt(int value, ref int hash)
         {
             hash ^= value;
         }
 
-        public static void Add(bool value, ref int hash)
+        public static void AddBool(bool value, ref int hash)
         {
             hash ^= (value ? 0x74659374 : 0x62649035);
         }
 
-        public static void Add(object value, ref int hash)
+        public static void AddObject(object value, ref int hash)
         {
             // Will be the index of this object instance
             hash ^= value.GetHashCode();

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -778,13 +778,13 @@ namespace Crest
             var settingsHash = Hashy.CreateHash();
 
             // Add all the settings that require rebuilding..
-            Hashy.Add(_lodDataResolution, ref settingsHash);
-            Hashy.Add(_geometryDownSampleFactor, ref settingsHash);
-            Hashy.Add(_lodCount, ref settingsHash);
-            Hashy.Add(_forceBatchMode, ref settingsHash);
-            Hashy.Add(_forceNoGPU, ref settingsHash);
-            Hashy.Add(_hideOceanTileGameObjects, ref settingsHash);
-            Hashy.Add(_layerName, ref settingsHash);
+            Hashy.AddInt(_lodDataResolution, ref settingsHash);
+            Hashy.AddInt(_geometryDownSampleFactor, ref settingsHash);
+            Hashy.AddInt(_lodCount, ref settingsHash);
+            Hashy.AddBool(_forceBatchMode, ref settingsHash);
+            Hashy.AddBool(_forceNoGPU, ref settingsHash);
+            Hashy.AddBool(_hideOceanTileGameObjects, ref settingsHash);
+            Hashy.AddObject(_layerName, ref settingsHash);
 
             return settingsHash;
         }


### PR DESCRIPTION
While working on something else and attempting to hash an object instance ID, i found it converting an object ref to a bool (i guess doing an 'is null' operation' and calling `Add(bool)`, and failing to hash properly (!?). Wow.

Rather unfortunate but i could not find an elegant way in C# to avoid implicit conversions. I did find i could pass the first arg to `Add()` by reference, which may sort it, however passing stuff in by reference is probably hackier than doing this.