### PR TITLE
Make fields public for floaty things

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -12,43 +12,42 @@ using UnityEngine;
 public class BoatAlignNormal : FloatingObjectBase
 {
     [Header("Buoyancy Force")]
-    [Tooltip("Height offset from transform center to bottom of boat (if any)."), SerializeField]
-    float _bottomH = 0f;
-    [Tooltip("Strength of buoyancy force per meter of submersion in water."), SerializeField]
-    float _buoyancyCoeff = 1.5f;
-    [Tooltip("Strength of torque applied to match boat orientation to water normal."), SerializeField]
-    float _boyancyTorque = 8f;
-    [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), SerializeField, Crest.Range(0, 1)]
-    float _accelerateDownhill = 0f;
+    [Tooltip("Height offset from transform center to bottom of boat (if any).")]
+    public float _bottomH = 0f;
+    [Tooltip("Strength of buoyancy force per meter of submersion in water.")]
+    public float _buoyancyCoeff = 1.5f;
+    [Tooltip("Strength of torque applied to match boat orientation to water normal.")]
+    public float _boyancyTorque = 8f;
+    [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), Crest.Range(0, 1)]
+    public float _accelerateDownhill = 0f;
 
     [Header("Engine Power")]
-    [Tooltip("Vertical offset for where engine force should be applied."), SerializeField]
-    float _forceHeightOffset = -0.3f;
-    [SerializeField] float _enginePower = 11f;
-    [SerializeField] float _turnPower = 1.3f;
+    [Tooltip("Vertical offset for where engine force should be applied.")]
+    public float _forceHeightOffset = -0.3f;
+    public float _enginePower = 11f;
+    public float _turnPower = 1.3f;
 
     [Header("Wave Response")]
-    [Tooltip("Width dimension of boat. The larger this value, the more filtered/smooth the wave response will be."), SerializeField]
-    float _boatWidth = 3f;
+    [Tooltip("Width dimension of boat. The larger this value, the more filtered/smooth the wave response will be.")]
+    public float _boatWidth = 3f;
     public override float ObjectWidth { get { return _boatWidth; } }
 
-    [SerializeField, Tooltip("Computes a separate normal based on boat length to get more accurate orientations, at the cost of an extra collision sample.")]
-    bool _useBoatLength = false;
-    [Tooltip("Length dimension of boat. Only used if Use Boat Length is enabled."), SerializeField, Predicated("_useBoatLength"), DecoratedField]
-    float _boatLength = 3f;
+    [Tooltip("Computes a separate normal based on boat length to get more accurate orientations, at the cost of an extra collision sample.")]
+    public bool _useBoatLength = false;
+    [Tooltip("Length dimension of boat. Only used if Use Boat Length is enabled."), Predicated("_useBoatLength"), DecoratedField]
+    public float _boatLength = 3f;
 
     [Header("Drag")]
-    [SerializeField] float _dragInWaterUp = 3f;
-    [SerializeField] float _dragInWaterRight = 2f;
-    [SerializeField] float _dragInWaterForward = 1f;
+    public float _dragInWaterUp = 3f;
+    public float _dragInWaterRight = 2f;
+    public float _dragInWaterForward = 1f;
 
     [Header("Controls")]
-    [SerializeField]
-    bool _playerControlled = true;
-    [Tooltip("Used to automatically add throttle input"), SerializeField]
-    float _throttleBias = 0f;
-    [Tooltip("Used to automatically add turning input"), SerializeField]
-    float _steerBias = 0f;
+    public bool _playerControlled = true;
+    [Tooltip("Used to automatically add throttle input")]
+    public float _throttleBias = 0f;
+    [Tooltip("Used to automatically add turning input")]
+    public float _steerBias = 0f;
 
     [Header("Debug")]
     [SerializeField]

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -21,35 +21,29 @@ namespace Crest
         Vector3 _centerOfMass = Vector3.zero;
         [SerializeField, FormerlySerializedAs("ForcePoints")]
         FloaterForcePoints[] _forcePoints = new FloaterForcePoints[] { };
-
-        [Tooltip("Vertical offset for where engine force should be applied."), SerializeField]
-        float _forceHeightOffset = 0f;
-        [SerializeField]
-        float _forceMultiplier = 10f;
-        [Tooltip("Width dimension of boat. The larger this value, the more filtered/smooth the wave response will be."), SerializeField]
-        float _minSpatialLength = 12f;
-        [SerializeField, Range(0, 1)]
-        float _turningHeel = 0.35f;
+        [Tooltip("Vertical offset for where engine force should be applied.")]
+        public float _forceHeightOffset = 0f;
+        public float _forceMultiplier = 10f;
+        [Tooltip("Width dimension of boat. The larger this value, the more filtered/smooth the wave response will be.")]
+        public float _minSpatialLength = 12f;
+        [Range(0, 1)]
+        public float _turningHeel = 0.35f;
 
         [Header("Drag")]
-        [SerializeField]
-        float _dragInWaterUp = 3f;
-        [SerializeField]
-        float _dragInWaterRight = 2f;
-        [SerializeField]
-        float _dragInWaterForward = 1f;
+        public float _dragInWaterUp = 3f;
+        public float _dragInWaterRight = 2f;
+        public float _dragInWaterForward = 1f;
 
         [Header("Control")]
-        [SerializeField, FormerlySerializedAs("EnginePower")]
-        float _enginePower = 7;
-        [SerializeField, FormerlySerializedAs("TurnPower")]
-        float _turnPower = 0.5f;
-        [SerializeField]
-        bool _playerControlled = true;
-        [Tooltip("Used to automatically add throttle input"), SerializeField]
-        float _engineBias = 0f;
-        [Tooltip("Used to automatically add turning input"), SerializeField]
-        float _turnBias = 0f;
+        [FormerlySerializedAs("EnginePower")]
+        public float _enginePower = 7;
+        [FormerlySerializedAs("TurnPower")]
+        public float _turnPower = 0.5f;
+        public bool _playerControlled = true;
+        [Tooltip("Used to automatically add throttle input")]
+        public float _engineBias = 0f;
+        [Tooltip("Used to automatically add turning input")]
+        public float _turnBias = 0f;
 
         private const float WATER_DENSITY = 1000;
 

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -16,27 +16,27 @@ namespace Crest
     public class SimpleFloatingObject : FloatingObjectBase
     {
         [Header("Buoyancy Force")]
-        [Tooltip("Offsets center of object to raise it (or lower it) in the water."), SerializeField]
-        float _raiseObject = 1f;
-        [Tooltip("Strength of buoyancy force per meter of submersion in water."), SerializeField]
-        float _buoyancyCoeff = 3f;
-        [Tooltip("Strength of torque applied to match boat orientation to water normal."), SerializeField]
-        float _boyancyTorque = 8f;
-        [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), SerializeField, Range(0, 1)]
-        float _accelerateDownhill = 0f;
+        [Tooltip("Offsets center of object to raise it (or lower it) in the water.")]
+        public float _raiseObject = 1f;
+        [Tooltip("Strength of buoyancy force per meter of submersion in water.")]
+        public float _buoyancyCoeff = 3f;
+        [Tooltip("Strength of torque applied to match boat orientation to water normal.")]
+        public float _boyancyTorque = 8f;
+        [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), Range(0, 1)]
+        public float _accelerateDownhill = 0f;
 
         [Header("Wave Response")]
-        [Tooltip("Diameter of object, for physics purposes. The larger this value, the more filtered/smooth the wave response will be."), SerializeField]
-        float _objectWidth = 3f;
+        [Tooltip("Diameter of object, for physics purposes. The larger this value, the more filtered/smooth the wave response will be.")]
+        public float _objectWidth = 3f;
         public override float ObjectWidth { get { return _objectWidth; } }
 
         [Header("Drag")]
-        [Tooltip("Vertical offset for where drag force should be applied."), SerializeField]
-        float _forceHeightOffset = -0.3f;
-        [SerializeField] float _dragInWaterUp = 3f;
-        [SerializeField] float _dragInWaterRight = 2f;
-        [SerializeField] float _dragInWaterForward = 1f;
-        [SerializeField] float _dragInWaterRotational = 0.2f;
+        [Tooltip("Vertical offset for where drag force should be applied.")]
+        public float _forceHeightOffset = -0.3f;
+        public float _dragInWaterUp = 3f;
+        public float _dragInWaterRight = 2f;
+        public float _dragInWaterForward = 1f;
+        public float _dragInWaterRotational = 0.2f;
 
         [Header("Debug")]
         [SerializeField] bool _debugDraw = false;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -28,6 +28,7 @@ Changed
    -  Add Overall Normals Scale parameter to material that scales final surface normal (includes both normal map and wave simulation normal).
    -  Headless support - add support for running without display, with new toggle on OceanRenderer to emulate it in Editor.
    -  No GPU support - add support for running without GPU, with new toggle on OceanRenderer to emulate it in Editor.
+   -  Made many fields scriptable (public) on *BoatProbes*, *BoatAlignNormal* and *SimpleFloatingObject*.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Made many fields public for *BoatProbes*, *BoatAlignNormal* and *SimpleFloatingObject*. I went through and made sure they were safe to make public (no state relied on them in Start etc).