### PR TITLE
Update ocean underwater material colours

### DIFF
--- a/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
+++ b/crest/Assets/Crest/Crest/Materials/Ocean-Underwater.mat
@@ -131,25 +131,25 @@ Material:
     - _Projection: 0
     - _RefractAmt: 0
     - _RefractionStrength: 1
-    - _RefractiveIndexOfAir: 1.2
+    - _RefractiveIndexOfAir: 1
     - _RefractiveIndexOfWater: 1.333
     - _Roughness: 0
     - _S: 1
     - _Shadows: 1
     - _ShorelineFoamMinDepth: 0.27
     - _SkyDirectionality: 0.875
-    - _Specular: 1
+    - _Specular: 0.7
     - _StartLevel: 0.157
     - _StencilFunction: 0
-    - _SubSurfaceBase: 1.04
-    - _SubSurfaceDepthMax: 9.4
+    - _SubSurfaceBase: 0
+    - _SubSurfaceDepthMax: 7
     - _SubSurfaceDepthPower: 2.57
     - _SubSurfaceHeightLerp: 1
     - _SubSurfaceHeightMax: 24.9
     - _SubSurfaceHeightPower: 1.68
     - _SubSurfaceScattering: 1
     - _SubSurfaceShallowColour: 1
-    - _SubSurfaceSun: 4.46
+    - _SubSurfaceSun: 1.68
     - _SubSurfaceSunFallOff: 5.26
     - _TexelSize: 0.125
     - _TextureRes: 1024
@@ -170,17 +170,17 @@ Material:
     - _WaveFoamStart: 0
     - _WaveFoamStrength: 1
     m_Colors:
-    - _DepthFogDensity: {r: 0.33, g: 0.23, b: 0.27, a: 1}
-    - _Diffuse: {r: 0, g: 0.012440592, b: 0.5660378, a: 1}
-    - _DiffuseGrazing: {r: 0.06345675, g: 0.10691091, b: 0.5849056, a: 1}
-    - _DiffuseShadow: {r: 0, g: 0.3560004, b: 0.5647059, a: 1}
+    - _DepthFogDensity: {r: 0.9, g: 0.3, b: 0.35, a: 1}
+    - _Diffuse: {r: 0, g: 0.003921569, b: 0.16862746, a: 1}
+    - _DiffuseGrazing: {r: 0, g: 0.003921569, b: 0.16862746, a: 1}
+    - _DiffuseShadow: {r: 0, g: 0, b: 0.08627451, a: 1}
     - _FoamBubbleColor: {r: 0.5482029, g: 0.71300006, b: 0.7062737, a: 1}
     - _FoamWhiteColor: {r: 1, g: 0.99634784, b: 0.97199994, a: 0.6862745}
     - _SkyAwayFromSun: {r: 0.15419213, g: 0.22129796, b: 0.5372549, a: 1}
     - _SkyBase: {r: 0.55200005, g: 0.85242355, b: 1, a: 1}
     - _SkyTowardsSun: {r: 2.6390157, g: 1.8217498, b: 0.9236555, a: 1}
     - _SubSurface: {r: 0, g: 0.48, b: 0.36, a: 1}
-    - _SubSurfaceColour: {r: 0.10196078, g: 0.57254905, b: 0.5256646, a: 1}
-    - _SubSurfaceShallowCol: {r: 0.552, g: 1, b: 1, a: 1}
+    - _SubSurfaceColour: {r: 0.09019608, g: 0.49803922, b: 0.45490196, a: 1}
+    - _SubSurfaceShallowCol: {r: 0, g: 0.003921569, b: 0.24705882, a: 1}
     - _SubSurfaceShallowColShadow: {r: 0.14417942, g: 0.2264151, b: 0.21173015, a: 1}
     - _SubSurfaceShallowColour: {r: 0.41999996, g: 0.75, b: 0.69, a: 1}


### PR DESCRIPTION
Copies over the colours, specular and depth fog density from URP so they are similar. I also changed IOR of air to 1 since it is deprecated.

@huwb Did you want the other ocean material to have the same values?