### PR TITLE
Fix compile error building win64 player

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
@@ -59,7 +59,7 @@ Shader "Crest/Copy Depth Buffer Into Cache"
 
 			float4 frag(Varyings input) : SV_Target
 			{
-				float deviceDepth = SAMPLE_DEPTH_TEXTURE(_CamDepthBuffer, input.uv);
+				float deviceDepth = tex2D(_CamDepthBuffer, input.uv);
 				float linear01Z = CustomLinear01Depth(deviceDepth);
 
 				float altitude;

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
@@ -59,7 +59,7 @@ Shader "Crest/Copy Depth Buffer Into Cache"
 
 			float4 frag(Varyings input) : SV_Target
 			{
-				float deviceDepth = tex2D(_CamDepthBuffer, input.uv);
+				float deviceDepth = tex2D(_CamDepthBuffer, input.uv).x;
 				float linear01Z = CustomLinear01Depth(deviceDepth);
 
 				float altitude;


### PR DESCRIPTION
Fixes compile error building standalone development build in win64, 2020.3.10.

Trivial change, but i have no idea why I hit this in years-old code.

