### PR TITLE
Don't verify reqs for builds

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -725,6 +725,13 @@ namespace Crest
 
         bool VerifyRequirements()
         {
+            // If running a build, don't assert any requirements at all. Requirements are for
+            // the runtime, not for making builds.
+            if (BuildPipeline.isBuildingPlayer)
+            {
+                return true;
+            }
+
             if (!RunningWithoutGPU)
             {
                 if (Application.platform == RuntimePlatform.WebGLPlayer)

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -725,12 +725,14 @@ namespace Crest
 
         bool VerifyRequirements()
         {
+#if UNITY_EDITOR
             // If running a build, don't assert any requirements at all. Requirements are for
             // the runtime, not for making builds.
             if (BuildPipeline.isBuildingPlayer)
             {
                 return true;
             }
+#endif
 
             if (!RunningWithoutGPU)
             {


### PR DESCRIPTION
Fixes #812 

`VerifyRequirements` only relevant/valid for runtime to check target platform, not for a build machine/environment.