### PR TITLE
Clear TAs in a single call

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -234,12 +234,15 @@ namespace Crest
                 gerstner.CrestUpdate(buf);
             }
 
-            // lod-dependent data
+            // Clear
+            buf.SetRenderTarget(_waveBuffers, 0, CubemapFace.Unknown, -1);
+            buf.ClearRenderTarget(false, true, new Color(0f, 0f, 0f, 0f));
+
+            // Lod-dependent data
             _filterWavelength._lodCount = lodCount;
             for (int lodIdx = lodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_waveBuffers, 0, CubemapFace.Unknown, lodIdx);
-                buf.ClearRenderTarget(false, true, new Color(0f, 0f, 0f, 0f));
 
                 // draw any data with lod preference
                 _filterWavelength._lodIdx = lodIdx;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -60,11 +60,14 @@ namespace Crest
                 return;
             }
 
+            // Clear
+            buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, -1);
+            var defaultToClip = OceanRenderer.Instance._defaultClippingState == OceanRenderer.DefaultClippingState.EverythingClipped;
+            buf.ClearRenderTarget(false, true, defaultToClip ? Color.white : Color.black);
+
             for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
-                var defaultToClip = OceanRenderer.Instance._defaultClippingState == OceanRenderer.DefaultClippingState.EverythingClipped;
-                buf.ClearRenderTarget(false, true, defaultToClip ? Color.white : Color.black);
                 buf.SetGlobalInt(sp_LD_SliceIndex, lodIdx);
                 SubmitDraws(lodIdx, buf);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -91,10 +91,13 @@ namespace Crest
                 return;
             }
 
+            // Clear
+            buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, -1);
+            buf.ClearRenderTarget(false, true, Color.black);
+
             for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
-                buf.ClearRenderTarget(false, true, Color.black);
                 buf.SetGlobalInt(sp_LD_SliceIndex, lodIdx);
                 SubmitDraws(lodIdx, buf);
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -44,6 +44,7 @@ namespace Crest
                 return;
             }
 
+            // Clear
             buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, -1);
             buf.ClearRenderTarget(false, true, s_nullColor);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -44,10 +44,12 @@ namespace Crest
                 return;
             }
 
+            buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, -1);
+            buf.ClearRenderTarget(false, true, s_nullColor);
+
             for (int lodIdx = OceanRenderer.Instance.CurrentLodCount - 1; lodIdx >= 0; lodIdx--)
             {
                 buf.SetRenderTarget(_targets, 0, CubemapFace.Unknown, lodIdx);
-                buf.ClearRenderTarget(false, true, s_nullColor);
                 buf.SetGlobalInt(sp_LD_SliceIndex, lodIdx);
                 SubmitDraws(lodIdx, buf);
             }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,7 @@ Changed
 .. bullet_list::
 
    -  *ShapeFFT* component allows smooth changing of wind direction everywhere in world.
+   -  Optimisation - water simulation data texture arrays cleared in a single call.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
"Oops"

The old code is a very bad pattern - synchronously clearing one slice at a time. This change clears all texture array slices in a single call.

Checked clear is working in RD.
