### PR TITLE
Collision provider baked FFT

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
@@ -1,0 +1,74 @@
+// Crest Ocean System
+
+// Copyright 2021 Wave Harmonic Ltd
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Crest
+{
+    public class FFTBaker
+    {
+        public static bool Bake(ShapeFFT fftWaves, int resolutionSpace, int resolutionTime, float period, float wavePatchWidth)
+        {
+            // TODO: assert wavePatchWidth is a power of 2
+            // TODO: probably assert period and resolutions are powers of 2 as well. would not hurt..
+
+            var desc = new RenderTextureDescriptor
+            {
+                width = resolutionSpace,
+                height = resolutionSpace,
+                volumeDepth = 1,
+                autoGenerateMips = false,
+                colorFormat = RenderTextureFormat.ARGBFloat,
+                enableRandomWrite = true,
+                dimension = UnityEngine.Rendering.TextureDimension.Tex2D,
+                depthBufferBits = 0,
+                sRGB = false
+            };
+
+            // width of wave patch
+            var wavePatchData = new RenderTexture(desc);
+            var buf = new CommandBuffer();
+
+            // TODO
+            var waveCombineShader = Resources.Load("some compute shader (see below)");
+
+            for (int timeIndex = 0; timeIndex < resolutionTime; timeIndex++)
+            {
+                float t = period * timeIndex / (float)resolutionTime;
+                buf.Clear();
+                var waveData = FFTCompute.GenerateDisplacements(buf, fftWaves._resolution, fftWaves._windTurbulence, fftWaves.WindDirRadForFFT, fftWaves.WindSpeedForFFT, t, fftWaves._spectrum, true);
+
+                // Create a compute shader that generates the final waves:
+                // - takes the waveData texture as input.
+                // - outputs to the stage texture
+                // - for each texel:
+                //    - compute world position using UV and wavePatchWidth
+                //    - initialise output to 0
+                //    - loop over each slice in the wave data, compute slice UV. Similar to computation in AnimWavesGerstner.shader.
+                //    - sample displacements from the slice and add them to the result. using Wrap sampling.
+                //       - could convert to heightfield here, and only store a single value
+                //       - some slices will be too high res. could omit, or maybe it doesnt matter.
+                //buf.SetComputeTextureParam(waveCombineShader, "input", waveData);
+                //buf.SetComputeTextureParam(waveCombineShader, "output", wavePatchData);
+                // ...
+                //buf.DispatchCompute();
+
+                Graphics.ExecuteCommandBuffer(buf);
+
+                // readback data to CPU
+                // what was the trick to doing this again? copy the render texture to a normal texture then read it back? urgh
+                //var data = wavePatchData.GetPixels();
+
+                // File away the data somewhere. Perhaps this? FFTCollisionProvider would have the runtime code.
+                //var fftCollProvider = OceanRenderer.Instance.CollisionProvider as FFTCollisionProvider;
+                //fftCollProvider.SaveData(t, data);
+            }
+
+            return true;
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c1003766a448a74a9690019c895063d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -321,6 +321,8 @@ namespace Crest
 
             LodDataMgrAnimWaves.RegisterUpdatable(this);
 
+            // TODO this is probably only useful for testing, and actually wants to be kicked off via a button/UI
+            // in the SimSettingsAnimWaves, or from a separate editor window or such
             if (_UseThisFFTForHeightQueries)
             {
                 FFTBaker.Bake(this, 256, 32, 16, 16);

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -61,6 +61,18 @@ float RandGauss()
 void DeepDispersion(float k, out float w, out float dwdk)
 {
 	w = sqrt(abs(_Gravity * k));
+
+	// lets say the waves should repeat ever 16s.
+	// TODO: drive this from outside to whatever period is needed.
+	const float globalPeriod = 16;
+	float thisPeriod = PI2 / w;
+	float loops = globalPeriod / thisPeriod;
+	// make sure loops integral number of times
+	loops = ceil( loops );
+	// work our way back to frequency
+	thisPeriod = globalPeriod / loops;
+	w = PI2 / thisPeriod;
+
 	dwdk = _Gravity / (2.0f * w);
 }
 


### PR DESCRIPTION
This is hopefully the start of a new collision approach suggested by user lug on discord. It will generate a patch of waves that loop in time and space, at a set of time steps, and saves it into CPU memory. This could be written to file from editor code and loaded in server builds.

I've modified the spectrum to loop in time (and will already loop in space by construction).

This PR is branched off another branch i'm working called "fft wave generators". These refactor the fft wave gen into a separate object and allows the FFT to be run in a simple/flexible way. Hopefully soon that branch will merge and this PR probably wants to be recreated. In the meantime that dev branch should be functional and should be fine to build off.
