### PR TITLE
Document Underwater Renderer

### DIFF
--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -37,7 +37,7 @@ Preview
 ^^^^^^^
 .. bullet_list::
 
-   -  Add new Underwater Renderer component which executes a fullscreen pass between transparent and post-processing pass.
+   -  Add new *Underwater Renderer* component which executes a fullscreen pass between transparent and post-processing pass.
 
 Changed
 ^^^^^^^

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -72,6 +72,10 @@ Performance
 
    -  FFT wave generation factored out so that multiple *ShapeFFT* components sharing the same settings will only run one FFT.
 
+   .. only:: hdrp
+
+      -  Underwater ocean mask now deactives when the underwater effect is not active. `[HDRP]`
+
 Deprecated
 ^^^^^^^^^^
 .. bullet_list::

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -29,6 +29,12 @@ Breaking
          Unity will raise a missing Render Feature reference error.
          Remove the missing Render Feature to resolve. `[URP]`
 
+Preview
+^^^^^^^
+.. bullet_list::
+
+   -  Add new Underwater Renderer component which executes a fullscreen pass between transparent and post-processing pass.
+
 Changed
 ^^^^^^^
 .. bullet_list::
@@ -39,6 +45,10 @@ Changed
    -  Default *Wind Speed* setting on *OceanRenderer* component to 10m/s.
    -  *CustomTimeProvider* override time/delta time functions are now defaulted to opt-in instead of opt-out.
 
+   .. only:: hdrp
+
+      -  Improve meniscus rendering by also rendering below ocean surface line. `HDRP`
+
 Fixed
 ^^^^^
 .. bullet_list::
@@ -46,6 +56,13 @@ Fixed
    -  Fix case where normal could be NaN, which could make screen flash black in `HDRP`.
    -  Fix *ShapeFFT* *Spectrum Fixed At Runtime* option not working.
    -  Fix shader compile errors on Windows 7.
+
+   .. only:: hdrp
+
+      -  Fix underwater breaking for XR `SPI`. `HDRP`
+      -  Fix underwater artefacts for XR `MP`. `HDRP`
+      -  Fix meniscus rendering incorrectly when camera is rotated. `HDRP`
+
 
 
 4.11

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,10 @@ Breaking
 
       -  Set minimum render pipeline package version to 10.5. `[HDRP] [URP]`
 
+   .. only:: hdrp
+
+      -  *Underwater Post-Processing* is disabled by default which means it will be inactive if the *Underwater Volume Override* is not present in the scene. `[HDRP]`
+
    .. only:: urp
 
       -  Remove *Sample Shadows* Render Feature as it is now scripted.

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -33,16 +33,12 @@ Breaking
          Unity will raise a missing Render Feature reference error.
          Remove the missing Render Feature to resolve. `[URP]`
 
-Preview
-^^^^^^^
-.. bullet_list::
-
-   -  Add new *Underwater Renderer* component which executes a fullscreen pass between transparent and post-processing pass.
-
 Changed
 ^^^^^^^
 .. bullet_list::
 
+   -  Add new *Underwater Renderer* component which executes a fullscreen pass between transparent and post-processing pass.
+      Please see :ref:`underwater` for more information.
    -  FFT wave generation factored out so that multiple *ShapeFFT* components sharing the same settings will only run one FFT.
    -  FFT generator count added to debug GUI.
    -  *ShapeFFT* component allows smooth changing of wind direction everywhere in world.

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -47,22 +47,35 @@ Changed
 
    .. only:: hdrp
 
-      -  Improve meniscus rendering by also rendering below ocean surface line. `HDRP`
+      -  Improve meniscus rendering by also rendering below ocean surface line. `[HDRP]`
 
 Fixed
 ^^^^^
 .. bullet_list::
 
-   -  Fix case where normal could be NaN, which could make screen flash black in `HDRP`.
+   -  Fix case where normal could be NaN, which could make screen flash black in `[HDRP]`.
    -  Fix *ShapeFFT* *Spectrum Fixed At Runtime* option not working.
    -  Fix shader compile errors on Windows 7.
 
    .. only:: hdrp
 
-      -  Fix underwater breaking for XR `SPI`. `HDRP`
-      -  Fix underwater artefacts for XR `MP`. `HDRP`
-      -  Fix meniscus rendering incorrectly when camera is rotated. `HDRP`
+      -  Fix underwater breaking for XR `SPI`. `[HDRP]`
+      -  Fix underwater artefacts for XR `MP`. `[HDRP]`
+      -  Fix meniscus rendering incorrectly when camera is rotated. `[HDRP]`
 
+Deprecated
+^^^^^^^^^^
+.. bullet_list::
+
+   .. only:: birp or urp
+
+      -  The *Underwater Effect* component (including *UnderWaterCurtainGeom.prefab* and *UnderWaterMeniscus.prefab*) has been superseded by the *Underwater Renderer*.
+         Please see :ref:`underwater` for more information. `[BIRP] [URP]`
+
+   .. only:: hdrp
+
+      -  The *Underwater Post-Process* effect has been superseded by the *Underwater Renderer*.
+         Please see :ref:`underwater` for more information. `[HDRP]`
 
 
 4.11

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,8 @@ rst_prolog = rst_prolog + """
 
 .. set:: TAA :abbr:`TAA (Temporal Anti-Aliasing)`
 .. set:: SMAA :abbr:`SMAA (Subpixel Morphological Anti-Aliasing)`
-.. set:: SPI :abbr:`SPI (Single Pass Instanced)`
+.. set:: SPI :abbr:`SPI (Single-Pass Instanced)`
+.. set:: MP :abbr:`MP (Multi-Pass)`
 .. set:: FFT :abbr:`FFT (Fast Fourier Transform)`
 .. set:: GC :abbr:`GC (Garbage Collector)`
 

--- a/docs/user/rendering.rst
+++ b/docs/user/rendering.rst
@@ -40,11 +40,17 @@ Transparent Object Underwater
 
 This is tricky because the underwater effect uses the opaque scene depths in order to render the water fog, which will not include transparents.
 
+The following only applies to the *Underwater Renderer*.
+
 .. only:: birp
 
    .. tab:: `BIRP`
 
-      .. include:: includes/_underwater-curtain-transparents.rst
+      Transparents will need to be rendered after the underwater effect.
+      The underwater effect is rendered at the :link:`CameraEvent.AfterForwardAlpha <{UnityDocScriptLink}/Rendering.CameraEvent.AfterForwardAlpha.html>` event.
+      They can be rendered after the underwater effect using :link:`Command Buffers <{BIRPDocLink}/GraphicsCommandBuffers.html>`.
+      Transparents rendered after the underwater effect will not have the underwater water fog shading applied to them.
+      The effect of the fog either needs to be faked by simply ramping the opacity down to 0 based on distance from the camera, or the water fog shader code needs to be included and called from the transparent shader.
 
 .. only:: hdrp
 
@@ -52,17 +58,22 @@ This is tricky because the underwater effect uses the opaque scene depths in ord
 
       The Submarine example scene demonstrates an underwater transparent effect - the bubbles from the propellors when the submarine is in motion.
       This effect is from the *Bubbles Propellor* GameObject, which is assigned a specific layer *TransparentFX*.
-      To drive the rendering, the *CustomPassForUnderwaterParticles* GameObject has a *Custom Pass Volume* component attached which is configured to render the *TransparentFX* layer in the *After Post Process* injection point, i.e. after the underwater postprocess has rendered.
-      Transparents rendered after the underwater postprocess will not have the underwater water fog shading applied to them.
-      The effect of the fog either needs to be faked by simply ramping the opacity down to 0 based on distance from the camera, or the water fog shader code needs included and called from teh transparent shader.
-      The shader *UnderwaterPostProcessHDRP.shader* is a good reference for calculating the underwater effect.
+      The particles need to be rendered between the underwater and post-processing passes which is achieved using a *Custom Pass Volume* component attached to the *CustomPassForUnderwaterParticles* GameObject.
+      It is configured to render the *TransparentFX* layer in the *Before Post Process* injection point with a priority of "-1" (which orders it to render after the underwater pass).
+      Transparents rendered after the underwater effect will not have the underwater water fog shading applied to them.
+      The effect of the fog either needs to be faked by simply ramping the opacity down to 0 based on distance from the camera, or the water fog shader code needs to be included and called from the transparent shader.
+      The shader *UnderwaterEffectPassHDRP.shader* is a good reference for calculating the underwater effect.
       This will require various parameters on the shader like fog density and others.
 
 .. only:: urp
 
    .. tab:: `URP`
 
-      .. include:: includes/_underwater-curtain-transparents.rst
+      Transparents will need to be rendered after the underwater effect.
+      The underwater effect is rendered at the *BeforeRenderingPostProcessing* event.
+      They can be rendered after the underwater effect using the :link:`Render Objects Render Feature <{URPDocLink}/urp-renderer-feature-how-to-add.html>` set to *BeforeRenderingPostProcessing*.
+      Transparents rendered after the underwater effect will not have the underwater water fog shading applied to them.
+      The effect of the fog either needs to be faked by simply ramping the opacity down to 0 based on distance from the camera, or the water fog shader code needs to be included and called from the transparent shader.
 
 .. only:: birp or urp
 

--- a/docs/user/underwater.rst
+++ b/docs/user/underwater.rst
@@ -99,6 +99,11 @@ Setup
    Underwater Post-Process `[HDRP]`
    --------------------------------
 
+   .. admonition:: Deprecated
+
+      The *Underwater Post-Process* will be removed in a future Crest version.
+      It has been replaced by the *Underwater Renderer*.
+
    Renders the underwater effect at the beginning of the post-processing stack.
 
    .. _underwater_pp_setup:

--- a/docs/user/underwater.rst
+++ b/docs/user/underwater.rst
@@ -34,7 +34,7 @@ Underwater Renderer
 
    .. admonition:: Bug
 
-      Due to a Unity bug, the Underwater Renderer does not support XR SPI for URP.
+      Due to a :link:`Unity bug <{UnityIssueLink}/1335524>`, the *Underwater Renderer* does not support XR `SPI` for `URP`.
 
 
 The *Underwater Renderer* component executes a fullscreen underwater effect between the transparent pass and post-processing pass.

--- a/docs/user/underwater.rst
+++ b/docs/user/underwater.rst
@@ -3,8 +3,10 @@
 Underwater
 ==========
 
+.. image:: /_media/UnderwaterPostProcess.png
+
 *Crest* supports seamless transitions above/below water.
-It can also has a meniscus which renders a subtle line at the intersection between the camera lens and the water to visually help the transition.
+It can also have a meniscus which renders a subtle line at the intersection between the camera lens and the water to visually help the transition.
 This is demonstrated in the *main.unity* scene in the example content.
 The ocean in this scene uses the material *Ocean-Underwater.mat* which enables rendering the underside of the surface.
 
@@ -25,14 +27,65 @@ Only the camera rendering the ocean surface will be used.
    Underwater effects do *not* support orthographic projection.
 
 
+Underwater Renderer
+-------------------
+
+.. only:: urp
+
+   .. admonition:: Bug
+
+      Due to a Unity bug, the Underwater Renderer does not support XR SPI for URP.
+
+
+The *Underwater Renderer* component executes a fullscreen underwater effect between the transparent pass and post-processing pass.
+
+It is similar to a post-processing effect, but has the benefit of allowing other renderers to execute after it and still receive post-processing.
+An example is to add underwater fog correctly to semi-transparent objects.
+
+This is the current underwater solution used for the example scenes, and is the simplest to setup.
+
+Setup
+^^^^^
+
+.. only:: birp
+
+   .. tab:: `BIRP`
+
+      -  Configure the ocean material for underwater rendering.
+         In the *Underwater* section of the material params, ensure *Enabled* is turned on and *Cull Mode* is set to *Off* so that the underside of the ocean surface renders.
+         See *Ocean-Underwater.mat* for an example.
+
+.. only:: hdrp
+
+   .. tab:: `HDRP`
+
+      -  Configure the ocean material for underwater rendering.
+         Ensure that *Double-Sided* is enabled under *Surface Options* on the ocean material so that the underside of the ocean surface renders.
+         See *Ocean-Underwater.mat* for an example.
+
+.. only:: urp
+
+   .. tab:: `URP`
+
+      -  Configure the ocean material for underwater rendering.
+         In the *Underwater* section of the material params, ensure *Enabled* is turned on and *Cull Mode* is set to *Off* so that the underside of the ocean surface renders.
+         See *Ocean-Underwater.mat* for an example.
+
+-  Add the *Underwater Renderer* component to your camera game object.
+
+
 .. only:: birp or urp
 
    Underwater Curtain `[BIRP] [URP]`
-   -----------------------------------
+   ---------------------------------
 
-   In the *main.unity* scene, the *UnderWaterCurtainGeom* and *UnderWaterMeniscus* prefabs are parented to the camera which renders the underwater effects.
+   .. admonition:: Deprecated
 
-   Checklist for using underwater:
+      The *Underwater Curtain* will be removed in a future Crest version.
+      It has been replaced by the *Underwater Renderer*.
+
+   Setup
+   ^^^^^
 
    -  Configure the ocean material for underwater rendering.
       In the *Underwater* section of the material params, ensure *Enabled* is turned on and *Cull Mode* is set to *Off* so that the underside of the ocean surface renders.
@@ -46,17 +99,12 @@ Only the camera rendering the ocean surface will be used.
    Underwater Post-Process `[HDRP]`
    --------------------------------
 
-   .. image:: /_media/UnderwaterPostProcess.png
-
-   .. only:: html or readthedocs
-
-      Unlike the Underwater Curtain, the custom post-process effect is pixel-perfect.
-
+   Renders the underwater effect at the beginning of the post-processing stack.
 
    .. _underwater_pp_setup:
 
-   Setup steps
-   ^^^^^^^^^^^
+   Setup
+   ^^^^^
 
    Steps to set up underwater:
 
@@ -64,20 +112,19 @@ Only the camera rendering the ocean surface will be used.
 
    #. Enable :link:`Custom Pass on the {HDRP} Asset <{HDRPDocLink}/HDRP-Asset.html#rendering>` and ensure that :link:`Custom pass on the camera's Frame Settings <{HDRPDocLink}/Frame-Settings.html#rendering>` is not disabled.
 
-   #. Add the custom post-process (*Crest.UnderwaterPostProcessHDRP*) to the *Before Post Process* list.
+   #. Add the custom post-process (*Crest.UnderwaterPostProcessHDRP*) to the *Before TAA* list.
       See the :link:`Custom Post Process documentation <{HDRPDocLink}/Custom-Post-Process.html#effect-ordering>`.
-
-      .. note:: For Unity 2020.2+/`HDRP` 10+, use *Before TAA*. This will fix the outline on alpha clipped objects when undewater.
 
    #. Add the *Crest/Underwater* :link:`Volume Component <{HDRPDocLink}/Volume-Components.html>`.
 
-      -  Please learn how to use the *Volume Framework* before proceeding as covering this is beyond the scope of our documentation:
+      -   Please learn how to use the *Volume Framework* before proceeding as covering this is beyond the scope of our documentation:
 
-         .. youtube:: vczkfjLoPf8
+      .. youtube:: vczkfjLoPf8
 
-            Adding Volumes to `HDRP` (Tutorial)
+         Adding Volumes to `HDRP` (Tutorial)
 
-   #. Configure the ocean material for underwater rendering - in the *Underwater* section of the material params, ensure *Cull Mode* is set to *Off* so that the underside of the ocean surface renders.
+   #. Configure the ocean material for underwater rendering.
+      Ensure that *Double-Sided* is enabled under *Surface Options* on the ocean material so that the underside of the ocean surface renders.
       See *Ocean-Underwater.mat* for an example.
 
 


### PR DESCRIPTION
Rearranges and rewrites a few things for the _Underwater Renderer_ being the primary underwater solution.

- Added _Underwater Renderer_ to underwater page
- Deprecated curtain and post-processing
- Changed underwater transparents for _Underwater Renderer_
- Added release notes

Here are the pages:
https://crest.readthedocs.io/en/docs-underwater-renderer/user/underwater.html
https://crest.readthedocs.io/en/docs-underwater-renderer/user/rendering.html
https://crest.readthedocs.io/en/docs-underwater-renderer/about/history.html

Let me know what you think.