### PR TITLE
Add texture format setting to fix precision issues from height input

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -59,6 +59,25 @@ namespace Crest
 
         protected OceanRenderer _ocean;
 
+        // Implement in any sub-class which supports having an asset file for settings. This is used for polymorphic
+        // operations. A sub-class will also implement an alternative for the specialised type called Settings.
+        public virtual SimSettingsBase SettingsBase => null;
+        SimSettingsBase _defaultSettings;
+
+        /// <summary>
+        /// Returns the default value of the settings asset for the provided type.
+        /// </summary>
+        protected SettingsType GetDefaultSettings<SettingsType>() where SettingsType : SimSettingsBase
+        {
+            if (_defaultSettings == null)
+            {
+                _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
+                _defaultSettings.name = SimName + " Auto-generated Settings";
+            }
+
+            return (SettingsType)_defaultSettings;
+        }
+
         public LodDataMgr(OceanRenderer ocean)
         {
             _ocean = ocean;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -67,21 +67,8 @@ namespace Crest
         public static void RegisterUpdatable(IShapeUpdatable updatable) => _updatables.Add(updatable);
         public static void DeregisterUpdatable(IShapeUpdatable updatable) => _updatables.RemoveAll(candidate => candidate == updatable);
 
-        SettingsType _defaultSettings;
-        public SettingsType Settings
-        {
-            get
-            {
-                if (_ocean._simSettingsAnimatedWaves != null) return _ocean._simSettingsAnimatedWaves;
-
-                if (_defaultSettings == null)
-                {
-                    _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
-                    _defaultSettings.name = SimName + " Auto-generated Settings";
-                }
-                return _defaultSettings;
-            }
-        }
+        public override SimSettingsBase SettingsBase => Settings;
+        public SettingsType Settings => _ocean._simSettingsAnimatedWaves != null ? _ocean._simSettingsAnimatedWaves : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrAnimWaves(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -28,7 +28,7 @@ namespace Crest
     {
         public override string SimName { get { return "AnimatedWaves"; } }
         // shape format. i tried RGB111110Float but error becomes visible. one option would be to use a UNORM setup.
-        protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16G16B16A16_SFloat;
+        protected override GraphicsFormat RequestedTextureFormat => Settings._renderTextureGraphicsFormat;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
 
         [Tooltip("Read shape textures back to the CPU for collision purposes.")]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -37,21 +37,8 @@ namespace Crest
         readonly int sp_Gravity = Shader.PropertyToID("_Gravity");
         readonly int sp_CourantNumber = Shader.PropertyToID("_CourantNumber");
 
-        SettingsType _defaultSettings;
-        public SettingsType Settings
-        {
-            get
-            {
-                if (_ocean._simSettingsDynamicWaves != null) return _ocean._simSettingsDynamicWaves;
-
-                if (_defaultSettings == null)
-                {
-                    _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
-                    _defaultSettings.name = SimName + " Auto-generated Settings";
-                }
-                return _defaultSettings;
-            }
-        }
+        public override SimSettingsBase SettingsBase => Settings;
+        public SettingsType Settings => _ocean._simSettingsDynamicWaves != null ? _ocean._simSettingsDynamicWaves : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrDynWaves(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -31,21 +31,8 @@ namespace Crest
 
         public const string FLOW_KEYWORD = "CREST_FLOW_ON_INTERNAL";
 
-        SettingsType _defaultSettings;
-        public SettingsType Settings
-        {
-            get
-            {
-                if (_ocean._simSettingsFlow != null) return _ocean._simSettingsFlow;
-
-                if (_defaultSettings == null)
-                {
-                    _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
-                    _defaultSettings.name = SimName + " Auto-generated Settings";
-                }
-                return _defaultSettings;
-            }
-        }
+        public override SimSettingsBase SettingsBase => Settings;
+        public SettingsType Settings => _ocean._simSettingsFlow != null ? _ocean._simSettingsFlow : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrFlow(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -34,21 +34,8 @@ namespace Crest
         readonly int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
         readonly int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
 
-        SettingsType _defaultSettings;
-        public SettingsType Settings
-        {
-            get
-            {
-                if (_ocean._simSettingsFoam != null) return _ocean._simSettingsFoam;
-
-                if (_defaultSettings == null)
-                {
-                    _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
-                    _defaultSettings.name = SimName + " Auto-generated Settings";
-                }
-                return _defaultSettings;
-            }
-        }
+        public override SimSettingsBase SettingsBase => Settings;
+        public SettingsType Settings => _ocean._simSettingsFoam != null ? _ocean._simSettingsFoam : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrFoam(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -4,6 +4,7 @@
 
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 
 namespace Crest
 {
@@ -12,7 +13,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Height Input")]
-    public class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrAnimWaves>
+    public partial class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrAnimWaves>
     {
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
@@ -76,4 +77,30 @@ namespace Crest
         protected override bool FeatureEnabled(OceanRenderer ocean) => true;
 #endif // UNITY_EDITOR
     }
+
+#if UNITY_EDITOR
+    public partial class RegisterHeightInput
+    {
+        public override bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var isValid = base.Validate(ocean, showMessage);
+
+            if (isValid)
+            {
+                if (ocean != null && ocean._simSettingsAnimatedWaves._renderTextureGraphicsFormat != GraphicsFormat.R32G32B32A32_SFloat)
+                {
+                    showMessage(
+                        "Changing the height of the ocean can reduce precision leading to artefacts like tearing or incorrect normals. " +
+                        $"{ocean._simSettingsAnimatedWaves._renderTextureGraphicsFormat} may not have enough precision.",
+                        "Change graphics format to <i>R32G32B32A32_SFloat</i>.",
+                        ValidatedHelper.MessageType.Warning,
+                        ocean
+                    );
+                }
+            }
+
+            return isValid;
+        }
+    }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -400,7 +400,7 @@ namespace Crest
         protected virtual string MaterialFeatureDisabledError => null;
         protected virtual string MaterialFeatureDisabledFix => null;
 
-        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        public virtual bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             var isValid = ValidatedHelper.ValidateInputMesh(RendererRequired, gameObject, showMessage);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -9,6 +9,7 @@ using UnityEngine.Experimental.Rendering;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsAnimatedWaves", menuName = "Crest/Animated Waves Sim Settings", order = 10000)]
+    [HelpURL(k_HelpURL)]
     public partial class SimSettingsAnimatedWaves : SimSettingsBase
     {
         /// <summary>
@@ -19,6 +20,8 @@ namespace Crest
 #pragma warning disable 414
         int _version = 0;
 #pragma warning restore 414
+
+        public const string k_HelpURL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves-settings";
 
         [Tooltip("How much waves are dampened in shallow water."), SerializeField, Range(0f, 1f)]
         float _attenuationInShallows = 0.95f;
@@ -146,5 +149,23 @@ namespace Crest
             }
         }
     }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(SimSettingsAnimatedWaves), true), CanEditMultipleObjects]
+    class SimSettingsAnimatedWavesEditor : SimSettingsBaseEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.Space();
+            if (GUILayout.Button("Open Online Help Page"))
+            {
+                Application.OpenURL(SimSettingsAnimatedWaves.k_HelpURL);
+            }
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+    }
+#endif
 #endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -4,6 +4,7 @@
 
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 
 namespace Crest
 {
@@ -42,6 +43,15 @@ namespace Crest
         [Tooltip("Whether to use a graphics shader for combining the wave cascades together. Disabling this uses a compute shader instead which doesn't need to copy back and forth between targets, but it may not work on some GPUs, in particular pre-DX11.3 hardware, which do not support typed UAV loads. The fail behaviour is a flat ocean."), SerializeField]
         bool _pingPongCombinePass = true;
         public bool PingPongCombinePass => _pingPongCombinePass;
+
+        [Tooltip("The render texture format to use for the wave simulation. It should only be changed if you need more precision. See the documentation for information.")]
+        public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R16G16B16A16_SFloat;
+
+        public override void AddToSettingsHash(ref int settingsHash)
+        {
+            base.AddToSettingsHash(ref settingsHash);
+            Hashy.AddInt((int)_renderTextureGraphicsFormat, ref settingsHash);
+        }
 
         /// <summary>
         /// Provides ocean shape to CPU.

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsBase.cs
@@ -15,6 +15,13 @@ namespace Crest
     /// </summary>
     public partial class SimSettingsBase : ScriptableObject
     {
+        /// <summary>
+        /// Adds anything that requires a rebuild to the provided settings hash.
+        /// </summary>
+        public virtual void AddToSettingsHash(ref int settingsHash)
+        {
+            // Intentionally left empty.
+        }
     }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
@@ -47,6 +47,12 @@ namespace Crest
         public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R16_SFloat;
         [Range(15f, 200f), Tooltip("Frequency to run the foam sim, in updates per second. Lower frequencies can be more efficient but may lead to visible jitter. Default is 30 updates per second.")]
         public float _simulationFrequency = 30f;
+
+        public override void AddToSettingsHash(ref int settingsHash)
+        {
+            base.AddToSettingsHash(ref settingsHash);
+            Hashy.AddInt((int)_renderTextureGraphicsFormat, ref settingsHash);
+        }
     }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -57,21 +57,8 @@ namespace Crest
         readonly int sp_LD_TexArray_Target = Shader.PropertyToID("_LD_TexArray_Target");
         readonly int sp_cascadeDataSrc = Shader.PropertyToID("_CascadeDataSrc");
 
-        SettingsType _defaultSettings;
-        public SettingsType Settings
-        {
-            get
-            {
-                if (_ocean._simSettingsShadow != null) return _ocean._simSettingsShadow;
-
-                if (_defaultSettings == null)
-                {
-                    _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
-                    _defaultSettings.name = SimName + " Auto-generated Settings";
-                }
-                return _defaultSettings;
-            }
-        }
+        public override SimSettingsBase SettingsBase => Settings;
+        public SettingsType Settings => _ocean._simSettingsShadow != null ? _ocean._simSettingsShadow : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrShadow(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -497,7 +497,6 @@ namespace Crest
             _lodAlphaBlackPointWhitePointFade = 1f - _lodAlphaBlackPointFade - _lodAlphaBlackPointFade;
 
             Root = OceanBuilder.GenerateMesh(this, _oceanChunkRenderers, _lodDataResolution, _geometryDownSampleFactor, _lodCount);
-            _generatedSettingsHash = CalculateSettingsHash();
 
             // Make sure we have correct defaults in case simulations are not enabled.
             LodDataMgrClipSurface.BindNullToGraphicsShaders();
@@ -528,6 +527,8 @@ namespace Crest
             }
 
             _canSkipCulling = false;
+
+            _generatedSettingsHash = CalculateSettingsHash();
         }
 
         private void OnDisable()
@@ -834,6 +835,16 @@ namespace Crest
 #pragma warning disable 0618
             Hashy.AddObject(_layerName, ref settingsHash);
 #pragma warning restore 0618
+
+            // Also include anything from the simulation settings for rebuilding.
+            foreach (var lod in _lodDatas)
+            {
+                // Null means it does not support settings.
+                if (lod.SettingsBase != null)
+                {
+                    lod.SettingsBase.AddToSettingsHash(ref settingsHash);
+                }
+            }
 
             return settingsHash;
         }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,6 +13,13 @@ Release Notes
 |version|
 ---------
 
+Changed
+^^^^^^^
+.. bullet_list::
+
+   -  Add *Render Texture Graphics Format* option to *Animated Waves Sim Settings* to solve precision issues when using height inputs.
+
+
 Fixed
 ^^^^^
 .. bullet_list::

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -30,6 +30,24 @@ The animated waves sim can be configured by assigning an Animated Waves Sim Sett
 The waves will be dampened/attenuated in shallow water if a *Sea Floor Depth* LOD data is used (see :ref:`sea-floor-depth-section`).
 The amount that waves are attenuated is configurable using the *Attenuation In Shallows* setting.
 
+
+.. _animated_waves_settings:
+
+Simulation Settings
+^^^^^^^^^^^^^^^^^^^
+
+All of the settings below refer to the *Animated Waves Sim Settings* asset.
+
+-  **Collision Source** - Where to obtain ocean shape on CPU for physics / gameplay.
+-  **Max Query Count** - Maximum number of wave queries that can be performed when using ComputeShaderQueries.
+-  **Ping Pong Combine Pass** - Whether to use a graphics shader for combining the wave cascades together.
+   Disabling this uses a compute shader instead which doesn't need to copy back and forth between targets, but it may not work on some GPUs, in particular pre-DX11.3 hardware, which do not support typed UAV loads.
+   The fail behaviour is a flat ocean.
+-  **Render Texture Graphics Format** - The render texture format to use for the wave simulation.
+   Consider using higher precision (like R32G32B32A32_SFloat) if you see tearing or wierd normals.
+   You may encounter this issue if you use any of the *Set Water Height* inputs.
+
+
 User Inputs
 ^^^^^^^^^^^
 


### PR DESCRIPTION
Fixes #864

- Refactors settings code to push code up to LodDataMgr
- Can now add settings from SimSettings to settings hash (only needed for changing textures so far I believe)
- Adds texture format option for animated waves to solve precision issues
- Adds validation to height input to warn users if not using higher precision texture
  - only really useful if they are using the default
- Documents animate waves settings and links to it