### PR TITLE
Report renderer bounds by default for Animated Waves input

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -42,10 +42,6 @@ namespace Crest
         [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;
 
-        [SerializeField, Tooltip("Use the bounding box of an attached renderer component to determine the max vertical displacement.")]
-        [Predicated(typeof(MeshRenderer)), DecoratedField]
-        bool _reportRendererBoundsToOceanSystem = false;
-
         protected override void Update()
         {
             base.Update();
@@ -58,7 +54,7 @@ namespace Crest
             var maxDispVert = _maxDisplacementVertical;
 
             // let ocean system know how far from the sea level this shape may displace the surface
-            if (_reportRendererBoundsToOceanSystem && _renderer != null)
+            if (_renderer != null)
             {
                 var minY = _renderer.bounds.min.y;
                 var maxY = _renderer.bounds.max.y;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -18,6 +18,7 @@ Changed
 .. bullet_list::
 
    -  Add *Render Texture Graphics Format* option to *Animated Waves Sim Settings* to solve precision issues when using height inputs.
+   -  Always report displacement in *Register Height Input* to solve culling issues.
 
 
 Fixed


### PR DESCRIPTION
Helps solve #865

Reports the renderer bounds on Animated Waves input by default. The reasoning is that I think reporting the renderer bounds requires some understanding of the system which most will not know. They may come across this issue and not understand the cause. This is a "working correctly by default and optimisation yourself" approach. Let me know what you think.