### PR TITLE
Add LOD data matrix height options

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -12,6 +12,11 @@ namespace Crest
     /// </summary>
     public class LodTransform : IFloatingOrigin
     {
+        // Anything higher (minus 1 for near plane) will be clipped.
+        const float k_RenderAboveSeaLevel = 10000f;
+        // Anything lower will be clipped.
+        const float k_RenderBelowSeaLevel = 10000f;
+
         protected int[] _transformUpdateFrame;
 
         [System.Serializable]
@@ -102,9 +107,9 @@ namespace Crest
                     _renderDataSource[lodIdx]._maxWavelength = _renderData[lodIdx]._maxWavelength;
                 }
 
-                _worldToCameraMatrix[lodIdx] = CalculateWorldToCameraMatrixRHS(_renderData[lodIdx]._posSnapped + Vector3.up * 100f, Quaternion.AngleAxis(90f, Vector3.right));
+                _worldToCameraMatrix[lodIdx] = CalculateWorldToCameraMatrixRHS(_renderData[lodIdx]._posSnapped + Vector3.up * k_RenderAboveSeaLevel, Quaternion.AngleAxis(90f, Vector3.right));
 
-                _projectionMatrix[lodIdx] = Matrix4x4.Ortho(-2f * lodScale, 2f * lodScale, -2f * lodScale, 2f * lodScale, 1f, 500f);
+                _projectionMatrix[lodIdx] = Matrix4x4.Ortho(-2f * lodScale, 2f * lodScale, -2f * lodScale, 2f * lodScale, 1f, k_RenderAboveSeaLevel + k_RenderBelowSeaLevel);
             }
         }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -25,6 +25,7 @@ Fixed
 .. bullet_list::
 
    -  Fix ocean not rendering on Xbox One and Xbox Series X.
+   -  Fix height input (and others) from not working 100m above sea level and 500m below sea level.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Helps solve #865

Current the LOD data is rendered from a position of 100m above sea level. I have had reports of people setting the height above this position. So this adds a setting to allow them to change both above and below rendering bounds.

Not sure if you planned on solving this some other way with water bodies, but this seems like an okay solution for now. Let me know what you think.

Will add documentation if solution seems good.