### PR TITLE
Add signed distance clip surface shader

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Models/OldBoat/RowBoat.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Models/OldBoat/RowBoat.prefab
@@ -105,7 +105,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _checkShaderName: 1
   _disableRenderer: 1
-  _version: 0
+  _version: 1
+  _mode: 0
+  _primitive: 3
   _disableClipSurfaceWhenTooFarFromSurface: 0
   _animatedWavesDisplacementSamplingIterations: 4
 --- !u!1001 &2226860581654032180
@@ -117,7 +119,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 100002, guid: 62ccde94e774dba4c8620e847d94f072, type: 3}
       propertyPath: m_Name
-      value: OldBoat Variant
+      value: RowBoat
       objectReference: {fileID: 0}
     - target: {fileID: 400002, guid: 62ccde94e774dba4c8620e847d94f072, type: 3}
       propertyPath: m_RootOrder

--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/BoatSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scenes/Internal/BoatSceneCore.prefab
@@ -259,6 +259,7 @@ MonoBehaviour:
   _createShadowData: 0
   _simSettingsShadow: {fileID: 0}
   _createClipSurfaceData: 1
+  _simSettingsClipSurface: {fileID: 0}
   _defaultClippingState: 0
   _showOceanProxyPlane: 0
   _editModeFPS: 30
@@ -5163,8 +5164,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6042195510057757633}
-  - component: {fileID: 3754956674247989678}
-  - component: {fileID: 6437497966077166402}
   - component: {fileID: 2366599179562479927}
   m_Layer: 0
   m_Name: ClipSurfaceConvexHull
@@ -5187,55 +5186,6 @@ Transform:
   m_Father: {fileID: 1709276512138961289}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &3754956674247989678
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3951424492669154611}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &6437497966077166402
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3951424492669154611}
-  m_Enabled: 0
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 0
-  m_ReflectionProbeUsage: 0
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 53ebdf534c08f483096dbd37ba1c2253, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!114 &2366599179562479927
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5250,7 +5200,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _checkShaderName: 1
   _disableRenderer: 1
-  _version: 0
+  _version: 1
+  _mode: 1
+  _primitive: 3
   _disableClipSurfaceWhenTooFarFromSurface: 0
   _animatedWavesDisplacementSamplingIterations: 4
 --- !u!1 &5831241881590923069
@@ -5502,15 +5454,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 71ede3c2ab0b7cb43b7dad6ae3b6190b, type: 3}
---- !u!4 &1709044165449915545 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4274299234749796, guid: 71ede3c2ab0b7cb43b7dad6ae3b6190b,
-    type: 3}
-  m_PrefabInstance: {fileID: 1709276513273483773}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1709113576438740099 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4341219009766782, guid: 71ede3c2ab0b7cb43b7dad6ae3b6190b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1709276513273483773}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1709044165449915545 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4274299234749796, guid: 71ede3c2ab0b7cb43b7dad6ae3b6190b,
     type: 3}
   m_PrefabInstance: {fileID: 1709276513273483773}
   m_PrefabAsset: {fileID: 0}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -290,7 +290,7 @@ namespace Crest
             var renderer = GetComponent<Renderer>();
             if (renderer.sharedMaterial && renderer.sharedMaterial.shader && !renderer.sharedMaterial.shader.name.StartsWith(shaderPrefix))
             {
-                ValidatedHelper.ValidateMaterial(renderer.sharedMaterial, shaderPrefix, gameObject, showMessage);
+                ValidatedHelper.ValidateMaterial(gameObject, showMessage, renderer.sharedMaterial, shaderPrefix);
 
                 isValid = false;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -8,6 +8,8 @@ using UnityEngine.Rendering;
 
 namespace Crest
 {
+    using SettingsType = SimSettingsClipSurface;
+
     /// <summary>
     /// Drives ocean surface clipping (carving holes). 0-1 values, surface clipped when > 0.5.
     /// </summary>
@@ -15,8 +17,7 @@ namespace Crest
     {
         public override string SimName { get { return "ClipSurface"; } }
 
-        // The clip values only really need 8bits
-        protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R8_UNorm;
+        protected override GraphicsFormat RequestedTextureFormat => Settings._renderTextureGraphicsFormat;
         protected override bool NeedToReadWriteTextureData { get { return true; } }
         static Texture2DArray s_nullTexture => TextureArrayHelpers.BlackTextureArray;
         protected override Texture2DArray NullTexture => s_nullTexture;
@@ -29,6 +30,9 @@ namespace Crest
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the <i>Clipping</i> feature on the ocean material to save performance.";
 
         bool _targetsClear = false;
+
+        public override SimSettingsBase SettingsBase => Settings;
+        public SettingsType Settings => _ocean._simSettingsClipSurface != null ? _ocean._simSettingsClipSurface : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrClipSurface(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -1,8 +1,10 @@
-﻿// Crest Ocean System
+// Crest Ocean System
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using UnityEditor;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Crest
 {
@@ -12,7 +14,7 @@ namespace Crest
     /// </summary>
     [AddComponentMenu(MENU_PREFIX + "Clip Surface Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#clip-surface")]
-    public class RegisterClipSurfaceInput : RegisterLodDataInput<LodDataMgrClipSurface>
+    public partial class RegisterClipSurfaceInput : RegisterLodDataInput<LodDataMgrClipSurface>
     {
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
@@ -20,13 +22,38 @@ namespace Crest
         /// </summary>
         [SerializeField, HideInInspector]
 #pragma warning disable 414
-        int _version = 0;
+        int _version = 1;
 #pragma warning restore 414
+
+        const string k_SignedDistanceShaderPath = "Hidden/Crest/Inputs/Clip Surface/Signed Distance";
+
+        public enum Mode
+        {
+            Geometry,
+            Primitive,
+        }
+
+        // Have this match UnityEngine.PrimitiveType.
+        public enum Primitive
+        {
+            Sphere = 0,
+            Cube = 3,
+        }
 
         bool _enabled = true;
         public override bool Enabled => _enabled;
 
-        [Header("Convex Hull Options")]
+        [Header("Clip Surface Input Options")]
+
+        [Tooltip("Where the source of the clipping will come from.")]
+        [SerializeField]
+        Mode _mode = Mode.Primitive;
+
+        [Tooltip("The primitive to render (signed distance) into the simulation.")]
+        [SerializeField, Predicated("_mode", inverted: true, Mode.Primitive), DecoratedField]
+        Primitive _primitive = Primitive.Cube;
+
+        [Header("3D Clipping Options")]
 
         [Tooltip("Prevents inputs from cancelling each other out when aligned vertically. It is imperfect so custom logic might be needed for your use case.")]
         [SerializeField] bool _disableClipSurfaceWhenTooFarFromSurface = false;
@@ -47,15 +74,114 @@ namespace Crest
         SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
         static int sp_DisplacementSamplingIterations = Shader.PropertyToID("_DisplacementSamplingIterations");
+        static readonly int sp_SignedDistanceShapeMatrix = Shader.PropertyToID("_SignedDistanceShapeMatrix");
 
-        private void LateUpdate()
+        Material _signedDistancedMaterial;
+        Primitive _activePrimitive;
+
+        // For rendering signed distance shapes and gizmos.
+        static Mesh s_Quad;
+        Matrix4x4 QuadMatrix
         {
-            if (OceanRenderer.Instance == null || _renderer == null)
+            get
+            {
+                var position = transform.position;
+                // Apply sea level to matrix so we can use it for rendering and gizmos.
+                position.y = OceanRenderer.Instance.SeaLevel;
+                var scale = Vector3.one * (Mathf.Max(transform.lossyScale.x, transform.lossyScale.y, transform.lossyScale.z) * 2f);
+                scale.z = 0f;
+                return Matrix4x4.TRS(position, Quaternion.Euler(90f, 0f, 0f), scale);
+            }
+        }
+
+        protected override void Start()
+        {
+            base.Start();
+
+            InitializeSignedDistanceMaterial();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+#if UNITY_EDITOR
+            InitializeSignedDistanceMaterial();
+#endif
+        }
+
+        void InitializeSignedDistanceMaterial()
+        {
+            if (_signedDistancedMaterial == null)
+            {
+                _signedDistancedMaterial = new Material(Shader.Find(k_SignedDistanceShaderPath));
+                _signedDistancedMaterial.hideFlags = HideFlags.HideAndDontSave;
+            }
+
+            // Could refactor using hashy.
+            if (_primitive != _activePrimitive)
+            {
+                foreach (var primitive in System.Enum.GetNames(typeof(Primitive)))
+                {
+                    _signedDistancedMaterial.DisableKeyword($"_{primitive.ToUpper()}");
+                }
+
+                _signedDistancedMaterial.EnableKeyword($"_{System.Enum.GetName(typeof(Primitive), _primitive).ToUpper()}");
+
+                _activePrimitive = _primitive;
+            }
+        }
+
+        public override void Draw(CommandBuffer buf, float weight, int isTransition, int lodIdx)
+        {
+            if (weight <= 0f)
             {
                 return;
             }
 
-            // Prevents possible conflicts since overlapping doesn't work for every case.
+            if (_mode == Mode.Primitive && _signedDistancedMaterial == null)
+            {
+                return;
+            }
+
+            if (_mode == Mode.Geometry && (_renderer == null || _material == null))
+            {
+                return;
+            }
+
+            buf.SetGlobalFloat(sp_Weight, weight);
+            buf.SetGlobalFloat(LodDataMgr.sp_LD_SliceIndex, lodIdx);
+            buf.SetGlobalVector(sp_DisplacementAtInputPosition, Vector3.zero);
+
+            if (_mode == Mode.Primitive)
+            {
+                if (s_Quad == null)
+                {
+                    s_Quad = Resources.GetBuiltinResource<Mesh>("Quad.fbx");
+                }
+
+                // Need this here or will see NullReferenceException on recompile.
+                if (_mpb == null)
+                {
+                    _mpb = new PropertyWrapperMPB();
+                }
+
+                buf.DrawMesh(s_Quad, QuadMatrix, _signedDistancedMaterial, submeshIndex: 0, shaderPass: 0, _mpb.materialPropertyBlock);
+            }
+            else
+            {
+                buf.DrawRenderer(_renderer, _material);
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (OceanRenderer.Instance == null || (_mode == Mode.Geometry && _renderer == null))
+            {
+                return;
+            }
+
+            // Prevents possible conflicts since overlapping doesn't work for every case for convex null.
             if (_disableClipSurfaceWhenTooFarFromSurface)
             {
                 var position = transform.position;
@@ -78,17 +204,28 @@ namespace Crest
 
             if (lodIdx > -1)
             {
+                // Need this here or will see NullReferenceException on recompile.
                 if (_mpb == null)
                 {
                     _mpb = new PropertyWrapperMPB();
                 }
 
-                _renderer.GetPropertyBlock(_mpb.materialPropertyBlock);
+                if (_mode == Mode.Geometry)
+                {
+                    _renderer.GetPropertyBlock(_mpb.materialPropertyBlock);
+                }
 
                 _mpb.SetInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
                 _mpb.SetInt(sp_DisplacementSamplingIterations, (int)_animatedWavesDisplacementSamplingIterations);
 
-                _renderer.SetPropertyBlock(_mpb.materialPropertyBlock);
+                if (_mode == Mode.Geometry)
+                {
+                    _renderer.SetPropertyBlock(_mpb.materialPropertyBlock);
+                }
+                else
+                {
+                    _mpb.SetMatrix(sp_SignedDistanceShapeMatrix, Matrix4x4.TRS(transform.position, transform.rotation, transform.lossyScale).inverse);
+                }
             }
         }
 
@@ -98,9 +235,84 @@ namespace Crest
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateClipSurfaceData;
         protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
         protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
-
         protected override string MaterialFeatureDisabledError => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING;
         protected override string MaterialFeatureDisabledFix => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
+
+        protected override bool RendererRequired => _mode == Mode.Geometry;
+        protected override bool RendererOptional => _mode != Mode.Geometry;
+
+        // Use Unity's UV sphere mesh for gizmos as Gizmos.DrawSphere is too low resolution.
+        static Mesh s_SphereMesh;
+
+        protected new void OnDrawGizmosSelected()
+        {
+            Gizmos.color = GizmoColor;
+
+            if (_mode == Mode.Geometry)
+            {
+                if (TryGetComponent<MeshFilter>(out var mf))
+                {
+                    Gizmos.DrawWireMesh(mf.sharedMesh, 0, transform.position, transform.rotation, transform.lossyScale);
+                }
+
+                return;
+            }
+
+            if (s_Quad == null)
+            {
+                s_Quad = Resources.GetBuiltinResource<Mesh>("Quad.fbx");
+            }
+
+            // Show gizmo for quad which encompasses the shape.
+            Gizmos.matrix = QuadMatrix;
+            Gizmos.DrawWireMesh(s_Quad);
+
+            Gizmos.matrix = transform.localToWorldMatrix;
+
+            switch (_primitive)
+            {
+                case Primitive.Sphere:
+                    if (s_SphereMesh == null)
+                    {
+                        s_SphereMesh = Resources.GetBuiltinResource<Mesh>("New-Sphere.fbx");
+                    }
+
+                    // Render mesh and wire sphere at default size (0.5m radius) which is scaled by gizmo matrix.
+                    Gizmos.DrawMesh(s_SphereMesh, submeshIndex: 0, Vector3.zero, Quaternion.identity, Vector3.one);
+                    Gizmos.DrawWireSphere(Vector3.zero, 0.5f);
+                    break;
+                case Primitive.Cube:
+                    // Render mesh and wire box at default size which is scaled by gizmo matrix.
+                    Gizmos.DrawCube(Vector3.zero, Vector3.one);
+                    Gizmos.DrawWireCube(Vector3.zero, Vector3.one);
+                    break;
+                default:
+                    Debug.LogError("Crest: Not a valid primitive type!");
+                    break;
+            }
+        }
 #endif
+    }
+
+    // Version handling - perform data migration after data loaded.
+    public partial class RegisterClipSurfaceInput : ISerializationCallbackReceiver
+    {
+        public void OnBeforeSerialize()
+        {
+            // Intentionally left empty.
+        }
+
+        public void OnAfterDeserialize()
+        {
+            // Version 1 (2021.07.25)
+            // - default mode changed from geo to primitive
+            if (_version == 0)
+            {
+                // The user is using geometry for clipping.
+                _mode = Mode.Geometry;
+
+                _version = 1;
+            }
+        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -115,7 +115,7 @@ namespace Crest
             }
         }
 
-        protected void Start()
+        protected virtual void Start()
         {
             InitRendererAndMaterial(true);
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -95,21 +95,19 @@ namespace Crest
         protected Material _material;
         SampleHeightHelper _sampleHelper = new SampleHeightHelper();
 
+        // If this is true, then the renderer should not be there as input source is from something else.
+        protected virtual bool RendererRequired => true;
+
         void InitRendererAndMaterial(bool verifyShader)
         {
             _renderer = GetComponent<Renderer>();
 
-            if (_renderer)
+            if (RendererRequired && _renderer != null)
             {
 #if UNITY_EDITOR
                 if (Application.isPlaying && _checkShaderName && verifyShader)
                 {
-                    ValidatedHelper.ValidateInputMesh(RendererRequired, gameObject, ValidatedHelper.DebugLog);
-
-                    if (TryGetComponent<MeshRenderer>(out var meshRenderer))
-                    {
-                        ValidatedHelper.ValidateMaterial(meshRenderer.sharedMaterial, ShaderPrefix, gameObject, ValidatedHelper.DebugLog);
-                    }
+                    ValidatedHelper.ValidateRenderer(gameObject, ValidatedHelper.DebugLog, ShaderPrefix);
                 }
 #endif
 
@@ -260,7 +258,7 @@ namespace Crest
     }
 
     [ExecuteAlways]
-    public abstract class RegisterLodDataInputWithSplineSupport<LodDataType, SplinePointCustomData>
+    public abstract partial class RegisterLodDataInputWithSplineSupport<LodDataType, SplinePointCustomData>
         : RegisterLodDataInput<LodDataType>
         , ISplinePointCustomDataSetup
 #if UNITY_EDITOR
@@ -285,6 +283,8 @@ namespace Crest
 
         protected abstract string SplineShaderName { get; }
         protected abstract Vector2 DefaultCustomData { get; }
+
+        protected override bool RendererRequired => _spline == null;
 
         void Awake()
         {
@@ -338,8 +338,6 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        protected override bool RendererRequired => _spline == null;
-
         protected override void Update()
         {
             base.Update();
@@ -387,7 +385,8 @@ namespace Crest
 #if UNITY_EDITOR
     public abstract partial class RegisterLodDataInputBase : IValidated
     {
-        protected virtual bool RendererRequired => true;
+        // Whether there is an alternative methods than a renderer (like splines).
+        protected virtual bool RendererOptional => false;
 
         protected virtual string FeatureToggleLabel => null;
         protected virtual string FeatureToggleName => null;
@@ -402,12 +401,7 @@ namespace Crest
 
         public virtual bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
-            var isValid = ValidatedHelper.ValidateInputMesh(RendererRequired, gameObject, showMessage);
-
-            if (TryGetComponent<MeshRenderer>(out var meshRenderer))
-            {
-                isValid = ValidatedHelper.ValidateMaterial(meshRenderer.sharedMaterial, ShaderPrefix, gameObject, showMessage) && isValid;
-            }
+            var isValid = ValidatedHelper.ValidateRenderer(gameObject, showMessage, RendererRequired, RendererOptional, ShaderPrefix);
 
             if (ocean != null && !FeatureEnabled(ocean))
             {
@@ -433,5 +427,29 @@ namespace Crest
 
     [CustomEditor(typeof(RegisterLodDataInputBase), true), CanEditMultipleObjects]
     class RegisterLodDataInputBaseEditor : ValidatedEditor { }
+
+    public abstract partial class RegisterLodDataInputWithSplineSupport<LodDataType, SplinePointCustomData>
+    {
+        protected override bool RendererOptional => true;
+
+        public override bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            bool isValid = base.Validate(ocean, showMessage);
+
+            // Will be invalid if no renderer and no spline.
+            if (RendererRequired && !TryGetComponent<Renderer>(out _))
+            {
+                showMessage
+                (
+                    "A <i>Crest Spline</i> component is required to drive this data. Alternatively a <i>MeshRenderer</i> can be added. Neither is currently attached to ocean input.",
+                    "Attach a <i>Crest Spline</i> component.",
+                    ValidatedHelper.MessageType.Error, gameObject,
+                    ValidatedHelper.FixAttachComponent<Spline.Spline>
+                );
+            }
+
+            return isValid;
+        }
+    }
 #endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs
@@ -1,0 +1,57 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Crest
+{
+    [CreateAssetMenu(fileName = "SimSettingsClipSurface", menuName = "Crest/Clip Surface Sim Settings", order = 10000)]
+    [HelpURL(HELP_URL)]
+    public class SimSettingsClipSurface : SimSettingsBase
+    {
+        /// <summary>
+        /// The version of this asset. Can be used to migrate across versions. This value should
+        /// only be changed when the editor upgrades the version.
+        /// </summary>
+        [SerializeField, HideInInspector]
+#pragma warning disable 414
+        int _version = 0;
+#pragma warning restore 414
+
+        public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#clip-surface";
+
+        // The clip values only really need 8bits (unless using signed distance).
+        [Tooltip("The render texture format to use for the clip surface simulation. It should only be changed if you need more precision. See the documentation for information.")]
+        public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R8_UNorm;
+
+        public override void AddToSettingsHash(ref int settingsHash)
+        {
+            base.AddToSettingsHash(ref settingsHash);
+            Hashy.AddInt((int)_renderTextureGraphicsFormat, ref settingsHash);
+        }
+    }
+
+#if UNITY_EDITOR
+    [CustomEditor(typeof(SimSettingsClipSurface), true), CanEditMultipleObjects]
+    class SimSettingsClipSurfaceEditor : SimSettingsBaseEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.Space();
+            if (GUILayout.Button("Open Online Help Page"))
+            {
+                Application.OpenURL(SimSettingsClipSurface.HELP_URL);
+            }
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+    }
+#endif
+}

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4bd553a2687d743038be08b018eca113
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: d254fdcebc9d1ce45a2d81cb7928a699, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -245,6 +245,10 @@ namespace Crest
         [Tooltip("Clip surface information for clipping the ocean surface."), SerializeField]
         bool _createClipSurfaceData = false;
         public bool CreateClipSurfaceData { get { return _createClipSurfaceData; } }
+
+        [Predicated("_createClipSurfaceData"), Embedded]
+        public SimSettingsClipSurface _simSettingsClipSurface;
+
         public enum DefaultClippingState
         {
             NothingClipped,

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -108,52 +108,41 @@ namespace Crest
             EditorUtility.SetDirty(gameObject);
         }
 
-        public static bool ValidateRenderer(GameObject gameObject, string shaderPrefix, ShowMessage showMessage)
+        public static bool ValidateRenderer(GameObject gameObject, ShowMessage showMessage, string shaderPrefix)
         {
-            var renderer = gameObject.GetComponent<Renderer>();
-            if (!renderer)
-            {
-                showMessage
-                (
-                    "A MeshRenderer component is required but none is attached to ocean input.",
-                    "Attach a <i>MeshRenderer</i> component.",
-                    MessageType.Error, gameObject,
-                    FixAttachComponent<MeshRenderer>
-                );
-
-                return false;
-            }
-
-            if (!ValidateMaterial(renderer.sharedMaterial, shaderPrefix, gameObject, showMessage))
-            {
-                return false;
-            }
-
-            return true;
+            return ValidateRenderer(gameObject, showMessage, isRendererRequired: true, isRendererOptional: false, shaderPrefix);
         }
 
-        public static bool ValidateMaterial(Material material, string shaderPrefix, GameObject gameObject, ShowMessage showMessage)
-        {
-            if (!material || material.shader && !material.shader.name.StartsWith(shaderPrefix))
-            {
-                showMessage
-                (
-                    $"Shader assigned to ocean input expected to be of type <i>{shaderPrefix}</i>.",
-                    "Assign a material that uses a shader of this type.",
-                    MessageType.Error, gameObject
-                );
-
-                return false;
-            }
-
-            return true;
-        }
-
-        public static bool ValidateInputMesh(bool rendererRequired, GameObject gameObject, ShowMessage showMessage)
+        public static bool ValidateRenderer(GameObject gameObject, ShowMessage showMessage, bool isRendererRequired, bool isRendererOptional, string shaderPrefix = null)
         {
             gameObject.TryGetComponent<MeshRenderer>(out var renderer);
 
-            if (!rendererRequired)
+            if (isRendererRequired)
+            {
+                if (renderer == null)
+                {
+                    // If renderer is optional, then a different error message with all the optionals should be presented.
+                    if (isRendererOptional)
+                    {
+                        return true;
+                    }
+
+                    showMessage
+                    (
+                        "A MeshRenderer component is required but none is attached to ocean input.",
+                        "Attach a <i>MeshRenderer</i> component.",
+                        MessageType.Error, gameObject,
+                        FixAttachComponent<MeshRenderer>
+                    );
+
+                    return false;
+                }
+                else if (!ValidateMaterial(gameObject, showMessage, renderer.sharedMaterial, shaderPrefix))
+                {
+                    return false;
+                }
+            }
+            else
             {
                 if (renderer)
                 {
@@ -164,20 +153,39 @@ namespace Crest
                         MessageType.Warning, gameObject,
                         FixRemoveRenderer
                     );
+
                     return false;
                 }
+
                 return true;
             }
 
-            if (!renderer)
+            return true;
+        }
+
+        public static bool ValidateMaterial(GameObject gameObject, ShowMessage showMessage, Material material, string shaderPrefix)
+        {
+            if (shaderPrefix == null && material == null)
             {
                 showMessage
                 (
-                    "A <i>Crest Spline</i> component is required to drive this data. Alternatively a <i>MeshRenderer</i> can be added. Neither is currently attached to ocean input.",
-                    "Attach a <i>Crest Spline</i> component.",
-                    MessageType.Error, gameObject,
-                    FixAttachComponent<Spline.Spline>
+                    $"<i>Mesh Renderer</i> requires a material.",
+                    "Assign a material.",
+                    MessageType.Error, gameObject
                 );
+
+                return false;
+            }
+
+            if (!material || material.shader && !material.shader.name.StartsWith(shaderPrefix))
+            {
+                showMessage
+                (
+                    $"Shader assigned to ocean input expected to be of type <i>{shaderPrefix}</i>.",
+                    "Assign a material that uses a shader of this type.",
+                    MessageType.Error, gameObject
+                );
+
                 return false;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -879,7 +879,7 @@ namespace Crest
             // Renderer
             if (_mode == GerstnerMode.Geometry)
             {
-                isValid = ValidatedHelper.ValidateRenderer(gameObject, "Crest/Inputs/Animated Waves/Gerstner", showMessage);
+                isValid = ValidatedHelper.ValidateRenderer(gameObject, showMessage, "Crest/Inputs/Animated Waves/Gerstner");
             }
             else if (_mode == GerstnerMode.Global && GetComponent<MeshRenderer>() != null)
             {

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceSignedDistance.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceSignedDistance.shader
@@ -1,0 +1,97 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Renders a signed distance shape into the clip surface texture.
+
+Shader "Hidden/Crest/Inputs/Clip Surface/Signed Distance"
+{
+	SubShader
+	{
+		ZWrite Off
+		ColorMask R
+		BlendOp Max
+
+		Pass
+		{
+			Cull Back
+
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+
+			#pragma multi_compile_local _SPHERE _CUBE
+
+			#include "UnityCG.cginc"
+			#include "../../OceanGlobals.hlsl"
+			#include "../../OceanInputsDriven.hlsl"
+			#include "../../OceanVertHelpers.hlsl"
+			#include "../../OceanHelpersNew.hlsl"
+			#include "../../OceanHelpersDriven.hlsl"
+
+			CBUFFER_START(CrestPerOceanInput)
+			uint _DisplacementSamplingIterations;
+			float4x4 _SignedDistanceShapeMatrix;
+			CBUFFER_END
+
+			struct Attributes
+			{
+				float3 positionOS : POSITION;
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+			};
+
+			float signedDistanceSphere(float3 position)
+			{
+				// Apply matrix and get distance from center.
+				return length(mul(_SignedDistanceShapeMatrix, float4(position, 1.0)).xyz);
+			}
+
+			float signedDistanceBox(float3 position)
+			{
+				// Apply matrix and restrict to one quadrant of a box.
+				position = abs(mul(_SignedDistanceShapeMatrix, float4(position, 1.0)));
+				// Get furthest distance from center.
+				return max(position.x, max(position.y, position.z));
+			}
+
+			Varyings Vert(Attributes input)
+			{
+				Varyings output;
+
+				output.positionCS = UnityObjectToClipPos(input.positionOS);
+				output.positionWS = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0));
+
+				return output;
+			}
+
+			float4 Frag(Varyings input) : SV_Target
+			{
+				float3 positionWS = input.positionWS;
+
+				float3 surfacePositionWS = SampleOceanDataDisplacedToWorldPosition
+				(
+					_LD_TexArray_AnimatedWaves,
+					positionWS,
+					_DisplacementSamplingIterations
+				);
+
+				// We only need the height as clip surface is sampled at the displaced position in the ocean shader.
+				positionWS.y += surfacePositionWS.y;
+
+#if _CUBE
+				float signedDistance = signedDistanceBox(positionWS);
+#else
+				float signedDistance = signedDistanceSphere(positionWS);
+#endif
+
+				return float4(1.0 - signedDistance, 0.0, 0.0, 1.0);
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceSignedDistance.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceSignedDistance.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 5529458a2151d4ae9bff760ee776ff63
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -17,6 +17,9 @@ Changed
 ^^^^^^^
 .. bullet_list::
 
+   -  Add signed-distance primitives for more accurate clipping and overlapping.
+      See :ref:`clip-surface-section` for more information.
+   -  Add *Render Texture Graphics Format* option to *Clip Surface Sim Settings* to support even more accurate clipping for signed-distance primitives.
    -  Add *Render Texture Graphics Format* option to *Animated Waves Sim Settings* to solve precision issues when using height inputs.
 
 

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -279,24 +279,67 @@ Clip Surface
 
 This data drives clipping of the ocean surface, as in carving out holes.
 This can be useful for hollow vessels or low terrain that goes below sea level.
-Data can come from geometry (convex hulls) or a texture.
+Data can come from primitives (signed-distance), geometry (convex hulls) or a texture.
 
 To turn on this feature, enable the *Create Clip Surface Data* option on the *OceanRenderer* script, and ensure the *Enable* option is ticked in the *Clip Surface* group on the ocean material.
 
-The data contains 0-1 values. Holes are carved into the surface when the values is greater than 0.5.
+The data contains 0-1 values. Holes are carved into the surface when the value is greater than 0.5.
 
-Overlapping or adjacent meshes will not work correctly in most cases.
-There will be cases where one mesh will overwrite another resulting in the ocean surface appearing where it should not.
-The mesh is rendered from a top-down perspective.
-The back faces add clip surface data and the front faces remove from it which creates the convex hull.
-With an overlapping mesh, the front faces of the sides of one mesh will clear the clipping data creating by the other mesh.
-Overlapping boxes which are not rotated on the X or Z axes will work well whilst spheres will have issues.
 
-Clip areas can be added by adding geometry that covers the desired hole area to the scene and then assigning the *RegisterClipSurfaceInput* script.
+.. _clip_surface_settings:
+
+Simulation Settings
+^^^^^^^^^^^^^^^^^^^
+
+All of the settings below refer to the *Clip Surface Sim Settings* asset.
+
+-  **Render Texture Graphics Format** - The render texture format to use for the clip surface simulation.
+   Consider using higher precision (like *R16_UNorm*) if you are using *Primitive* mode for even more accurate clipping.
+
+
+.. _clip_surface_inputs:
+
+User Inputs
+^^^^^^^^^^^
+
+Primitive Mode
+~~~~~~~~~~~~~~
+
+Clip areas can be added using signed-distance primitives which produces accurate clipping and supports overlapping.
+Add a *RegisterClipSurfaceInput* script to a *GameObject* and set *Mode* to *Primitive*.
+The position, rotation and dimensions of the primitive is determined by the *Transform*.
 See the *FloatingOpenContainer* object in the *boat.unity* scene for an example usage.
 
+Geometry Mode
+~~~~~~~~~~~~~
+
+Clip areas can be added by adding geometry that covers the desired hole area to the scene and then assigning the *RegisterClipSurfaceInput* script and setting *Mode* to *Geometry*.
+See the *RowBoat* object in the *main.unity* scene for an example usage.
+
 To use other available shaders like *ClipSurfaceRemoveArea* or *ClipSurfaceRemoveAreaTexture*: create a material, assign to renderer and disable *Assign Clip Surface Material* option.
-For the *ClipSurfaceRemoveArea* shaders, the geometry should be added from a top down perspective and the faces pointing upwards.
+For the *ClipSurfaceRemoveArea* shaders, the geometry should be added from a top-down perspective and the faces pointing upwards.
+
+The following input shaders are provided under *Crest/Inputs/Clip Surface*:
+
+-  **Convex Hull** - Renders geometry into clip surface data taking all dimensions into account.
+   An example use case is rendering the convex hull of a vessel to remove the ocean surface from within it.
+   See the *RowBoat* object in the *main.unity* scene for an example usage.
+
+   .. note::
+
+      Overlapping or adjacent meshes will not work correctly in most cases.
+      There will be cases where one mesh will overwrite another resulting in the ocean surface appearing where it should not.
+      The mesh is rendered from a top-down perspective.
+      The back faces add clip surface data and the front faces remove from it which creates the convex hull.
+      With an overlapping mesh, the front faces of the sides of one mesh will clear the clipping data creating by the other mesh.
+      Overlapping boxes which are not rotated on the X or Z axes will work well whilst spheres will have issues.
+      Consider using *Primitive* mode which supports overlapping.
+
+-  **Include Area** - Removes clipping data so the ocean surface renders.
+
+-  **Remove Area** - Adds clipping data to remove the ocean surface.
+
+-  **Remove Area Texture** - Adds clipping data using a texture to remove the ocean surface.
 
 
 .. _shadows-section:


### PR DESCRIPTION
Adds signed distance shapes (Sphere and Box) to the clip surface input. It uses the clip surface input transform to define the shape. It renders the quad using DrawMesh. It gets the material from the mesh renderer.

<img width="897" alt="11" src="https://user-images.githubusercontent.com/5249806/126730530-02176e1e-0f92-47ba-afdc-10306a3529c9.png">

The only issue is the corners of the box can get cut off or rounded:
<img width="897" alt="22" src="https://user-images.githubusercontent.com/5249806/126730543-992df308-d0f9-4a6f-9def-cd4ecd2899e6.png">

The PR has a few commits which adds test data which I can remove before code review.

I considered moving away from using a mesh renderer and using DrawMesh for all inputs. But I didn't want it to hold this up as that is a significant refactor when including migration code.

I was thinking of adding the shape type to the component itself and driving the shape keywords with scripting. Thoughts?

## Issues

- Blending doesn't work on my old Mac but probably because it is old