### PR TITLE
Fix disabled input not being cleared if last one

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -86,11 +86,8 @@ namespace Crest
                 SubmitDraws(lodIdx, buf);
             }
 
-            // targets have now been cleared, we can early out next time around
-            if (drawList.Count == 0)
-            {
-                _targetsClear = true;
-            }
+            // Targets are only clear if nothing was drawn
+            _targetsClear = drawList.Count == 0;
         }
 
         readonly static string s_textureArrayName = "_LD_TexArray_Flow";

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -27,6 +27,7 @@ Fixed
    -  Fix ocean not rendering on Xbox One and Xbox Series X.
    -  Fix height input (and others) from not working 100m above sea level and 500m below sea level.
    -  Fix FFT shader build errors for Game Core platforms.
+   -  Fix flow simulation sometimes not clearing after disabling last input.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Flow, ~~clip and depth~~ simulations where not being cleared when the last input is disabled.