### PR TITLE
Support MSAA

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -1,0 +1,19 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest
+{
+    using UnityEngine;
+
+    /// <summary>
+    /// General purpose helpers which, at the moment, do not warrant a seperate file.
+    /// </summary>
+    public static class Helpers
+    {
+        public static bool IsMSAAEnabled(Camera camera)
+        {
+            return camera.allowMSAA && QualitySettings.antiAliasing > 0f;
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec910a367ef7649938742dcf107ef839
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -378,6 +378,7 @@ namespace Crest
         readonly int sp_clipByDefault = Shader.PropertyToID("_CrestClipByDefault");
         readonly int sp_lodAlphaBlackPointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointFade");
         readonly int sp_lodAlphaBlackPointWhitePointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointWhitePointFade");
+        readonly int sp_CrestDepthTextureOffset = Shader.PropertyToID("_CrestDepthTextureOffset");
         static int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
         public static int sp_perCascadeInstanceData = Shader.PropertyToID("_CrestPerCascadeInstanceData");
         public static int sp_cascadeData = Shader.PropertyToID("_CrestCascadeData");
@@ -882,6 +883,7 @@ namespace Crest
             Shader.SetGlobalFloat(sp_clipByDefault, _defaultClippingState == DefaultClippingState.EverythingClipped ? 1f : 0f);
             Shader.SetGlobalFloat(sp_lodAlphaBlackPointFade, _lodAlphaBlackPointFade);
             Shader.SetGlobalFloat(sp_lodAlphaBlackPointWhitePointFade, _lodAlphaBlackPointWhitePointFade);
+            Shader.SetGlobalInt(sp_CrestDepthTextureOffset, Helpers.IsMSAAEnabled(ViewCamera) ? 1 : 0);
 
             // LOD 0 is blended in/out when scale changes, to eliminate pops. Here we set it as a global, whereas in OceanChunkRenderer it
             // is applied to LOD0 tiles only through instance data. This global can be used in compute, where we only apply this factor for slice 0.

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -149,7 +149,7 @@ void ApplyCaustics(in const float3 i_scenePos, in const half3 i_lightDir, in con
 
 
 half3 OceanEmission(in const half3 i_view, in const half3 i_n_pixel, in const float3 i_lightDir,
-	in const half4 i_grabPos, in const float i_pixelZ, in const half2 i_uvDepth, in const float i_sceneZ,
+	in const half4 i_grabPos, in const float i_pixelZ, in const half2 i_uvDepth, in const float i_sceneZ, const float i_rawDepth,
 	in const half3 i_bubbleCol, in sampler2D i_normals, in const bool i_underwater, in const half3 i_scatterCol,
 	in const CascadeParams cascadeData0, in const CascadeParams cascadeData1)
 {
@@ -179,13 +179,13 @@ half3 OceanEmission(in const half3 i_view, in const half3 i_n_pixel, in const fl
 		// Compute depth fog alpha based on refracted position if it landed on an underwater surface, or on unrefracted depth otherwise
 		if (sceneZRefract > i_pixelZ)
 		{
-			depthFogDistance = sceneZRefract - i_pixelZ;
 			uvBackgroundRefract = uvBackground + refractOffset;
+			depthFogDistance = CrestLinearEyeDepth(CrestMultiSampleSceneDepth(rawDepth, uvBackgroundRefract)) - i_pixelZ;
 		}
 		else
 		{
 			// It seems that when MSAA is enabled this can sometimes be negative
-			depthFogDistance = max(i_sceneZ - i_pixelZ, 0.0);
+			depthFogDistance = max(CrestLinearEyeDepth(CrestMultiSampleSceneDepth(i_rawDepth, uvBackground)) - i_pixelZ, 0.0);
 
 			// We have refracted onto a surface in front of the water. Cancel the refraction offset.
 			uvBackgroundRefract = uvBackground;

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -20,6 +20,7 @@ float _MeshScaleLerp;
 float _CrestClipByDefault;
 float _CrestLodAlphaBlackPointFade;
 float _CrestLodAlphaBlackPointWhitePointFade;
+int _CrestDepthTextureOffset;
 
 float3 _PrimaryLightDirection;
 float3 _PrimaryLightIntensity;

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
@@ -13,6 +13,8 @@
 UNITY_DECLARE_SCREENSPACE_TEXTURE(_CameraDepthTexture);
 UNITY_DECLARE_SCREENSPACE_TEXTURE(_BackgroundTexture);
 
+float4 _CameraDepthTexture_TexelSize;
+
 // NOTE: _Normals is used outside of _APPLYNORMALMAPPING_ON so we cannot surround it here.
 sampler2D _Normals;
 sampler2D _ReflectionTex;

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
@@ -98,7 +98,7 @@ Shader "Hidden/Crest/Underwater/Underwater Effect"
 				const float rawOceanDepth = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, uvScreenSpace).x;
 
 				bool isOceanSurface; bool isUnderwater; float sceneZ;
-				GetOceanSurfaceAndUnderwaterData(rawOceanDepth, mask, isBelowHorizon, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
+				GetOceanSurfaceAndUnderwaterData(uvScreenSpace, rawOceanDepth, mask, isBelowHorizon, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
 
 				float wt = ComputeMeniscusWeight(uvScreenSpace, mask, horizonPositionNormal, sceneZ);
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
@@ -12,6 +12,8 @@ float4 _HorizonPosNormal;
 float4 _HorizonPosNormalRight;
 half _DataSliceOffset;
 
+float4 _CrestOceanMaskDepthTexture_TexelSize;
+
 float4 DebugRenderOceanMask(const bool isOceanSurface, const bool isUnderwater, const float mask, const float3 sceneColour)
 {
 	if (isOceanSurface)
@@ -83,7 +85,29 @@ void GetHorizonData(const float2 uv, out float4 horizonPositionNormal, out bool 
 #endif // !_FULL_SCREEN_EFFECT
 }
 
+#if defined(UNITY_SAMPLE_SCREENSPACE_TEXTURE)
+float CrestMultiSampleOceanDepth(const float i_rawDepth, const float2 i_positionNDC)
+{
+	float rawDepth = i_rawDepth;
+
+	if (_CrestDepthTextureOffset > 0)
+	{
+		// We could use screen size instead.
+		float2 texelSize = _CrestOceanMaskDepthTexture_TexelSize.xy;
+		int3 offset = int3(-_CrestDepthTextureOffset, 0, _CrestDepthTextureOffset);
+
+		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.xy * texelSize));
+		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.yx * texelSize));
+		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.yz * texelSize));
+		rawDepth = CREST_DEPTH_COMPARE(rawDepth, UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, i_positionNDC + offset.zy * texelSize));
+	}
+
+	return rawDepth;
+}
+#endif
+
 void GetOceanSurfaceAndUnderwaterData(
+	const float2 positionNDC,
 	const float rawOceanDepth,
 	const float mask,
 	const bool isBelowHorizon,
@@ -96,9 +120,17 @@ void GetOceanSurfaceAndUnderwaterData(
 {
 	isOceanSurface = mask != UNDERWATER_MASK_NO_MASK && (rawDepth < rawOceanDepth + oceanDepthTolerance);
 	isUnderwater = mask == UNDERWATER_MASK_WATER_SURFACE_BELOW || (isBelowHorizon && mask != UNDERWATER_MASK_WATER_SURFACE_ABOVE);
+
 	// Merge ocean depth with scene depth.
-	rawDepth = isOceanSurface ? rawOceanDepth : rawDepth;
-	sceneZ = CrestLinearEyeDepth(rawDepth);
+	if (isOceanSurface)
+	{
+		rawDepth = rawOceanDepth;
+		sceneZ = CrestLinearEyeDepth(CrestMultiSampleOceanDepth(rawDepth, positionNDC));
+	}
+	else
+	{
+		sceneZ = CrestLinearEyeDepth(CrestMultiSampleSceneDepth(rawDepth, positionNDC));
+	}
 }
 
 #ifdef CREST_OCEAN_EMISSION_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
@@ -101,6 +101,14 @@ Varyings Vert(Attributes v)
 
 half4 Frag(const Varyings input, const bool i_isFrontFace : SV_IsFrontFace) : SV_Target
 {
+	// @MSAAOutlineFix:
+	// The edge of the ocean surface at the near plane will be MSAA'd leaving a noticeable edge. By rendering the mask
+	// with a slightly further near plane, it exposes the edge to having the underwater fog applied which is much nicer.
+	if (_CrestDepthTextureOffset > 0 && LinearEyeDepth(input.positionCS.z) < (_ProjectionParams.y + 0.001))
+	{
+		discard;
+	}
+
 	if (IsUnderwater(i_isFrontFace, _ForceUnderwater))
 	{
 		return (half4)UNDERWATER_MASK_WATER_SURFACE_BELOW;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -38,6 +38,7 @@ Fixed
    -  Fix FFT shader build errors for Game Core platforms.
    -  Fix FFT material allocations every frame.
    -  Fix flow simulation sometimes not clearing after disabling last input.
+   -  Fix outline around objects when MSAA is enabled by making it less noticeable.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Related Issues: #800 #529

Searches for the maximum depth value. It adds four additional samples for the ocean renderer and four additional samples for the underwater renderer. The end result is a dark edge around objects instead of a light edge which is preferable.

![1_Broke](https://user-images.githubusercontent.com/5249806/129283401-6a2fdf20-3ba3-4c1b-a1d8-8b9db20f3c95.jpg)
Without Fix

![1_Fixed](https://user-images.githubusercontent.com/5249806/129283405-6760bfc7-a2b6-4a5f-9486-6482514ed4a2.jpg)
With Fix

The offset amount is driven by scripting as it needs to be "2" for HDRP if refraction is used; otherwise, the issue will reoccur. I cannot work out why this is a problem for HDRP and not BIRP.

![S (283)](https://user-images.githubusercontent.com/5249806/129282876-e504b9d2-72b9-4a1d-ae55-6f09a6523d67.jpg)
HDRP refraction with 1 offset (gets worse with higher refraction)

![S (284)](https://user-images.githubusercontent.com/5249806/129282889-162fa540-b196-48e8-8a7d-c79f8e3a2c8c.jpg)
HDRP refraction with 2 offset

The approach fails in certain situations where objects are close together:

![S (285)](https://user-images.githubusercontent.com/5249806/129282900-f8973b7e-648a-4865-9c8d-eeb48e0a0d30.jpg)

There is a way to sample from the MSAA depth texture for HDRP which produces perfect results, but the texture is not accessible if Render Graph is used which is going to be the default beyond HDRP 10. I made a post asking for assistance: https://forum.unity.com/threads/how-to-sample-from-_depthtexturems-when-render-graph-is-enabled.1155200/