### PR TITLE
Sample foam in fragment shader

### DIFF
--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,7 @@ Changed
    -  Add *Render Texture Graphics Format* option to *Animated Waves Sim Settings* to solve precision issues when using height inputs.
    -  Add default textures to ocean shader.
    -  Update ocean shader default values.
+   -  Improve foam detail at medium to long distance.
 
    .. only:: urp
 
@@ -38,6 +39,7 @@ Fixed
    -  Fix FFT shader build errors for Game Core platforms.
    -  Fix FFT material allocations every frame.
    -  Fix flow simulation sometimes not clearing after disabling last input.
+   -  Fix pixelated looking foam bubbles at medium to long distance.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Solves #671 and should help with #635.

Samples foam from the fragment shader. The difference is quite significant from a distance.

Vertex (Current):
<img width="941" alt="1_Vert" src="https://user-images.githubusercontent.com/5249806/129679227-0793e3c5-a03a-4c99-83df-feeaf83deef1.png">

Fragment:
<img width="941" alt="1_Frag" src="https://user-images.githubusercontent.com/5249806/129679241-9f58ad62-eb78-4d0f-99db-9970b31a04f5.png">

Shoreline foam is greatly improved and the foam bubbles is no longer pixelated.

The foam bubbles could also be solved using a higher mesh density, but those screenshots already have a decent mesh density (384 resolution / 4 down sample). And adjusting the texture scale can produce passable results.

I have added it as a toggle/keyword for comparison. We could keep it optional. I've moved the camera in the main scene for testing.

Also, this won't look correct with ShapeGerstner or ShapeFFT because of #878. It makes the lines more prominent.

@huwb Let me know what you think.
