### PR TITLE
Render underwater horizon into mask

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -47,23 +47,9 @@ namespace Crest
         [Tooltip("Copying params each frame ensures underwater appearance stays consistent with ocean material params. Has a small overhead so should be disabled if not needed.")]
         internal bool _copyOceanMaterialParamsEachFrame = true;
 
-        [SerializeField, Predicated("useHorizonSafetyMarginMultiplier", inverted: true), Range(0f, 1f)]
-        [Tooltip("Adjusts the far plane for horizon line calculation. Helps with horizon line issue. (Experimental)")]
+        [SerializeField, Range(0f, 1f)]
+        [Tooltip("Adjusts the far plane for horizon line calculation. Helps with horizon line issue.")]
         internal float _farPlaneMultiplier = 0.68f;
-
-        [SerializeField, Tooltip("Use the old horizon safety margin multiplier to fix horizon line issues instead of the new experimental far plane multiplier.")]
-        internal bool _useHorizonSafetyMarginMultiplier = false;
-
-        // A magic number found after a small-amount of iteration that is used to deal with horizon-line floating-point
-        // issues. It allows us to give it a small *nudge* in the right direction based on whether the camera is above
-        // or below the horizon line itself already.
-        [SerializeField, Predicated("useHorizonSafetyMarginMultiplier"), Range(0f, 1f)]
-        [Tooltip("A safety margin multiplier to adjust horizon line based on camera position to avoid minor artifacts caused by floating point precision issues, the default value has been chosen based on careful experimentation.")]
-        internal float _horizonSafetyMarginMultiplier = 0.01f;
-
-        [SerializeField, Predicated("useHorizonSafetyMarginMultiplier"), DecoratedField]
-        [Tooltip("Dynamic resolution can cause the horizon gap issue to widen. Scales the safety margin multiplier to compensate.")]
-        internal bool _scaleSafetyMarginWithDynamicResolution = true;
 
         [Space(10)]
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -23,12 +23,10 @@
 #define CREST_SHADOW_INDEX_SOFT 0
 #define CREST_SHADOW_INDEX_HARD 1
 
-// Background
-#define UNDERWATER_MASK_NO_MASK 1.0
-// Water rendered from above
-#define UNDERWATER_MASK_WATER_SURFACE_ABOVE 0.0
-// Water rendered from below
-#define UNDERWATER_MASK_WATER_SURFACE_BELOW 2.0
+// Water rendered from above.
+#define UNDERWATER_MASK_ABOVE_SURFACE 0.0
+// Water rendered from below. Used to invert meniscus sampling so keep as 2.0.
+#define UNDERWATER_MASK_BELOW_SURFACE 2.0
 
 #if defined(STEREO_INSTANCING_ON) || defined(STEREO_MULTIVIEW_ON)
 #define CREST_HANDLE_XR 1

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
@@ -88,9 +88,6 @@ Shader "Hidden/Crest/Underwater/Underwater Effect"
 				// We need this when sampling a screenspace texture.
 				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 
-				float4 horizonPositionNormal; bool isBelowHorizon;
-				GetHorizonData(input.uv, horizonPositionNormal, isBelowHorizon);
-
 				const float2 uvScreenSpace = UnityStereoTransformScreenSpaceTex(input.uv);
 				half3 sceneColour = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestCameraColorTexture, uvScreenSpace).rgb;
 				float rawDepth = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CameraDepthTexture, uvScreenSpace).x;
@@ -98,9 +95,9 @@ Shader "Hidden/Crest/Underwater/Underwater Effect"
 				const float rawOceanDepth = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskDepthTexture, uvScreenSpace).x;
 
 				bool isOceanSurface; bool isUnderwater; float sceneZ;
-				GetOceanSurfaceAndUnderwaterData(rawOceanDepth, mask, isBelowHorizon, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
+				GetOceanSurfaceAndUnderwaterData(rawOceanDepth, mask, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
 
-				float wt = ComputeMeniscusWeight(uvScreenSpace, mask, horizonPositionNormal, sceneZ);
+				float wt = ComputeMeniscusWeight(uvScreenSpace, mask, _HorizonNormal, sceneZ);
 
 #if _DEBUG_VIEW_OCEAN_MASK
 				return DebugRenderOceanMask(isOceanSurface, isUnderwater, mask, sceneColour);

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMaskHorizon.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMaskHorizon.shader
@@ -1,0 +1,63 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Renders the ocean horizon line into the mask.
+
+Shader "Hidden/Crest/Underwater/Horizon"
+{
+	SubShader
+	{
+		Pass
+		{
+			// Quads will face towards the camera if given the camera's rotation.
+			Cull Back
+			// Could be enabled if needed.
+			ZWrite Off
+
+			CGPROGRAM
+			#pragma vertex Vert
+			#pragma fragment Frag
+
+			#pragma multi_compile_instancing
+
+			#include "UnityCG.cginc"
+
+			#include "../../OceanConstants.hlsl"
+			#include "../../OceanGlobals.hlsl"
+
+			struct Attributes
+			{
+				float3 positionOS : POSITION;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct Varyings
+			{
+				float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			Varyings Vert(Attributes input)
+			{
+				// This will work for all pipelines.
+				Varyings output = (Varyings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				output.positionCS = UnityObjectToClipPos(input.positionOS);
+				output.positionWS = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0));
+				return output;
+			}
+
+			half4 Frag(Varyings input) : SV_Target
+			{
+				return (half4) input.positionWS.y > _OceanCenterPosWorld.y
+					? UNDERWATER_MASK_ABOVE_SURFACE
+					: UNDERWATER_MASK_BELOW_SURFACE;
+			}
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMaskHorizon.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMaskHorizon.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f99e556f3e6e041a48ceb5a41eddae28
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
@@ -8,15 +8,15 @@
 half3 _AmbientLighting;
 float4x4 _InvViewProjection;
 float4x4 _InvViewProjectionRight;
-float4 _HorizonPosNormal;
-float4 _HorizonPosNormalRight;
 half _DataSliceOffset;
+float2 _HorizonNormal;
+
 
 float4 DebugRenderOceanMask(const bool isOceanSurface, const bool isUnderwater, const float mask, const float3 sceneColour)
 {
 	if (isOceanSurface)
 	{
-		return float4(sceneColour * float3(mask == UNDERWATER_MASK_WATER_SURFACE_ABOVE, mask == UNDERWATER_MASK_WATER_SURFACE_BELOW, 0.0), 1.0);
+		return float4(sceneColour * float3(mask == UNDERWATER_MASK_ABOVE_SURFACE, mask == UNDERWATER_MASK_BELOW_SURFACE, 0.0), 1.0);
 	}
 	else
 	{
@@ -27,66 +27,44 @@ float4 DebugRenderOceanMask(const bool isOceanSurface, const bool isUnderwater, 
 float3 ComputeWorldSpaceView(const float2 uv)
 {
 	const float2 pixelCS = uv * 2.0 - float2(1.0, 1.0);
-	#if CREST_HANDLE_XR
-		const float4x4 InvViewProjection = unity_StereoEyeIndex == 0 ? _InvViewProjection : _InvViewProjectionRight;
-	#else
-		const float4x4 InvViewProjection = _InvViewProjection;
-	#endif
+#if CREST_HANDLE_XR
+	const float4x4 InvViewProjection = unity_StereoEyeIndex == 0 ? _InvViewProjection : _InvViewProjectionRight;
+#else
+	const float4x4 InvViewProjection = _InvViewProjection;
+#endif
 	const float4 pixelWS_H = mul(InvViewProjection, float4(pixelCS, 1.0, 1.0));
 	const float3 pixelWS = pixelWS_H.xyz / pixelWS_H.w;
 	return _WorldSpaceCameraPos - pixelWS;
 }
 
-float MeniscusSampleOceanMask(const float2 uvScreenSpace, const float2 dy, const half offset)
+float MeniscusSampleOceanMask(const float2 uvScreenSpace, const float2 offset, const half magnitude)
 {
-	float2 uv = uvScreenSpace + dy * offset;
+	float2 uv = uvScreenSpace + offset * magnitude;
 	return UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, uv).r;
 }
 
-half ComputeMeniscusWeight(const float2 uvScreenSpace, const float mask, const float4 horizonPositionNormal, const float sceneZ)
+half ComputeMeniscusWeight(const float2 uvScreenSpace, const float mask, const float2 horizonNormal, const float sceneZ)
 {
-	float wt = 1.0;
+	float weight = 1.0;
 #if CREST_MENISCUS
 #if !_FULL_SCREEN_EFFECT
-	// Render meniscus by checking mask in opposite direction of surface normal.
-	// If the sample is different than the current mask, apply meniscus.
-	// Skip the meniscus beyond one unit to prevent numerous artefacts.
-	if (mask != UNDERWATER_MASK_NO_MASK && sceneZ < 1.0)
-	{
-		float wt_mul = 0.9;
-		// Adding the mask value will flip the UV when mask is below surface.
-		// Apply the horizon normal so it works with any orientation.
-		float2 dy = (float2(-1.0 + mask, -1.0 + mask) / _ScreenParams.y) * -horizonPositionNormal.zw;
-		wt *= (MeniscusSampleOceanMask(uvScreenSpace, dy, 1.0) != mask) ? wt_mul : 1.0;
-		wt *= (MeniscusSampleOceanMask(uvScreenSpace, dy, 2.0) != mask) ? wt_mul : 1.0;
-		wt *= (MeniscusSampleOceanMask(uvScreenSpace, dy, 3.0) != mask) ? wt_mul : 1.0;
-	}
+	// Render meniscus by checking the mask along the horizon normal which is flipped using the surface normal from
+	// mask. Adding the mask value will flip the UV when mask is below surface.
+	float2 offset = float2(-1.0 + mask, -1.0 + mask) * horizonNormal / length(_ScreenParams.xy * horizonNormal);
+	float multiplier = 0.9;
+
+	// Sample three pixels along the normal. If the sample is different than the current mask, apply meniscus.
+	weight *= (MeniscusSampleOceanMask(uvScreenSpace, offset, 1.0) != mask) ? multiplier : 1.0;
+	weight *= (MeniscusSampleOceanMask(uvScreenSpace, offset, 2.0) != mask) ? multiplier : 1.0;
+	weight *= (MeniscusSampleOceanMask(uvScreenSpace, offset, 3.0) != mask) ? multiplier : 1.0;
 #endif // _FULL_SCREEN_EFFECT
 #endif // CREST_MENISCUS
-	return wt;
-}
-
-void GetHorizonData(const float2 uv, out float4 horizonPositionNormal, out bool isBelowHorizon)
-{
-#if !_FULL_SCREEN_EFFECT
-	// The horizon line is the intersection between the far plane and the ocean plane. The pos and normal of this
-	// intersection line is passed in.
-#if CREST_HANDLE_XR
-	horizonPositionNormal = unity_StereoEyeIndex == 0 ? _HorizonPosNormal : _HorizonPosNormalRight;
-#else // CREST_HANDLE_XR
-	horizonPositionNormal = _HorizonPosNormal;
-#endif // CREST_HANDLE_XR
-	isBelowHorizon = dot(uv - horizonPositionNormal.xy, horizonPositionNormal.zw) > 0.0;
-#else // !_FULL_SCREEN_EFFECT
-	horizonPositionNormal = 0;
-	isBelowHorizon = true;
-#endif // !_FULL_SCREEN_EFFECT
+	return weight;
 }
 
 void GetOceanSurfaceAndUnderwaterData(
 	const float rawOceanDepth,
 	const float mask,
-	const bool isBelowHorizon,
 	inout float rawDepth,
 	inout bool isOceanSurface,
 	inout bool isUnderwater,
@@ -94,8 +72,8 @@ void GetOceanSurfaceAndUnderwaterData(
 	const float oceanDepthTolerance
 )
 {
-	isOceanSurface = mask != UNDERWATER_MASK_NO_MASK && (rawDepth < rawOceanDepth + oceanDepthTolerance);
-	isUnderwater = mask == UNDERWATER_MASK_WATER_SURFACE_BELOW || (isBelowHorizon && mask != UNDERWATER_MASK_WATER_SURFACE_ABOVE);
+	isOceanSurface = (rawDepth < rawOceanDepth + oceanDepthTolerance);
+	isUnderwater = mask == UNDERWATER_MASK_BELOW_SURFACE;
 	// Merge ocean depth with scene depth.
 	rawDepth = isOceanSurface ? rawOceanDepth : rawDepth;
 	sceneZ = CrestLinearEyeDepth(rawDepth);

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
@@ -32,8 +32,8 @@ float _ForceUnderwater;
 
 Varyings Vert(Attributes v)
 {
+	// This will work for all pipelines.
 	Varyings output = (Varyings)0;
-
 	UNITY_SETUP_INSTANCE_ID(v);
 	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
@@ -103,11 +103,11 @@ half4 Frag(const Varyings input, const bool i_isFrontFace : SV_IsFrontFace) : SV
 {
 	if (IsUnderwater(i_isFrontFace, _ForceUnderwater))
 	{
-		return (half4)UNDERWATER_MASK_WATER_SURFACE_BELOW;
+		return (half4)UNDERWATER_MASK_BELOW_SURFACE;
 	}
 	else
 	{
-		return (half4)UNDERWATER_MASK_WATER_SURFACE_ABOVE;
+		return (half4)UNDERWATER_MASK_ABOVE_SURFACE;
 	}
 }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -27,6 +27,9 @@ Fixed
    -  Fix ocean not rendering on Xbox One and Xbox Series X.
    -  Fix height input (and others) from not working 100m above sea level and 500m below sea level.
    -  Fix FFT shader build errors for Game Core platforms.
+   -  Fix underwater effect undershooting or overshooting ocean surface when XR camera is nearly aligned with horizon.
+   -  Fix underwater effect being flipped at certain camera orientations.
+   -  Fix meniscus thickness consistency (in some cases disappearing) with different camera orientations.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Replaces C# horizon line code with a horizon line shader. It renders a quad near the far plane and compares the world position against the ocean level. It passed the test cases I had available and solved a few edge cases.

PR also includes meniscus fixes/improvements.

## Mask

Fixes the following edge cases:
- inverted horizon normal at certain camera transforms
- horizon instability when VR hardware is nearly aligned with horizon (last chapter of [video](https://www.youtube.com/watch?v=pGFjiWDinK0))

### Performance

Measuring the cost of the horizon shader. Measurements taken for the entire mask pass.

No waves and aligned with horizon (worst case scenario)
Old mask: 0.04ms
New mask: 0.14ms

Waves
Old mask: 0.11ms
New mask: 0.11ms

### Issues

I haven't experienced any. Will have to do some more testing with clip surface and underwater fog input branch. I tested against the "underwater from geometry" branch and seemed good.

## Meniscus

Also includes following meniscus fixes and improvements:
- Use _ScreenParams.xy instead of _ScreenParams.y. And apply ocean normal. Makes thickness more consistent
- Now works when there isn't much ocean surface visible

The latter is most prominent when the camera is aligned with horizon:

Before:
<img width="233" alt="1_1_before" src="https://user-images.githubusercontent.com/5249806/130337992-6f94094f-1bce-4df1-ac15-69d2bd3b782b.png">

After:
<img width="233" alt="1_2_after" src="https://user-images.githubusercontent.com/5249806/130337993-41b0e10e-56c6-463f-94b9-5992d7fee335.png">

This is possible (or simpler to do) now that the mask state is binary and covers the entire screen.

### Performance

No waves and aligned with horizon (worst case scenario)
Old effect: 0.76ms
New effect: 0.91ms

Waves
Old effect: 0.80ms
New effect: 1.60ms

Before the meniscus had a condition to only render when the mask sample contained the ocean surface. But that condition has been removed to improve the meniscus.

