### PR TITLE
Fix OceanDepthCache disabling in edit mode

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs
@@ -15,9 +15,12 @@ namespace Crest
     /// (directional light, reflections, ambient etc) with the underwater depth. This works with vanilla lighting, but
     /// uncommon or custom lighting will require a custom solution (use this for reference).
     /// </summary>
+    [DefaultExecutionOrder(k_DefaultExecutionOrder)]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_EXAMPLE + "Underwater Environmental Lighting")]
     public class UnderwaterEnvironmentalLighting : MonoBehaviour
     {
+        public const int k_DefaultExecutionOrder = OceanRenderer.k_DefaultExecutionOrder + 1;
+
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
         /// only be changed when the editor upgrades the version.

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/UnderwaterEnvironmentalLighting.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 201
+  executionOrder: 0
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 100
+  executionOrder: 0
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -37,9 +37,12 @@ namespace Crest
     /// script should normally be attached to the viewpoint, typically the main camera.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Floating Origin")]
+    [DefaultExecutionOrder(k_DefaultExecutionOrder)]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "other-features.html" + Internal.Constants.HELP_URL_RP + "#floating-origin")]
     public class FloatingOrigin : MonoBehaviour
     {
+        public const int k_DefaultExecutionOrder = -200;
+
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
         /// only be changed when the editor upgrades the version.

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: -200
+  executionOrder: 0
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -16,10 +16,13 @@ namespace Crest
     /// This should be used for static geometry, dynamic objects should be tagged with the Render Ocean Depth component.
     /// </summary>
     [ExecuteAlways]
+    [DefaultExecutionOrder(k_DefaultExecutionOrder)]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "shallows-and-shorelines.html" + Internal.Constants.HELP_URL_RP)]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Depth Cache")]
     public partial class OceanDepthCache : MonoBehaviour
     {
+        public const int k_DefaultExecutionOrder = OceanRenderer.k_DefaultExecutionOrder + 1;
+
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
         /// only be changed when the editor upgrades the version.
@@ -90,12 +93,6 @@ namespace Crest
 
         void Start()
         {
-            if (OceanRenderer.Instance == null)
-            {
-                enabled = false;
-                return;
-            }
-
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && _runValidationOnStart)
             {
@@ -641,6 +638,17 @@ namespace Crest
                 );
 
                 isValid = false;
+            }
+
+            if (ocean == null)
+            {
+                showMessage
+                (
+                    "The <i>Ocean Depth Cache</i> uses the <i>Ocean Renderer</i> height which is not present. " +
+                    "The transform height will be used instead.",
+                    "", // Leave fix message blank as this could be a valid option.
+                    ValidatedHelper.MessageType.Info, this
+                );
             }
 
             if (ocean != null && ocean.Root != null && !Mathf.Approximately(transform.position.y, ocean.Root.position.y))

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -23,10 +23,14 @@ namespace Crest
     /// and moves/scales the ocean based on the viewpoint. It also hosts a number of global settings that can be tweaked here.
     /// </summary>
     [ExecuteAlways, SelectionBase]
+    [DefaultExecutionOrder(k_DefaultExecutionOrder)]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Renderer")]
     [HelpURL(Constants.HELP_URL_GENERAL)]
     public partial class OceanRenderer : MonoBehaviour
     {
+        // Update ocean after Cinemachine.
+        public const int k_DefaultExecutionOrder = 200;
+
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
         /// only be changed when the editor upgrades the version.

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs.meta
@@ -13,7 +13,7 @@ MonoImporter:
   - _simSettingsFlow: {instanceID: 0}
   - _primaryLight: {instanceID: 0}
   - _simSettingsShadow: {instanceID: 0}
-  executionOrder: 200
+  executionOrder: 0
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -16,10 +16,13 @@ namespace Crest
     /// For convenience, all shader material settings are copied from the main ocean shader.
     /// </summary>
     [RequireComponent(typeof(Camera))]
+    [DefaultExecutionOrder(k_DefaultExecutionOrder)]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Underwater Renderer")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "underwater.html" + Internal.Constants.HELP_URL_RP)]
     public partial class UnderwaterRenderer : MonoBehaviour
     {
+        public const int k_DefaultExecutionOrder = OceanRenderer.k_DefaultExecutionOrder + 1;
+
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
         /// only be changed when the editor upgrades the version.

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs.meta
@@ -8,7 +8,7 @@ MonoImporter:
       type: 2}
   - _oceanMaskMaterial: {fileID: 2100000, guid: 2ddd9bab6a9ad7542a419bcaeff337a8,
       type: 2}
-  executionOrder: 202
+  executionOrder: 0
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
This PR replaces #629.

The OceanDepthCache disabling itself in edit mode is the primary issue this PR addresses.

While #629 is a complete and robust solution, it is quite heavy for the three components that will use it:
- OceanPlanarReflections
- OceanDepthCache
- UnderwaterEnvironmentalLighting

Disabling the component only saves Update or PreRender from running and for these components which normally only have one it should be fine (OceanDepthCache disables after start anyway). Also, OceanDepthCache hard dependent on OceanRenderer as it falls back to the transform height.

Instead this makes it so dependent components execute after the OceanRenderer and leaves managing delayed initialisation to the user if they really need it. This is done with DefaultExecutionOrder attribute. It is the same thing as setting the execution order in the project settings, except they don't show up in the list. It can be overridden by the user if they add their own entry.

Let me know what you think.