### PR TITLE
Fix Ocean Depth Cache disabling itself in edit mode

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -90,12 +90,6 @@ namespace Crest
 
         void Start()
         {
-            if (OceanRenderer.Instance == null)
-            {
-                enabled = false;
-                return;
-            }
-
 #if UNITY_EDITOR
             if (EditorApplication.isPlaying && _runValidationOnStart)
             {
@@ -641,6 +635,17 @@ namespace Crest
                 );
 
                 isValid = false;
+            }
+
+            if (ocean == null)
+            {
+                showMessage
+                (
+                    "The <i>Ocean Depth Cache</i> uses the <i>Ocean Renderer</i> height which is not present. " +
+                    "The transform height will be used instead.",
+                    "", // Leave fix message blank as this could be a valid option.
+                    ValidatedHelper.MessageType.Info, this
+                );
             }
 
             if (ocean != null && ocean.Root != null && !Mathf.Approximately(transform.position.y, ocean.Root.position.y))

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -46,6 +46,7 @@ Fixed
    -  Fix underwater effect being flipped at certain camera orientations.
    -  Fix meniscus thickness consistency (in some cases disappearing) with different camera orientations.
    -  Fix inputs (eg keyboard) working when game view is not focused.
+   -  Fix *Ocean Depth Cache* disabling itself in edit mode when no ocean is present.
 
    .. only:: hdrp
 


### PR DESCRIPTION
It gets reported every so often that the _Ocean Depth Cache_ disables itself in edit mode. There is no hard requirement on an _Ocean Renderer_ being present so I have removed the check. I have added validation to notify users of the considerations. 