### PR TITLE
Clip surface input inverted option

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -178,7 +178,7 @@ namespace Crest
 
         int _registeredQueueValue = int.MinValue;
 
-        bool GetQueue(out int queue)
+        protected virtual bool GetQueue(out int queue)
         {
             var rend = GetComponent<Renderer>();
             if (rend && rend.sharedMaterial != null)

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceConvexHull.shader
@@ -6,6 +6,11 @@
 
 Shader "Crest/Inputs/Clip Surface/Convex Hull"
 {
+	Properties
+	{
+		[Toggle] _Inverted("Inverted", Float) = 0
+	}
+
 	SubShader
 	{
 		ZWrite Off
@@ -28,6 +33,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 
 			CBUFFER_START(CrestPerOceanInput)
 			uint _DisplacementSamplingIterations;
+			float _Inverted;
 			CBUFFER_END
 
 			struct Attributes
@@ -66,7 +72,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				{
 					clip(-1);
 				}
-				return float4(1, 0, 0, 1);
+				return float4(_Inverted == 0, 0, 0, 1);
 			}
 			ENDCG
 		}
@@ -86,8 +92,10 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 			#include "../../OceanHelpersNew.hlsl"
 			#include "../../OceanHelpersDriven.hlsl"
 
+
 			CBUFFER_START(CrestPerOceanInput)
 			uint _DisplacementSamplingIterations;
+			float _Inverted;
 			CBUFFER_END
 
 			struct Attributes
@@ -126,7 +134,7 @@ Shader "Crest/Inputs/Clip Surface/Convex Hull"
 				{
 					clip(-1);
 				}
-				return float4(0, 0, 0, 1);
+				return float4(_Inverted, 0, 0, 1);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceSignedDistance.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/ClipSurfaceSignedDistance.shader
@@ -10,7 +10,7 @@ Shader "Hidden/Crest/Inputs/Clip Surface/Signed Distance"
 	{
 		ZWrite Off
 		ColorMask R
-		BlendOp Max
+		BlendOp [_BlendOp]
 
 		Pass
 		{
@@ -21,6 +21,7 @@ Shader "Hidden/Crest/Inputs/Clip Surface/Signed Distance"
 			#pragma fragment Frag
 
 			#pragma multi_compile_local _SPHERE _CUBE
+			#pragma multi_compile_local _ _INVERTED
 
 			#include "UnityCG.cginc"
 			#include "../../OceanGlobals.hlsl"
@@ -89,7 +90,11 @@ Shader "Hidden/Crest/Inputs/Clip Surface/Signed Distance"
 				float signedDistance = signedDistanceSphere(positionWS);
 #endif
 
-				return float4(1.0 - signedDistance, 0.0, 0.0, 1.0);
+#if !_INVERTED
+				signedDistance = 1.0 - signedDistance;
+#endif
+
+				return float4(signedDistance, 0.0, 0.0, 1.0);
 			}
 			ENDCG
 		}

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -18,7 +18,7 @@ Changed
 .. bullet_list::
 
    -  Add *Dynamic Waves* reflections from *Ocean Depth Cache* geometry.
-
+   -  Add inverted option to *Clip Surface* signed-distance primitives and convex hulls which removes clipping.
 
 
 4.13


### PR DESCRIPTION
Adds an "inverted" option to both SDF and convex hull clip surface inputs. Both of these can now remove clip surface data.

With the new order property for SDF, one can create some interesting patterns:

![SDFCH](https://user-images.githubusercontent.com/5249806/131981918-221fe80d-ca8f-4518-9371-1c4381f8e119.jpg)
Left: Convex Hull. Right: SDFs