### PR TITLE
Fix no SSS value at extents

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -524,6 +524,14 @@ Shader "Crest/Ocean"
 					#endif
 				}
 
+#if _SUBSURFACESCATTERING_ON
+				// Extents need the default SSS to avoid popping and not being noticeably different.
+				if (_LD_SliceIndex == (_SliceCount - 1))
+				{
+					sss = CREST_SSS_MAXIMUM - CREST_SSS_RANGE;
+				}
+#endif
+
 				#if _APPLYNORMALMAPPING_ON
 				#if _FLOW_ON
 				ApplyNormalMapsWithFlow(positionXZWSUndisplaced, input.flow_shadow.xy, lodAlpha, cascadeData0, instanceData, n_pixel);

--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -23,6 +23,9 @@
 #define CREST_SHADOW_INDEX_SOFT 0
 #define CREST_SHADOW_INDEX_HARD 1
 
+#define CREST_SSS_MAXIMUM 0.6
+#define CREST_SSS_RANGE 0.12
+
 // Water rendered from above.
 #define UNDERWATER_MASK_ABOVE_SURFACE 0.0
 // Water rendered from below. Used to invert meniscus sampling so keep as 2.0.

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -82,9 +82,7 @@ void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_
 		const float2x2 jacobian = (float4(disp_x.xz, disp_z.xz) - disp.xzxz) / i_texelSize;
 		// Determinant is < 1 for pinched, < 0 for overlap/inversion
 		const float det = determinant( jacobian );
-		const float sssMax = 0.6;
-		const float sssRange = 0.12;
-		io_sss += i_wt * saturate( sssMax - sssRange * det );
+		io_sss += i_wt * saturate( CREST_SSS_MAXIMUM - CREST_SSS_RANGE * det );
 	}
 #endif // _SUBSURFACESCATTERING_ON
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -39,6 +39,7 @@ Fixed
    -  Fix high CPU memory usage from underwater effect shader in builds.
    -  Fix FFT spectrum not being editable when time is paused.
    -  Fix *ShapeFFT* component producing inverted looking waves when enabled in editor play mode.
+   -  Fix SSS colour missing or popping in the distance.
 
    .. only:: hdrp
 


### PR DESCRIPTION
The extents have no SSS factor resulting in popping and extents being noticeably different.

![Issue](https://cdn.discordapp.com/attachments/577081395718127646/882897282125672498/Unity_tGeA9X2rHL.jpg)
Extents can be seen in the right view.

Solved by setting SSS factor to 0.5 at last LOD.