### PR TITLE
Add dynamic waves depth cache reflections

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -120,7 +120,8 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	// http://hyperphysics.phy-astr.gsu.edu/hbase/watwav.html#c1
 	float waterDepth = SampleLod(_LD_TexArray_SeaFloorDepth, uv_slice).x;
 	float depthMul = 1.0 - (1.0 - saturate(2.0 * waterDepth / wavelength)) * dt * 2.0;
-	ftp *= depthMul;
+	// Zero multiplier for zero depth to relfect waves.
+	ftp *= waterDepth > 0.0 ? depthMul : 0.0;
 
 	_LD_TexArray_Target[id] = float2(ftp, vtp);
 }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,9 +13,12 @@ Release Notes
 |version|
 ---------
 
-.. admonition:: TODO
+Changed
+^^^^^^^
+.. bullet_list::
 
-   Work in progress
+   -  Add *Dynamic Waves* reflections from *Ocean Depth Cache* geometry.
+
 
 
 4.13


### PR DESCRIPTION
Adds reflections from the ocean depth cache for dynamic waves.

The attenuation formula applied to dynamic waves is not strong so in its current state most dynamic waves pass through zero depth values. This PR just makes the depth cache absolute when at zero which results in a reflection. Some still pass through (especially if zero depth is thin).

https://user-images.githubusercontent.com/5249806/132119168-13b1bf7b-b37f-40a9-a396-c74a09b87471.mov

Without reflections
<br>

https://user-images.githubusercontent.com/5249806/132120099-0b24e1cb-53f0-40b1-9976-b386fd0b9f5f.mov

With reflections
<br>

Let me know what you think.