### PR TITLE
Water body material override

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -34,6 +34,7 @@ namespace Crest
         public Renderer Rend { get; private set; }
         PropertyWrapperMPB _mpb;
 
+        public bool MaterialOverridden { get; set; }
 
         // We need to ensure that all ocean data has been bound for the mask to
         // render properly - this is something that needs to happen irrespective
@@ -113,7 +114,7 @@ namespace Crest
                 return;
             }
 
-            if (Rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
+            if (!MaterialOverridden && Rend.sharedMaterial != OceanRenderer.Instance.OceanMaterial)
             {
                 Rend.sharedMaterial = OceanRenderer.Instance.OceanMaterial;
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1101,6 +1101,17 @@ namespace Crest
                         if (overlapping)
                         {
                             overlappingOne = true;
+
+                            if (body._overrideMaterial != null)
+                            {
+                                tile.Rend.sharedMaterial = body._overrideMaterial;
+                                tile.MaterialOverridden = true;
+                            }
+                            else
+                            {
+                                tile.MaterialOverridden = false;
+                            }
+
                             break;
                         }
                     }

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -38,6 +38,9 @@ namespace Crest
 
         public Bounds AABB { get; private set; }
 
+        [Tooltip("Water geometry tiles that overlap this waterbody area will be assigned this material. This " +
+            "is useful for varying water appearance across different water bodies. If no override material is " +
+            "specified, the default material assigned to the OceanRenderer component will be used.")]
         public Material _overrideMaterial = null;
 
         private void OnEnable()

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -38,6 +38,8 @@ namespace Crest
 
         public Bounds AABB { get; private set; }
 
+        public Material _overrideMaterial = null;
+
         private void OnEnable()
         {
             CalculateBounds();

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -19,6 +19,7 @@ Changed
 
    -  Add *Dynamic Waves* reflections from *Ocean Depth Cache* geometry.
    -  Add inverted option to *Clip Surface* signed-distance primitives and convex hulls which removes clipping.
+   -  Add *Override Material* field to the *Water Body* component to enable varying water material across water bodies.
 
 
 4.13

--- a/docs/user/water-bodies.rst
+++ b/docs/user/water-bodies.rst
@@ -22,6 +22,9 @@ There are mechanisms to limit the area:
    The *Clip Surface* feature can be used to precisely remove any remaining water outside the intended area.
    Additionally, the clipping system can be configured to clip everything by default, and then areas can be defined where water should be included. See the :ref:`clip-surface-section` section.
 
+Another advantage of the *WaterBody* component is it allows an optional override material to be provided, to change the appearance of the water.
+This currently only changes the appearance of the water surface, it does not currently affect the underwater effect.
+
 
 Wizard (preview)
 ----------------


### PR DESCRIPTION
**Status:** Ready for review

In response to a support request - add a material override field to water bodies. Seems to work fairly straightforwardly (IMO).
