### PR TITLE
Make FFT use 4 samples per wave (min), not 2

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryBase.cs
@@ -308,7 +308,8 @@ namespace Crest
             // The smallest wavelengths should repeat no more than twice across the smaller spatial length. Unless we're
             // in the last LOD - then this is the best we can do.
             float minWavelength = i_minSpatialLength / 2f;
-            float minGridSize = minWavelength / OceanRenderer.Instance.MinTexelsPerWave;
+            float samplesPerWave = 2f;
+            float minGridSize = minWavelength / samplesPerWave;
 
             if (countPts + segment.x > _queryPosXZ_minGridSize.Length)
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodTransform.cs
@@ -129,7 +129,8 @@ namespace Crest
             float oceanBaseScale = OceanRenderer.Instance.Scale;
             float maxDiameter = 4f * oceanBaseScale * Mathf.Pow(2f, lodIdx);
             float maxTexelSize = maxDiameter / OceanRenderer.Instance.LodDataResolution;
-            return 2f * maxTexelSize * OceanRenderer.Instance.MinTexelsPerWave;
+            float texelsPerWave = 2f;
+            return 2f * maxTexelSize * texelsPerWave;
         }
 
         public void SetOrigin(Vector3 newOrigin)

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -178,11 +178,6 @@ namespace Crest
 
         [Header("Detail Params")]
 
-        [Range(2, 16)]
-        [Tooltip("Min number of verts / shape texels per wave."), SerializeField]
-        float _minTexelsPerWave = 3f;
-        public float MinTexelsPerWave => _minTexelsPerWave;
-
         [Delayed, Tooltip("The smallest scale the ocean can be."), SerializeField]
         float _minScale = 8f;
 
@@ -371,7 +366,6 @@ namespace Crest
         bool _canSkipCulling = false;
 
         public static int sp_crestTime = Shader.PropertyToID("_CrestTime");
-        readonly int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
         readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
         readonly int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
         readonly int sp_sliceCount = Shader.PropertyToID("_SliceCount");
@@ -876,8 +870,7 @@ namespace Crest
                 FlowProvider?.UpdateQueries();
             }
 
-            // set global shader params
-            Shader.SetGlobalFloat(sp_texelsPerWave, MinTexelsPerWave);
+            // Set global shader params
             Shader.SetGlobalFloat(sp_crestTime, CurrentTime);
             Shader.SetGlobalFloat(sp_sliceCount, CurrentLodCount);
             Shader.SetGlobalFloat(sp_clipByDefault, _defaultClippingState == DefaultClippingState.EverythingClipped ? 1f : 0f);

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -83,8 +83,9 @@ namespace Crest
             ShapeGerstnerBatched _gerstner;
             int _batchIndex = -1;
 
-            // The ocean input system uses this to decide which lod this batch belongs in
-            public float Wavelength => OceanRenderer.Instance._lodTransform.MaxWavelength(_batchIndex) / 2f;
+            // The ocean input system uses this to decide which LOD this batch belongs in. Multiply
+            // by 1.5 to boost sample count a bit for Gerstner which looks bad with 2 samples per wave.
+            public float Wavelength => 1.5f * OceanRenderer.Instance._lodTransform.MaxWavelength(_batchIndex) / 2f;
 
             public bool Enabled { get; set; }
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -13,7 +13,6 @@ SamplerState sampler_Crest_linear_repeat;
 
 CBUFFER_START(CrestPerFrame)
 float _CrestTime;
-float _TexelsPerWave;
 float3 _OceanCenterPosWorld;
 float _SliceCount;
 float _MeshScaleLerp;

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -12,8 +12,8 @@ SamplerState LODData_point_clamp_sampler;
 SamplerState sampler_Crest_linear_repeat;
 
 CBUFFER_START(CrestPerFrame)
-float _CrestTime;
 float3 _OceanCenterPosWorld;
+float _CrestTime;
 float _SliceCount;
 float _MeshScaleLerp;
 float _CrestClipByDefault;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -19,6 +19,8 @@
 #define SPECTRUM_OCTAVE_COUNT		14.0
 #define SPECTRUM_SMALLEST_WL_POW_2	-4.0
 
+#define SAMPLES_PER_WAVE 4
+
 uint _Size;
 float _WindSpeed;
 float _Turbulence;
@@ -104,21 +106,30 @@ void SpectrumInitalize(uint3 id : SV_DispatchThreadID)
 	const int2 center = _Size.xx / 2;
 	const int2 coord = id.xy - center;
 
+	if( coord.x == 0 && coord.y == 0 )
+	{
+		_ResultInit[id] = 0.0;
+		return;
+	}
+
 	uint depth;
 	{
 		uint width, height;
 		_ResultInit.GetDimensions( width, height, depth );
 	}
 
-	if ( id.z < (depth - 1) && max( abs( coord.x ), abs( coord.y ) ) < int(_Size / 4) )
+	uint maxCoord = int( max( abs( coord.x ), abs( coord.y ) ) );
+
+	// If not largest cascade which will get all wavelengths, then limit
+	// so we split range of frequencies with no overlaps
+	if ( id.z < (depth - 1) &&
+		// Too low wavelength
+		( maxCoord < _Size / (2 * SAMPLES_PER_WAVE) ||
+		// Too high wavelength
+		maxCoord >= _Size / SAMPLES_PER_WAVE )
+		)
 	{
 		_ResultInit[id] = 0.0;
-		return;
-	}
-
-	if (coord.x == 0 && coord.y == 0)
-	{
-		_ResultInit[id] = float4(0, 0, 0, 0);
 		return;
 	}
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -49,8 +49,8 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	const float2 worldPosXZ = UVToWorld(input_uv, sliceIndex, cascadeData);
 	const float gridSize = cascadeData._texelWidth;
 
-	// average wavelength for this scale
-	const float wavelength = 1.0 * _TexelsPerWave * gridSize;
+	// Min wavelength for this scale
+	const float wavelength = 2.0 * gridSize;
 	// could make velocity depend on waves
 	//float h = max(waterSignedDepth + ft, 0.);
 	float c = ComputeWaveSpeed(wavelength, _Gravity);


### PR DESCRIPTION
**Status**: Seems to work here but could use second pair of eyes

I think this fixes both the lines in foam #878 , and also recently asked question on discord about quality of a single band of FFT waves (by gamemachine i think).

Using 2 samples per wave in FFT is too low. This uses 4 samples per wave instead.

It seems like this fixes the lines in foam, which seem to have been down to bad quality of wave displacements. There are still repeating patterns in foam which is to be expected, but not obvious lines.

Also the Texels Per Wave param on the OceanRenderer component seems to need to be set to 2 for best results. I dont think this param is a good user facing feature, so I've committed to removing it to clean up the UI and hardcode what i feel should be a system var (and hard code it to nyquist limit).
