### PR TITLE
Store terrain height instead of computing water depth

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -92,6 +92,7 @@ namespace Crest
             simMaterial.SetFloat(sp_Damping, Settings._damping);
             simMaterial.SetFloat(sp_Gravity, OceanRenderer.Instance.Gravity * Settings._gravityMultiplier);
             simMaterial.SetFloat(sp_CourantNumber, Settings._courantNumber);
+            simMaterial.SetVector(OceanRenderer.sp_oceanCenterPosWorld, OceanRenderer.Instance.Root.position);
 
             // assign sea floor depth - to slot 1 current frame data. minor bug here - this depth will actually be from the previous frame,
             // because the depth is scheduled to render just before the animated waves, and this sim happens before animated waves.

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -65,6 +65,7 @@ namespace Crest
             simMaterial.SetFloat(sp_WaveFoamCoverage, Settings._waveFoamCoverage);
             simMaterial.SetFloat(sp_ShorelineFoamMaxDepth, Settings._shorelineFoamMaxDepth);
             simMaterial.SetFloat(sp_ShorelineFoamStrength, Settings._shorelineFoamStrength);
+            simMaterial.SetVector(OceanRenderer.sp_oceanCenterPosWorld, OceanRenderer.Instance.Root.position);
 
             // assign animated waves - to slot 1 current frame data
             LodDataMgrAnimWaves.Bind(simMaterial);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -9,14 +9,15 @@ using UnityEngine.Rendering;
 namespace Crest
 {
     /// <summary>
-    /// Renders depth of the ocean (height of sea level above ocean floor), by rendering the relative height of tagged objects from top down.
+    /// Data that gives depth of the ocean (height of sea level above ocean floor). Stores terrain height and water level
+    /// offset.
     /// </summary>
     public class LodDataMgrSeaFloorDepth : LodDataMgr
     {
         public override string SimName { get { return "SeaFloorDepth"; } }
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16_SFloat;
         protected override bool NeedToReadWriteTextureData { get { return false; } }
-        // We want the null colour to be the depth where wave attenuation begins (1000 metres)
+        // We want the clear colour to be the min terrain height (-1000m)
         readonly static Color s_nullColor = Color.red * -1000f;
         static Texture2DArray s_nullTexture;
         protected override Texture2DArray NullTexture => s_nullTexture;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -17,7 +17,7 @@ namespace Crest
         protected override GraphicsFormat RequestedTextureFormat => GraphicsFormat.R16_SFloat;
         protected override bool NeedToReadWriteTextureData { get { return false; } }
         // We want the null colour to be the depth where wave attenuation begins (1000 metres)
-        readonly static Color s_nullColor = Color.red * 1000f;
+        readonly static Color s_nullColor = Color.red * -1000f;
         static Texture2DArray s_nullTexture;
         protected override Texture2DArray NullTexture => s_nullTexture;
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -372,7 +372,7 @@ namespace Crest
 
         public static int sp_crestTime = Shader.PropertyToID("_CrestTime");
         readonly int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
-        readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
+        public static int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
         readonly int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
         readonly int sp_sliceCount = Shader.PropertyToID("_SliceCount");
         readonly int sp_clipByDefault = Shader.PropertyToID("_CrestClipByDefault");

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -370,9 +370,11 @@ namespace Crest
 
         bool _canSkipCulling = false;
 
+        public static readonly int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
         public static int sp_crestTime = Shader.PropertyToID("_CrestTime");
+        public static int sp_perCascadeInstanceData = Shader.PropertyToID("_CrestPerCascadeInstanceData");
+        public static int sp_cascadeData = Shader.PropertyToID("_CrestCascadeData");
         readonly int sp_texelsPerWave = Shader.PropertyToID("_TexelsPerWave");
-        public static int sp_oceanCenterPosWorld = Shader.PropertyToID("_OceanCenterPosWorld");
         readonly int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
         readonly int sp_sliceCount = Shader.PropertyToID("_SliceCount");
         readonly int sp_clipByDefault = Shader.PropertyToID("_CrestClipByDefault");
@@ -380,8 +382,6 @@ namespace Crest
         readonly int sp_lodAlphaBlackPointWhitePointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointWhitePointFade");
         readonly int sp_CrestDepthTextureOffset = Shader.PropertyToID("_CrestDepthTextureOffset");
         static int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
-        public static int sp_perCascadeInstanceData = Shader.PropertyToID("_CrestPerCascadeInstanceData");
-        public static int sp_cascadeData = Shader.PropertyToID("_CrestCascadeData");
 
 #if UNITY_EDITOR
         static float _lastUpdateEditorTime = -1f;

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -108,7 +108,8 @@ void SampleFlow(in Texture2DArray i_oceanFlowSampler, in float3 i_uv_slice, in f
 
 void SampleSeaDepth(in Texture2DArray i_oceanDepthSampler, in float3 i_uv_slice, in float i_wt, inout half io_oceanDepth)
 {
-	io_oceanDepth += i_wt * (i_oceanDepthSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0).x - CREST_OCEAN_DEPTH_BASELINE);
+	const float waterDepth = _OceanCenterPosWorld.y - i_oceanDepthSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0).x;
+	io_oceanDepth += i_wt * (waterDepth - CREST_OCEAN_DEPTH_BASELINE);
 }
 
 void SampleShadow(in Texture2DArray i_oceanShadowSampler, in float3 i_uv_slice, in float i_wt, inout half2 io_shadow)

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/GerstnerShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/GerstnerShared.hlsl
@@ -26,7 +26,7 @@ CBUFFER_END
 half3 ComputeGerstner(float2 worldPosXZ, float3 uv_slice)
 {
 	// sample ocean depth (this render target should 1:1 match depth texture, so UVs are trivial)
-	const half depth = _LD_TexArray_SeaFloorDepth.Sample(LODData_linear_clamp_sampler, uv_slice).x;
+	const half depth = _OceanCenterPosWorld.y - _LD_TexArray_SeaFloorDepth.Sample(LODData_linear_clamp_sampler, uv_slice).x;
 
 	// Preferred wave directions
 #if CREST_DIRECT_TOWARDS_POINT_INTERNAL

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
@@ -72,7 +72,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 				float wt = _Weight;
 
 				// Attenuate if depth is less than half of the average wavelength
-				const half depth = _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, float3(input.uv_uvWaves.xy, _LD_SliceIndex), 0.0).x;
+				const half depth = _OceanCenterPosWorld.y - _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, float3(input.uv_uvWaves.xy, _LD_SliceIndex), 0.0).x;
 				half depth_wt = saturate(2.0 * depth / _AverageWavelength);
 				const float attenuationAmount = _AttenuationInShallows * _RespectShallowWaterAttenuation;
 				wt *= attenuationAmount * depth_wt + (1.0 - attenuationAmount);

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
@@ -107,7 +107,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
                 float wt = input.invNormDistToShoreline_weight.y;
 
                 // Attenuate if depth is less than half of the average wavelength
-                const half depth = _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, input.uv_slice.xyz, 0.0).x;
+                const half depth = _OceanCenterPosWorld.y - _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, input.uv_slice.xyz, 0.0).x;
                 const half depth_wt = saturate(2.0 * depth / _AverageWavelength);
                 const float attenuationAmount = _AttenuationInShallows * _RespectShallowWaterAttenuation;
                 wt *= attenuationAmount * depth_wt + (1.0 - attenuationAmount);

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
@@ -69,7 +69,7 @@ Shader "Crest/Copy Depth Buffer Into Cache"
 				altitude = lerp(_HeightNearHeightFar.x, _HeightNearHeightFar.y, linear01Z);
 #endif
 
-				return float4(_OceanCenterPosWorld.y - altitude, 0.0, 0.0, 1.0);
+				return float4(altitude, 0.0, 0.0, 1.0);
 			}
 
 			ENDCG

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepths.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepths.shader
@@ -9,15 +9,15 @@ Shader "Crest/Inputs/Depth/Ocean Depth From Geometry"
 	{
 		Pass
 		{
-			BlendOp Min
-
+			BlendOp Max
+			ColorMask R
+			
 			CGPROGRAM
 			#pragma vertex Vert
 			#pragma fragment Frag
 
 			#include "UnityCG.cginc"
 			#include "../../OceanConstants.hlsl"
-			#include "../../OceanGlobals.hlsl"
 
 			struct Attributes
 			{
@@ -27,24 +27,20 @@ Shader "Crest/Inputs/Depth/Ocean Depth From Geometry"
 			struct Varyings
 			{
 				float4 positionCS : SV_POSITION;
-				float depth : TEXCOORD0;
+				float terrainHeight : TEXCOORD0;
 			};
 
 			Varyings Vert(Attributes input)
 			{
 				Varyings o;
 				o.positionCS = UnityObjectToClipPos(input.positionOS);
-
-				float altitude = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0)).y;
-
-				o.depth = _OceanCenterPosWorld.y - altitude;
-
+				o.terrainHeight = mul(unity_ObjectToWorld, float4(input.positionOS, 1.0)).y;
 				return o;
 			}
 
 			float4 Frag(Varyings input) : SV_Target
 			{
-				return float4(input.depth, 0.0, 0.0, 0.0);
+				return float4(input.terrainHeight, 0.0, 0.0, 0.0);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -2,7 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-// Draw cached depths into current frame ocean depth data
+// Draw cached terrain heights into current frame data
+
 Shader "Crest/Inputs/Depth/Cached Depths"
 {
 	Properties
@@ -14,10 +15,8 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 	{
 		Pass
 		{
-			// Min blending to take the min of all depths. Similar in spirit to zbuffer'd visibility when viewing from top down.
-			// To confuse matters further, ocean depth is now more like 'sea floor altitude' - a height above a deep water value,
-			// so values are increasing in Y and we need to take the MAX of all depths.
-			BlendOp Min
+			// When blending, take highest terrain height
+			BlendOp Max
 			ColorMask R
 
 			CGPROGRAM

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputsDriven.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputsDriven.hlsl
@@ -54,7 +54,6 @@ Texture2DArray _LD_TexArray_Shadow;
 // shadowing for example.
 Texture2DArray _LD_TexArray_AnimatedWaves_Source;
 Texture2DArray _LD_TexArray_WaveBuffer_Source;
-Texture2DArray _LD_TexArray_SeaFloorDepth_Source;
 Texture2DArray _LD_TexArray_ClipSurface_Source;
 Texture2DArray _LD_TexArray_Foam_Source;
 Texture2DArray _LD_TexArray_Flow_Source;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -118,8 +118,8 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	// eventually break. i model "Deep" water, but then simply ramp down waves in non-deep water with a linear multiplier.
 	// http://hyperphysics.phy-astr.gsu.edu/hbase/Waves/watwav2.html
 	// http://hyperphysics.phy-astr.gsu.edu/hbase/watwav.html#c1
-	float waterDepth = SampleLod(_LD_TexArray_SeaFloorDepth, uv_slice).x;
-	float depthMul = 1.0 - (1.0 - saturate(2.0 * waterDepth / wavelength)) * dt * 2.0;
+	const float waterDepth = _OceanCenterPosWorld.y - SampleLod(_LD_TexArray_SeaFloorDepth, uv_slice).x;
+	const float depthMul = 1.0 - (1.0 - saturate(2.0 * waterDepth / wavelength)) * dt * 2.0;
 	// Zero multiplier for zero depth to relfect waves.
 	ftp *= waterDepth > 0.0 ? depthMul : 0.0;
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -92,7 +92,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 
 	// Add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
 	const float3 uv_slice_displaced = WorldToUV(worldPosXZ + disp.xz, cascadeData, sliceIndex);
-	float signedOceanDepth = SampleLodLevel(_LD_TexArray_SeaFloorDepth, uv_slice_displaced, 0.0).x + disp.y;
+	const float signedOceanDepth = _OceanCenterPosWorld.y - SampleLodLevel(_LD_TexArray_SeaFloorDepth, uv_slice_displaced, 0.0).x + disp.y;
 	foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1.0 - signedOceanDepth / _ShorelineFoamMaxDepth);
 
 	_LD_TexArray_Target[id] = saturate(foam);

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -258,8 +258,10 @@ These settings should generally be left unchanged unless one is experiencing iss
 Sea Floor Depth
 ---------------
 
-This simulation stores water depth information.
-This is useful information for the system; it is used to attenuate large waves in
+This simulation stores information that can be used to calculate the water depth.
+Specifically it stores the terrain height, which can then be differenced with the sea level
+to obtain the water depth.
+This water depth is useful information to the system; it is used to attenuate large waves in
 shallow water, to generate foam near shorelines, and to provide shallow water shading.
 It is calculated by rendering the render geometry in the scene for each LOD from a top down perspective and recording the Y value of the surface.
 


### PR DESCRIPTION
**Status**: Ready to merge

This stores terrain height into the depth data.

This is roughly equivalent to storing water depth, but is more general. It will make things simpler when the water level can vary for lakes and rivers. For example populating a depth cache for a river where water level varies is complicated, as the generation needs to know the water level. With this change, the depth cache just stores terrain height which is simple.

Anything that needs the water depth now calculates it as the difference between the sea level and the terrain height. The local water bodies branch will add another channel to this texture to store the sea level, so the calculation will eventually subtract the two channels rather than using the global sea level.

I searched all usages of `_LD_TexArray_SeaFloorDepth` and fixed them up.

The not great thing about this is it now stores 'terrain heights' in data that is called 'water depth' everywhere, which is confusing. However the local water bodies branch will add water water as a new channel and then this data sort of contains water depth, or at least data related to water depth, so its probably fine.
