### PR TITLE
Fix white texture when sims are disabled with texture quality below full resolution (workaround)

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -78,7 +78,15 @@ namespace Crest
 
             for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
             {
+                // There is a bug using Graphics.CopyTexture with Texture2DArray when "Texture Quality"
+                // (QualitySettings.masterTextureLimit) is not "Full Res" (0) where result is junk (white from what I
+                // have seen). Reported to Unity on 2021.09.15.
+                // https://issuetracker.unity3d.com/product/unity/issues/guid/1365775
+                // https://docs.unity3d.com/ScriptReference/QualitySettings-masterTextureLimit.html
+                var originalMTL = QualitySettings.masterTextureLimit;
+                QualitySettings.masterTextureLimit = 0;
                 Graphics.CopyTexture(texture, 0, 0, array, textureArrayIndex, 0);
+                QualitySettings.masterTextureLimit = originalMTL;
             }
 
             return array;

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -80,14 +80,13 @@ namespace Crest
             {
                 // There is a bug using Graphics.CopyTexture with Texture2DArray when "Texture Quality"
                 // (QualitySettings.masterTextureLimit) is not "Full Res" (0) where result is junk (white from what I
-                // have seen). Reported to Unity on 2021.09.15.
+                // have seen). Changing this setting at runtime might cause a hitch so use SetPixels for now.
+                // Reported to Unity on 2021.09.15.
                 // https://issuetracker.unity3d.com/product/unity/issues/guid/1365775
-                // https://docs.unity3d.com/ScriptReference/QualitySettings-masterTextureLimit.html
-                var originalMTL = QualitySettings.masterTextureLimit;
-                QualitySettings.masterTextureLimit = 0;
-                Graphics.CopyTexture(texture, 0, 0, array, textureArrayIndex, 0);
-                QualitySettings.masterTextureLimit = originalMTL;
+                array.SetPixels(texture.GetPixels(0), textureArrayIndex, 0);
             }
+
+            array.Apply();
 
             return array;
         }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -30,6 +30,8 @@ Fixed
 
    -  Fix lines in foam data producing noticeable repeating patterns when using `FFT` waves.
    -  Fix caustics jittering when far from zero and underwater in XR.
+   -  Fix disabled simulations' data being at maximum when "Texture Quality" is not "Full Res".
+      In one case this manifested as the entire ocean being shadowed in builds.
 
 Removed
 ^^^^^^^


### PR DESCRIPTION
When "Project Settings > Texture Quality" is not "Full Res" our black texture array becomes white (probably junk). This is a bug with _Graphics.CopyTexture_ when using texture arrays. This can happen in builds when quality settings may be different (ie high in editor or low in build) than in editor which can be hard to debug.

Workaround is to set [_QualitySettings.masterTextureLimit_](https://docs.unity3d.com/ScriptReference/QualitySettings-masterTextureLimit.html) to zero before calling _Graphics.CopyTexture_. I have seen others do this for other bugs for this same method. We can also use SetPixels instead but this looks good enough. I have submitted a bug report to Unity for texture arrays.