### PR TITLE
Remove duplicate matrix calculation

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
@@ -75,6 +75,9 @@ namespace Crest
                 _filterOceanData
             );
 
+            // Call after UpdatePostProcessMaterial as it copies material from ocean which will overwrite this.
+            SetInverseViewProjectionMatrix(_underwaterEffectMaterial.material);
+
             _underwaterEffectCommandBuffer.Clear();
 
             if (_camera.allowMSAA)
@@ -182,20 +185,6 @@ namespace Crest
             else
             {
                 underwaterPostProcessMaterial.DisableKeyword(FULL_SCREEN_EFFECT);
-            }
-
-            // Have to set these explicitly as the built-in transforms aren't in world-space for the blit function
-            if (XRHelpers.IsSinglePass)
-            {
-                // NOTE: Not needed for HDRP.
-                underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjection, (GL.GetGPUProjectionMatrix(XRHelpers.LeftEyeProjectionMatrix, false) * XRHelpers.LeftEyeViewMatrix).inverse);
-                underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjectionRight, (GL.GetGPUProjectionMatrix(XRHelpers.RightEyeProjectionMatrix, false) * XRHelpers.RightEyeViewMatrix).inverse);
-            }
-            else
-            {
-                // NOTE: Not needed for HDRP.
-                var inverseViewProjectionMatrix = (GL.GetGPUProjectionMatrix(camera.projectionMatrix, false) * camera.worldToCameraMatrix).inverse;
-                underwaterPostProcessMaterial.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
             }
 
             // Project ocean normal onto camera plane.

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
@@ -54,6 +54,8 @@ namespace Crest
             _oceanMaskCommandBuffer.SetGlobalTexture(sp_CrestOceanMaskTexture, _maskTexture.colorBuffer);
             _oceanMaskCommandBuffer.SetGlobalTexture(sp_CrestOceanMaskDepthTexture, _depthTexture.depthBuffer);
 
+            SetInverseViewProjectionMatrix(_oceanMaskMaterial.material);
+
             PopulateOceanMask(
                 _oceanMaskCommandBuffer,
                 _camera,
@@ -110,20 +112,6 @@ namespace Crest
             // Render horizon into mask using a fullscreen triangle at the far plane. Horizon must be rendered first or
             // it will overwrite the mask with incorrect values.
             {
-                // Have to set these explicitly as the built-in transforms aren't in world-space for the blit function.
-                if (XRHelpers.IsSinglePass)
-                {
-                    // NOTE: Not needed for HDRP.
-                    oceanMaskMaterial.SetMatrix(sp_InvViewProjection, (GL.GetGPUProjectionMatrix(XRHelpers.LeftEyeProjectionMatrix, false) * XRHelpers.LeftEyeViewMatrix).inverse);
-                    oceanMaskMaterial.SetMatrix(sp_InvViewProjectionRight, (GL.GetGPUProjectionMatrix(XRHelpers.RightEyeProjectionMatrix, false) * XRHelpers.RightEyeViewMatrix).inverse);
-                }
-                else
-                {
-                    // NOTE: Not needed for HDRP.
-                    var inverseViewProjectionMatrix = (GL.GetGPUProjectionMatrix(camera.projectionMatrix, false) * camera.worldToCameraMatrix).inverse;
-                    oceanMaskMaterial.SetMatrix(sp_InvViewProjection, inverseViewProjectionMatrix);
-                }
-
                 // Compute _ZBufferParams x and y values.
                 float zBufferParamsX; float zBufferParamsY;
                 if (SystemInfo.usesReversedZBuffer)

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -65,6 +65,10 @@ namespace Crest
 
         Camera _camera;
         bool _firstRender = true;
+
+        Matrix4x4 _gpuInverseViewProjectionMatrix;
+        Matrix4x4 _gpuInverseViewProjectionMatrixRight;
+
         // XR MP will create two instances of this class so it needs to be static to track the pass/eye.
         internal static int s_xrPassIndex = -1;
 
@@ -159,10 +163,35 @@ namespace Crest
             XRHelpers.Update(_camera);
             XRHelpers.UpdatePassIndex(ref s_xrPassIndex);
 
+            // Built-in renderer does not provide these matrices.
+            if (XRHelpers.IsSinglePass)
+            {
+                _gpuInverseViewProjectionMatrix = (GL.GetGPUProjectionMatrix(XRHelpers.LeftEyeProjectionMatrix, false) * XRHelpers.LeftEyeViewMatrix).inverse;
+                _gpuInverseViewProjectionMatrixRight = (GL.GetGPUProjectionMatrix(XRHelpers.RightEyeProjectionMatrix, false) * XRHelpers.RightEyeViewMatrix).inverse;
+            }
+            else
+            {
+                _gpuInverseViewProjectionMatrix = (GL.GetGPUProjectionMatrix(_camera.projectionMatrix, false) * _camera.worldToCameraMatrix).inverse;
+            }
+
             OnPreRenderOceanMask();
             OnPreRenderUnderwaterEffect();
 
             _firstRender = false;
+        }
+
+        void SetInverseViewProjectionMatrix(Material material)
+        {
+            // Have to set these explicitly as the built-in transforms aren't in world-space for the blit function.
+            if (XRHelpers.IsSinglePass)
+            {
+                material.SetMatrix(sp_InvViewProjection, _gpuInverseViewProjectionMatrix);
+                material.SetMatrix(sp_InvViewProjectionRight, _gpuInverseViewProjectionMatrixRight);
+            }
+            else
+            {
+                material.SetMatrix(sp_InvViewProjection, _gpuInverseViewProjectionMatrix);
+            }
         }
     }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -20,6 +20,12 @@ Changed
    -  Add *Dynamic Waves* reflections from *Ocean Depth Cache* geometry.
    -  Add inverted option to *Clip Surface* signed-distance primitives and convex hulls which removes clipping.
 
+Performance
+^^^^^^^^^^^
+.. bullet_list::
+
+   -  Only calculate inverse view projection matrix when required.
+
 
 4.13
 ----


### PR DESCRIPTION
I was calculating this twice. Also, removes this code path from SRP as the IVP matrix is provided by Unity.