### PR TITLE
Add ObsoleteShaderGUI

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/ObsoleteShaderGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/ObsoleteShaderGUI.cs
@@ -1,0 +1,38 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest
+{
+    using UnityEditor;
+
+    /// <summary>
+    /// Adds a deprecated message to shaders.
+    ///
+    /// USAGE
+    /// Add to bottom of Shader block:
+    /// CustomEditor "Crest.ObsoleteShaderGUI"
+    /// Optionally add to Properties block:
+    /// [HideInInspector] _ObsoleteMessage("The additional message.", Float) = 0
+    /// </summary>
+    public class ObsoleteShaderGUI : ShaderGUI
+    {
+        public override void OnGUI(MaterialEditor editor, MaterialProperty[] properties)
+        {
+            var message = "This shader is deprecated and will be removed in a future version.";
+
+            {
+                var property = FindProperty("_ObsoleteMessage", properties, propertyIsMandatory: false);
+                if (property != null)
+                {
+                    message += " " + property.displayName;
+                }
+            }
+
+            EditorGUILayout.HelpBox(message, MessageType.Warning);
+
+            // Render the default GUI.
+            base.OnGUI(editor, properties);
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Editor/ObsoleteShaderGUI.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/ObsoleteShaderGUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f6f2e8b8d583478bb2ab2e377d6b63e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a custom ShaderGUI for obsolete shaders.

<img width="912" alt="Screen Shot 2021-09-17 at 1 36 15 pm" src="https://user-images.githubusercontent.com/5249806/133850805-afa2ff1d-96a9-47f0-8f33-983ff9bd441e.png">

Example usage:

```shader
Shader "Crest/Inputs/Animated Waves/Set Base Water Height Using Geometry"
{
	Properties
	{
		[HideInInspector] _ObsoleteMessage("Use <i>Crest/Inputs/Sea Floor Depth/Set Base Water Height Using Geometry</i> instead.", Float) = 0
                // ...
	}
        // ...
        CustomEditor "Crest.ObsoleteShaderGUI"
}
```