### PR TITLE
Water body auto clip-include

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -34,6 +34,9 @@ namespace Crest
         bool _runValidationOnStart = true;
 #pragma warning restore 414
 
+		[Tooltip("If clipping is enabled and set to clip everywhere by default, this option will register this water body to ensure its area does not get clipped."), SerializeField]
+		bool _registerWithClipSurfaceData = true;
+		
         public static List<WaterBody> WaterBodies => _waterBodies;
         static List<WaterBody> _waterBodies = new List<WaterBody>();
 
@@ -76,7 +79,7 @@ namespace Crest
 
             _waterBodies.Add(this);
 
-            if (OceanRenderer.Instance && OceanRenderer.Instance.CreateClipSurfaceData
+            if (_registerWithClipSurfaceData && OceanRenderer.Instance && OceanRenderer.Instance.CreateClipSurfaceData
                 && OceanRenderer.Instance._defaultClippingState == OceanRenderer.DefaultClippingState.EverythingClipped)
             {
                 if (_clipInput == null)

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -34,9 +34,9 @@ namespace Crest
         bool _runValidationOnStart = true;
 #pragma warning restore 414
 
-		[Tooltip("If clipping is enabled and set to clip everywhere by default, this option will register this water body to ensure its area does not get clipped."), SerializeField]
-		bool _registerWithClipSurfaceData = true;
-		
+        [Tooltip("If clipping is enabled and set to clip everywhere by default, this option will register this water body to ensure its area does not get clipped."), SerializeField]
+        bool _registerWithClipSurfaceData = true;
+        
         public static List<WaterBody> WaterBodies => _waterBodies;
         static List<WaterBody> _waterBodies = new List<WaterBody>();
 

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -86,7 +86,12 @@ namespace Crest
         {
             _waterBodies.Remove(this);
 
-            HandleClipInputRegistration();
+            if (_clipInput != null)
+            {
+                RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrClipSurface)).Remove(_clipInput);
+
+                _clipInput = null;
+            }
         }
 
         private void CalculateBounds()

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -79,6 +79,7 @@ namespace Crest
 
             _waterBodies.Add(this);
 
+            // Needs to execute after the Ocean Renderer as Update is stripped from builds.
             HandleClipInputRegistration();
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 203
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -28,6 +28,7 @@ Changed
    -  Add *Ocean Renderer >  Water Body Culling* option so the ocean can ignore culling.
       Useful if using *Water Body > Override Material* and still want an ocean.
    -  Improve multiple *Water Body* overlapping case when *Water Body > Override Material* option is used.
+   -  Water Body adds an inclusion to clipping (ie unclips) if *Default Clipping State* is *Everything Clipped*.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
Make waterbody automatically clip-include

If clipping is enabled and clipping set to remove everything by default, then the waterbody ensures its area is clip-included.

This seems good to me, but needs the ocean lifetime stuff to ensure OnEnable is called after the OceanRenderer.

No urgency on this so ill just park it here.

NOTE: Just realised i created it against master instead of local-water-body. I'm guessing the life cycle stuff won't merge soon so this is probably fine, but review-by-commit is necessary, just the last one is relevant.