### PR TITLE
Fix underwater high CPU memory usage

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -39,6 +39,7 @@ namespace Crest
         [SerializeField]
         [Tooltip("Add a meniscus to the boundary between water and air.")]
         internal bool _meniscus = true;
+        public bool IsMeniscusEnabled => _meniscus;
 
 
         [Header("Advanced")]

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
@@ -15,13 +15,10 @@ Shader "Hidden/Crest/Underwater/Underwater Effect"
 			#pragma vertex Vert
 			#pragma fragment Frag
 
-			#pragma multi_compile_instancing
-
 			// Use multi_compile because these keywords are copied over from the ocean material. With shader_feature,
 			// the keywords would be stripped from builds. Unused shader variants are stripped using a build processor.
 			#pragma multi_compile_local __ _SUBSURFACESCATTERING_ON
 			#pragma multi_compile_local __ _SUBSURFACESHALLOWCOLOUR_ON
-			#pragma multi_compile_local __ _TRANSPARENCY_ON
 			#pragma multi_compile_local __ _CAUSTICS_ON
 			#pragma multi_compile_local __ _SHADOWS_ON
 			#pragma multi_compile_local __ _COMPILESHADERWITHDEBUGINFO_ON

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMask.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMask.shader
@@ -40,8 +40,6 @@ Shader "Hidden/Crest/Underwater/Ocean Mask"
 			#pragma vertex Vert
 			#pragma fragment Frag
 
-			#pragma multi_compile_instancing
-
 			#include "UnityCG.cginc"
 
 			#include "../../Helpers/BIRP/Common.hlsl"

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -32,6 +32,7 @@ Fixed
    -  Fix caustics jittering when far from zero and underwater in XR.
    -  Fix disabled simulations' data being at maximum when "Texture Quality" is not "Full Res".
       In one case this manifested as the entire ocean being shadowed in builds.
+   -  Fix high CPU memory usage from underwater effect shader in builds.
 
 Removed
 ^^^^^^^


### PR DESCRIPTION
I made a mistake with stripping as I was not stripping variants for the "__" (ie no keyword) case. It was reported on discord that underwater shader was using ~500mb. It is now under 25mb which puts it in line with other shaders.