### PR TITLE
Fix clip surface using incorrect slices

### DIFF
--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -28,6 +28,7 @@ Fixed
    -  Fix incorrect baked depth cache data that were baked since `Crest` 4.14.
    -  Fix XR `SPI` underwater rendering for Unity 2021.2 standalone.
    -  Fix *Underwater Renderer* not rendering on *Intel iGPUs*.
+   -  Fix clip surface inputs losing accuracy with large waves.
 
    .. only:: hdrp
 


### PR DESCRIPTION
An issue with clip surface not being accurate for large waves was reported and I discovered it was blowing out when there was horizontal displacement. Uncertain if it is the reported issue.

![old](https://user-images.githubusercontent.com/5249806/134635317-f3d3bd1c-b557-4710-8165-aa01ad7956c0.jpg)
Blowout of the sphere which is clamped sample due to incorrect slice index.

![new](https://user-images.githubusercontent.com/5249806/134635328-4abf020b-3b5b-4723-a16b-21b104258e71.jpg)
Fixed.