### PR TITLE
Fix FFTs not updating with spectrum changes when paused

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
@@ -200,7 +200,7 @@ namespace Crest
         RenderTexture GenerateDisplacementsInternal(CommandBuffer buf, float time, bool updateSpectrum)
         {
             // Check if already generated, and we're not being asked to re-update the spectrum
-            if (_generationTime == time)
+            if (_generationTime == time && !updateSpectrum)
             {
                 return _waveBuffers;
             }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -33,6 +33,7 @@ Fixed
    -  Fix disabled simulations' data being at maximum when "Texture Quality" is not "Full Res".
       In one case this manifested as the entire ocean being shadowed in builds.
    -  Fix high CPU memory usage from underwater effect shader in builds.
+   -  Fix FFT spectrum not being editable when time is paused.
 
    .. only:: hdrp
 


### PR DESCRIPTION
This is just a quick fix. Downside is that it runs at full rate instead of editor update intervals. Alternatives could be to add a CurrentUnscaledTime similar to CurrentTime. Or to hash the spectrum.

Let me know what you think.