### PR TITLE
Fix default spectrum breaking in editor when enabled in play mode for ShapeFFT

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -65,32 +65,35 @@ namespace Crest
         [Tooltip("Scales horizontal displacement"), Range(0f, 2f)]
         public float _chop = 1.6f;
 
-#if !UNITY_EDITOR
         void Awake()
         {
-            // If it is version zero, and we are in a build, then it must be the default.
-            if (_version == 0)
-            {
-                // Reset is called in the editor only so manually call here for standalone builds.
-                Reset();
-            }
+            // For builds and when Shape* component is enabled in play mode.
+            Upgrade();
         }
-#endif
 
         void Reset()
         {
-            // Auto-upgrade any new data objects directly to v1. This is in lieu of simply
-            // giving _version a default value of 1 to distuingish new data, which we can't do
-            // because _version is not present in the old data at all.
-            // TODO: after a few releases, we can be sure _version will be present in the data.
-            // At this point we can bump _version to a default value of 1 and from that point
-            // onwards know that version is correct, and this auto upgrade path can go away.
-            for (int i = 0; i < _powerLog.Length; i++)
+            // For when the reset button is used.
+            Upgrade();
+        }
+
+        void Upgrade()
+        {
+            if (_version == 0)
             {
-                // This is equivalent to power /= 25, in log10 space
-                _powerLog[i] -= 1.39794f;
+                // Auto-upgrade any new data objects directly to v1. This is in lieu of simply
+                // giving _version a default value of 1 to distuingish new data, which we can't do
+                // because _version is not present in the old data at all.
+                // TODO: after a few releases, we can be sure _version will be present in the data.
+                // At this point we can bump _version to a default value of 1 and from that point
+                // onwards know that version is correct, and this auto upgrade path can go away.
+                for (int i = 0; i < _powerLog.Length; i++)
+                {
+                    // This is equivalent to power /= 25, in log10 space
+                    _powerLog[i] -= 1.39794f;
+                }
+                _version = 1;
             }
-            _version = 1;
         }
 
 #if UNITY_EDITOR

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -33,6 +33,7 @@ Fixed
    -  Fix disabled simulations' data being at maximum when "Texture Quality" is not "Full Res".
       In one case this manifested as the entire ocean being shadowed in builds.
    -  Fix high CPU memory usage from underwater effect shader in builds.
+   -  Fix *ShapeFFT* component producing inverted looking waves when enabled in editor play mode.
 
    .. only:: hdrp
 


### PR DESCRIPTION
This was an edge case that I missed. If ShapeFFT is enabled in play mode in the editor with a default spectrum, then it will not get the version upgrade it needs.

The fix was to also call the upgrade code in Awake in the editor.