### PR TITLE
Fix visible specks underwater

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -62,6 +62,7 @@ namespace Crest
             public bool _viewOceanMask = false;
             public bool _disableOceanMask = false;
             public bool _disableHeightAboveWaterOptimization = false;
+            public bool _disableArtifactCorrection = false;
         }
 
         Camera _camera;

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/CrestFillMaskArtefacts.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/CrestFillMaskArtefacts.compute
@@ -1,0 +1,54 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Checks both orthogonal and diagonal pixels to fill artefacts in the mask. If checked pixels are all the same then it
+// assumes that the current pixel should also be the same and fixes it.
+
+#pragma kernel FillMaskArtefacts
+
+RWTexture2D<float> _CrestOceanMaskTexture;
+
+[numthreads(8, 8, 1)]
+void FillMaskArtefacts(const uint3 id : SV_DispatchThreadID)
+{
+    const uint3 offset = uint3(1, -1, 0);
+
+    // Check orthogonal pixels.
+    {
+        const float4 pixels = float4
+        (
+            _CrestOceanMaskTexture[id.xy + offset.xz],
+            _CrestOceanMaskTexture[id.xy + offset.yz],
+            _CrestOceanMaskTexture[id.xy + offset.zy],
+            _CrestOceanMaskTexture[id.xy + offset.zx]
+        );
+
+        // If these pixels are all the same, then it is valid that this pixel also equals them.
+        if (pixels.x == pixels.y && pixels.y == pixels.z && pixels.z == pixels.w)
+        {
+            _CrestOceanMaskTexture[id.xy] = pixels.x;
+            return;
+        }
+    }
+
+    // Check diagonal pixels.
+    {
+        const float4 pixels = float4
+        (
+            _CrestOceanMaskTexture[id.xy + offset.xx],
+            _CrestOceanMaskTexture[id.xy + offset.yy],
+            _CrestOceanMaskTexture[id.xy + offset.xy],
+            _CrestOceanMaskTexture[id.xy + offset.yx]
+        );
+
+        // If these pixels are all the same, then it is valid that this pixel also equals them.
+        if (pixels.x == pixels.y && pixels.y == pixels.z && pixels.z == pixels.w)
+        {
+            _CrestOceanMaskTexture[id.xy] = pixels.x;
+            return;
+        }
+    }
+
+    _CrestOceanMaskTexture[id.xy] = _CrestOceanMaskTexture[id.xy];
+}

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/CrestFillMaskArtefacts.compute.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/CrestFillMaskArtefacts.compute.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 248ec3ea6a4434e0d8ffa2aec3746bb9
+ComputeShaderImporter:
+  externalObjects: {}
+  currentAPIMask: 65536
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -47,6 +47,7 @@ Fixed
    -  Fix FFT spectrum not being editable when time is paused.
    -  Fix *ShapeFFT* component producing inverted looking waves when enabled in editor play mode.
    -  Fix SSS colour missing or popping in the distance.
+   -  Fix underwater artefacts (bright specks).
 
    .. only:: birp
 


### PR DESCRIPTION
Fixes #739

Uses a compute shader to fill specks visible when underwater due to ocean surface precision issues and other imperfections producing incorrect mask values. Incorrect values can be incorrectly flipped VFACE and/or gaps in the ocean surface.

Samples both orthogonal and diagonal pixels separately. If the sampled pixels are all equal, then it writes that value to the current pixel. Sampling both orthogonal and diagonal is necessary for when a chain of incorrect values is in the mask which is possible.

![grid-orthogonal](https://user-images.githubusercontent.com/5249806/135944094-97a8f2a8-7c66-489e-a4f1-b2fdf12f7f90.jpg) ![grid-diagonal](https://user-images.githubusercontent.com/5249806/135944097-6df030ad-9263-4959-bb18-a09fd67e115f.jpg)
S = current pixel. 1-4 is checked pixels.

On a 1660Ti at 4K, GPU performance cost was 0.31ms. This cost appears to be consistent.

This shader won't work on old macs as it doesn't like read and write to RWTexture2D for some reason (which is also why I think combine compute shader didn't work). Will need to test on newer mac soon.