### PR TITLE
Fix depth cache incorrectly importing 4.14 baked depth caches

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -405,10 +405,18 @@ namespace Crest
                 AssetDatabase.ImportAsset(path);
 
                 TextureImporter ti = AssetImporter.GetAtPath(path) as TextureImporter;
+                ti.textureShape = TextureImporterShape.Texture2D;
                 ti.textureType = TextureImporterType.SingleChannel;
                 ti.sRGBTexture = false;
                 ti.alphaSource = TextureImporterAlphaSource.None;
+                ti.mipmapEnabled = false;
                 ti.alphaIsTransparency = false;
+                // Compression will clamp negative values.
+                ti.textureCompression = TextureImporterCompression.Uncompressed;
+                ti.filterMode = FilterMode.Point;
+                ti.wrapMode = TextureWrapMode.Clamp;
+                // Values are slightly different with NPOT Scale applied.
+                ti.npotScale = TextureImporterNPOTScale.None;
                 ti.SaveAndReimport();
 
                 Debug.Log("Crest: Cache saved to " + path, AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(path));

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,12 @@ Changed
 
    -  Added new CPU-based collision provider - *Baked FFT Data*.
 
+Fixed
+^^^^^
+.. bullet_list::
+
+   -  Fix incorrect baked depth cache data that were baked since `Crest` 4.14.
+
 
 4.14
 ----


### PR DESCRIPTION
Negative values were being clamped due to compression which I have disabled. I also disabled NPOT Scale which slightly changed values on import.