### PR TITLE
Fix underwater specks for Intel iGPUs

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -23,6 +23,13 @@ namespace Crest
             return false;
         }
 
+        public static bool IsIntelGPU()
+        {
+            // Works for Windows and MacOS. Grabbed from Unity Graphics repository:
+            // https://github.com/Unity-Technologies/Graphics/blob/68b0d42c/com.unity.render-pipelines.high-definition/Runtime/RenderPipeline/HDRenderPipeline.PostProcess.cs#L198-L199
+            return SystemInfo.graphicsDeviceName.ToLowerInvariant().Contains("intel");
+        }
+
         public static void Swap<T>(ref T a, ref T b)
         {
             var temp = b;

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
@@ -90,7 +90,8 @@ namespace Crest
 
             // @Memory: We could investigate making this an 8-bit texture instead to reduce GPU memory usage.
             // @Memory: We could potentially try a half resolution mask as the mensicus could mask resolution issues.
-            descriptor.colorFormat = RenderTextureFormat.RHalf;
+            // Intel iGPU for Metal and DirectX both had issues with R16. 2021.11.18
+            descriptor.colorFormat = Helpers.IsIntelGPU() ? RenderTextureFormat.RFloat : RenderTextureFormat.RHalf;
             descriptor.depthBufferBits = 0;
             descriptor.enableRandomWrite = true;
             buffer.GetTemporaryRT(sp_CrestOceanMaskTexture, descriptor);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -26,6 +26,7 @@ Fixed
 
    -  Fix incorrect baked depth cache data that were baked since `Crest` 4.14.
    -  Fix XR `SPI` underwater rendering for Unity 2021.2 standalone.
+   -  Fix *Underwater Renderer* not rendering on *Intel iGPUs*.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Report on:

_Dell Inspiron 3537_
processor: CPU: Intel (R) Core (TM) i7-4500U CPU @ 1.80GHz [4 cores]
graphics_memory: VRAM: 2216MB. Max texture size: 16384px. Shader level: 50
Version: Direct3D 11.0 [level 11.0]
Renderer: Intel (R) HD Graphics Family VRAM: 2216 MB

_MacBook Pro_ (mine)
Intel iGPU

It looks like UAV Read/Write is patchy which I believe is also the problem with the combine compute shader. There isn't a great way to detect this as I thought `SystemInfo.IsFormatSupported(GraphicsFormat, FormatUsage.LoadStore)` is the correct check but it passes in this case. Going by the _Graphics_ repository there are specific checks for Intel so this is in line with Unity. I have reported it to Unity a while ago and see what they say.