### PR TITLE
Underwater Shader API

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
@@ -33,6 +33,7 @@ namespace Crest
             "_FULL_SCREEN_EFFECT",
             "_DEBUG_VIEW_OCEAN_MASK",
             "_DEBUG_VIEW_STENCIL",
+            "CREST_UNDERWATER_BEFORE_TRANSPARENT",
 
             // Unity 2021.2 considers this UserDefined."
             "STEREO_ENABLED_ON",

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -170,6 +170,30 @@ namespace Crest
                 properties
             );
         }
+
+        public static void SetShaderVector(Material material, int nameID, Vector4 value, bool global = false)
+        {
+            if (global)
+            {
+                Shader.SetGlobalVector(nameID, value);
+            }
+            else
+            {
+                material.SetVector(nameID, value);
+            }
+        }
+
+        public static void SetShaderInt(Material material, int nameID, int value, bool global = false)
+        {
+            if (global)
+            {
+                Shader.SetGlobalInt(nameID, value);
+            }
+            else
+            {
+                material.SetInt(nameID, value);
+            }
+        }
     }
 
     static class Extensions

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -94,10 +94,7 @@ namespace Crest
 
         void OnDisable()
         {
-            if (OceanRenderer.Instance != null)
-            {
-                OceanRenderer.Instance.OceanMaterial.DisableKeyword("_OLD_UNDERWATER");
-            }
+            Shader.DisableKeyword("CREST_UNDERWATER_BEFORE_TRANSPARENT");
         }
 
         void ConfigureMaterial()
@@ -147,7 +144,7 @@ namespace Crest
                     _rend.material.CopyPropertiesFromMaterial(OceanRenderer.Instance.OceanMaterial);
                 }
 
-                OceanRenderer.Instance.OceanMaterial.EnableKeyword("_OLD_UNDERWATER");
+                Shader.EnableKeyword("CREST_UNDERWATER_BEFORE_TRANSPARENT");
 
                 // Assign lod0 shape - trivial but bound every frame because lod transform comes from here
                 if (_mpb == null)

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -32,7 +32,7 @@ namespace Crest
         public Bounds _boundsLocal;
         Mesh _mesh;
         public Renderer Rend { get; private set; }
-        PropertyWrapperMPB _mpb;
+        internal PropertyWrapperMPB _mpb;
 
         public bool MaterialOverridden { get; set; }
 

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -141,7 +141,7 @@ namespace Crest
                 return;
             }
 
-            UnderwaterDepthFogDensity = _overrideMaterial.GetVector("_DepthFogDensity") * UnderwaterRenderer.DepthFogDensityFactor;
+            UnderwaterDepthFogDensity = _overrideMaterial.GetVector(OceanRenderer.ShaderIDs.s_DepthFogDensity) * UnderwaterRenderer.DepthFogDensityFactor;
             // Only run optimisation in play mode due to shared height above water.
             if (Application.isPlaying)
             {

--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -27,13 +27,18 @@
 #define CREST_SSS_MAXIMUM 0.6
 #define CREST_SSS_RANGE 0.12
 
-// Water rendered from below.
-#define UNDERWATER_MASK_BELOW_SURFACE -1.0
-// Water rendered from above.
-#define UNDERWATER_MASK_ABOVE_SURFACE  1.0
-
-// No mask.
-#define UNDERWATER_MASK_NONE 0.0
+// Note: Must match k_MaskBelowSurfaceCull in UnderwaterRenderer.Mask.cs.
+// Fog rendered from below and before transparents and ocean tile is culled.
+#define CREST_MASK_BELOW_SURFACE_CULLED -2.0
+// Note: Must match k_MaskBelowSurface in UnderwaterRenderer.Mask.cs.
+// Fog rendered from below.
+#define CREST_MASK_BELOW_SURFACE        -1.0
+// Fog rendered from above.
+#define CREST_MASK_ABOVE_SURFACE         1.0
+// No mask. Used by meniscus when using volumes.
+#define CREST_MASK_NONE                  0.0
+// No fog. Nicer wording for comparisons.
+#define CREST_MASK_NO_FOG                0.0
 
 // The maximum distance the meniscus will be rendered. Only valid when rendering underwater from geometry. The value is
 // used to scale the meniscus as it is calculate using a pixel offset which can make the meniscus large at a distance.

--- a/crest/Assets/Crest/Crest/Shaders/OceanFoam.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanFoam.hlsl
@@ -82,7 +82,7 @@ void ComputeFoam
 
 	// Additive underwater foam - use same foam texture but add mip bias to blur for free
 	half bubbleFoamTexValue = BubbleFoamTexture(i_texture, i_worldXZ, i_worldXZUndisplaced, i_n, i_view, lodVal, cascadeData0, cascadeData1);
-	o_bubbleCol = (half3)bubbleFoamTexValue * _FoamBubbleColor.rgb * saturate(i_foam * _WaveFoamBubblesCoverage) * AmbientLight();
+	o_bubbleCol = (half3)bubbleFoamTexValue * _FoamBubbleColor.rgb * saturate(i_foam * _WaveFoamBubblesCoverage) * WaveHarmonic::Crest::AmbientLight();
 
 	// White foam on top, with black-point fading
 	half whiteFoam = WhiteFoamTexture(i_texture, foamAmount, i_worldXZUndisplaced, lodVal, cascadeData0, cascadeData1);
@@ -98,11 +98,11 @@ void ComputeFoam
 	half3 fN = normalize(i_n + _WaveFoamNormalStrength * half3(-dfdx, 0., -dfdz));
 	// do simple NdL and phong lighting
 	half foamNdL = max(0., dot(fN, i_lightDir));
-	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (AmbientLight() + _WaveFoamLightScale * _LightColor0 * foamNdL * i_shadow);
+	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (WaveHarmonic::Crest::AmbientLight() + _WaveFoamLightScale * _LightColor0 * foamNdL * i_shadow);
 	half3 refl = reflect(-i_view, fN);
 	o_whiteFoamCol.rgb += pow(max(0., dot(refl, i_lightDir)), _WaveFoamSpecularFallOff) * _WaveFoamSpecularBoost * _LightColor0 * i_shadow;
 #else // _FOAM3DLIGHTING_ON
-	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (AmbientLight() + _WaveFoamLightScale * _LightColor0 * i_shadow);
+	o_whiteFoamCol.rgb = _FoamWhiteColor.rgb * (WaveHarmonic::Crest::AmbientLight() + _WaveFoamLightScale * _LightColor0 * i_shadow);
 #endif // _FOAM3DLIGHTING_ON
 
 	o_whiteFoamCol.a = _FoamWhiteColor.a * whiteFoam;

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -20,6 +20,7 @@ float _CrestClipByDefault;
 float _CrestLodAlphaBlackPointFade;
 float _CrestLodAlphaBlackPointWhitePointFade;
 int _CrestDepthTextureOffset;
+int _CrestDataSliceOffset;
 float3 _CrestFloatingOriginOffset;
 
 float3 _PrimaryLightDirection;

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -260,6 +260,16 @@ bool IsUnderwater(const bool i_isFrontFace, const float i_forceUnderwater)
 	return !i_isFrontFace || i_forceUnderwater > 0.0;
 }
 
+half UnderwaterShadowSSS(const float2 i_positionXZ)
+{
+	const int index = clamp(_CrestDataSliceOffset, 0, _SliceCount - 2);
+	const float3 uv = WorldToUV(i_positionXZ, _CrestCascadeData[index], index);
+	// Camera should be at center of LOD system so no need for blending (alpha, weights, etc). This might not be
+	// the case if there is large horizontal displacement, but the _DataSliceOffset should help by setting a
+	// large enough slice as minimum.
+	return saturate(1.0 - _LD_TexArray_Shadow.SampleLevel(LODData_linear_clamp_sampler, uv, 0.0).x);
+}
+
 float FeatherWeightFromUV(const float2 i_uv, const half i_featherWidth)
 {
 	float2 offset = abs(i_uv - 0.5);

--- a/crest/Assets/Crest/Crest/Shaders/OceanLightingHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanLightingHelpers.hlsl
@@ -5,22 +5,29 @@
 #ifndef CREST_OCEAN_LIGHTING_HELPERS_H
 #define CREST_OCEAN_LIGHTING_HELPERS_H
 
-#if defined(LIGHTING_INCLUDED)
-float3 WorldSpaceLightDir(float3 worldPos)
+namespace WaveHarmonic
 {
-	float3 lightDir = _WorldSpaceLightPos0.xyz;
-	if (_WorldSpaceLightPos0.w > 0.)
+	namespace Crest
 	{
-		// non-directional light - this is a position, not a direction
-		lightDir = normalize(lightDir - worldPos.xyz);
-	}
-	return lightDir;
-}
+#if defined(LIGHTING_INCLUDED)
+		float3 WorldSpaceLightDir(float3 worldPos)
+		{
+			float3 lightDir = _WorldSpaceLightPos0.xyz;
+			if (_WorldSpaceLightPos0.w > 0.)
+			{
+				// non-directional light - this is a position, not a direction
+				lightDir = normalize(lightDir - worldPos.xyz);
+			}
+			return lightDir;
+		}
 #endif
 
-half3 AmbientLight()
-{
-	return half3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
+		half3 AmbientLight()
+		{
+			return half3(unity_SHAr.w, unity_SHAg.w, unity_SHAb.w);
+		}
+	}
 }
+
 
 #endif // CREST_OCEAN_LIGHTING_HELPERS_H

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
@@ -13,6 +13,8 @@
 TEXTURE2D_X(_CameraDepthTexture); SAMPLER(sampler_CameraDepthTexture);
 UNITY_DECLARE_SCREENSPACE_TEXTURE(_BackgroundTexture);
 
+half3 _CrestAmbientLighting;
+
 float4 _CameraDepthTexture_TexelSize;
 
 TEXTURE2D_X(_CrestScreenSpaceShadowTexture);

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderHelpers.hlsl
@@ -64,6 +64,7 @@ float CrestLinearEyeDepth(const float i_rawDepth)
 #endif // _PROJECTION
 }
 
+#ifdef TEXTURE2D_X
 // Works for all pipelines.
 float CrestMultiSampleDepth
 (
@@ -105,5 +106,6 @@ float CrestMultiLoadDepth(TEXTURE2D_X(i_texture), const uint2 i_positionSS, cons
 
 	return rawDepth;
 }
+#endif
 
 #endif // CREST_OCEAN_SHADER_HELPERS_H

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
@@ -22,6 +22,8 @@ Shader "Hidden/Crest/Underwater/Underwater Effect"
 	#pragma multi_compile_local __ _DEBUG_VIEW_OCEAN_MASK
 	#pragma multi_compile_local __ _DEBUG_VIEW_STENCIL
 
+	#pragma multi_compile _ CREST_UNDERWATER_BEFORE_TRANSPARENT
+
 	#include "UnityCG.cginc"
 	#include "Lighting.cginc"
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -213,7 +213,7 @@ Shader "Crest/Underwater Curtain"
 				}
 #endif // _SUBSURFACESHALLOWCOLOUR_ON
 
-				const half3 scatterCol = ScatterColour(seaFloorDepth, shadow, sss, view, AmbientLight(), lightDir, lightCol, true);
+				const half3 scatterCol = ScatterColour(seaFloorDepth, shadow, sss, view, WaveHarmonic::Crest::AmbientLight(), lightDir, lightCol, true);
 
 				half3 sceneColour = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_BackgroundTexture, input.grabPos.xy / input.grabPos.w).rgb;
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffect.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffect.hlsl
@@ -80,8 +80,20 @@ real4 Frag (Varyings input) : SV_Target
 	return DebugRenderStencil(sceneColour);
 #endif
 
-	bool isOceanSurface; bool isUnderwater; float sceneZ;
-	GetOceanSurfaceAndUnderwaterData(input.positionCS, positionSS, rawOceanDepth, mask, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
+	bool isOceanSurface; bool isUnderwater; bool hasCaustics; float sceneZ;
+	GetOceanSurfaceAndUnderwaterData
+	(
+		input.positionCS,
+		positionSS,
+		rawOceanDepth,
+		mask,
+		rawDepth,
+		isOceanSurface,
+		isUnderwater,
+		hasCaustics,
+		sceneZ,
+		0.0
+	);
 
 	float fogDistance = sceneZ;
 	float meniscusDepth = 0.0;
@@ -103,7 +115,18 @@ real4 Frag (Varyings input) : SV_Target
 		const Light lightMain = GetMainLight();
 		const real3 lightDir = lightMain.direction;
 		const real3 lightCol = lightMain.color;
-		sceneColour = ApplyUnderwaterEffect(positionSS, scenePos, sceneColour, lightCol, lightDir, rawDepth, sceneZ, fogDistance, view, isOceanSurface);
+		sceneColour = ApplyUnderwaterEffect
+		(
+			positionSS,
+			scenePos,
+			sceneColour,
+			lightCol,
+			lightDir,
+			sceneZ,
+			fogDistance,
+			view,
+			hasCaustics
+		);
 	}
 
 	float wt = ComputeMeniscusWeight(positionSS, mask, _HorizonNormal, meniscusDepth);

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectIncludes.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectIncludes.hlsl
@@ -1,0 +1,161 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// NOTE: It is important that everything has a Crest prefix to avoid possible conflicts.
+
+#ifndef CREST_UNDERWATER_EFFECT_INCLUDES_INCLUDED
+#define CREST_UNDERWATER_EFFECT_INCLUDES_INCLUDED
+
+// Surface Shader Analysis determines what inputs Unity will generate (ie the magic of surface shaders). But the
+// analyzer only understands "DX9 style HLSL syntax" so no constant parameters. SHADER_TARGET_SURFACE_ANALYSIS is
+// defined which can be used for workarounds. It was easiest to provide a dummy function for the only "public" function,
+// thus excluding all of our other code and includes from the analyzer. Source:
+// https://github.com/TwoTailsGames/Unity-Built-in-Shaders/blob/6a63f93bc1f20ce6cd47f981c7494e8328915621/CGIncludes/HLSLSupport.cginc#L7-L11
+#ifdef SHADER_TARGET_SURFACE_ANALYSIS
+// Must update signature with implementation below.
+bool CrestApplyUnderwaterFog(float2 b, float3 c, float d, float e, inout half3 a) { return a.x + b.x + c.x + d.x + e.x; }
+#else // SHADER_TARGET_SURFACE_ANALYSIS
+
+UNITY_DECLARE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture);
+UNITY_DECLARE_SCREENSPACE_TEXTURE(_CrestWaterVolumeFrontFaceTexture);
+UNITY_DECLARE_SCREENSPACE_TEXTURE(_CrestWaterVolumeBackFaceTexture);
+
+half3 _CrestDiffuse;
+half3 _CrestDiffuseGrazing;
+
+#if CREST_SHADOWS_ON
+half3 _CrestDiffuseShadow;
+#endif
+
+#if CREST_SUBSURFACESCATTERING_ON
+half3 _CrestSubSurfaceColour;
+half _CrestSubSurfaceBase;
+half _CrestSubSurfaceSun;
+half _CrestSubSurfaceSunFallOff;
+#endif
+
+half3 _CrestAmbientLighting;
+half4 _CrestDepthFogDensity;
+
+#include "../OceanConstants.hlsl"
+#include "../OceanGlobals.hlsl"
+#include "../OceanInputsDriven.hlsl"
+#include "../OceanShaderHelpers.hlsl"
+#include "../OceanLightingHelpers.hlsl"
+
+half3 CrestScatterColour
+(
+	const half3 i_ambientLighting,
+	const half3 i_lightCol,
+	const half3 i_lightDir,
+	const half3 i_view,
+	const float i_shadow
+)
+{
+	// Base colour.
+	float v = abs(i_view.y);
+	half3 col = lerp(_CrestDiffuse, _CrestDiffuseGrazing, 1. - pow(v, 1.0));
+
+#if CREST_SHADOWS_ON
+	col = lerp(_CrestDiffuseShadow, col, i_shadow);
+#endif
+
+#if CREST_SUBSURFACESCATTERING_ON
+	{
+		col *= i_ambientLighting;
+
+		// Approximate subsurface scattering - add light when surface faces viewer. Use geometry normal - don't need high freqs.
+		half towardsSun = pow(max(0., dot(i_lightDir, -i_view)), _CrestSubSurfaceSunFallOff);
+		half3 subsurface = (_CrestSubSurfaceBase + _CrestSubSurfaceSun * towardsSun) * _CrestSubSurfaceColour.rgb * i_lightCol * i_shadow;
+		col += subsurface;
+	}
+#endif // CREST_SUBSURFACESCATTERING_ON
+
+	return col;
+}
+
+// Taken from: OceanHelpersNew.hlsl
+float3 CrestWorldToUV(in float2 i_samplePos, in CascadeParams i_cascadeParams, in float i_sliceIndex)
+{
+	float2 uv = (i_samplePos - i_cascadeParams._posSnapped) / (i_cascadeParams._texelWidth * i_cascadeParams._textureRes) + 0.5;
+	return float3(uv, i_sliceIndex);
+}
+
+bool CrestApplyUnderwaterFog(const float2 positionNDC, const float3 positionWS, float deviceDepth, half multiplier, inout half3 color)
+{
+#if CREST_WATER_VOLUME
+	// No fog before volume.
+	float rawFrontFaceZ = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestWaterVolumeFrontFaceTexture, positionNDC);
+	if (rawFrontFaceZ > 0.0 && rawFrontFaceZ < deviceDepth)
+	{
+		return false;
+	}
+
+#if CREST_WATER_VOLUME_2D
+	// No fog if plane is not in view. If we wanted to be consistent with the underwater shader, we should also check
+	// this for non fly-through volumes too, but being inside a non fly-through volume is undefined behaviour so we can
+	// save a variant.
+	if (rawFrontFaceZ == 0.0)
+	{
+		return false;
+	}
+#endif // CREST_WATER_VOLUME_2D
+#endif // CREST_WATER_VOLUME
+
+	half mask = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestOceanMaskTexture, positionNDC).r;
+	if (mask >= CREST_MASK_NO_FOG)
+	{
+		return false;
+	}
+
+	half3 lightColor = _LightColor0.rgb;
+	float3 lightDirection = WaveHarmonic::Crest::WorldSpaceLightDir(positionWS);
+	half3 view =  normalize(_WorldSpaceCameraPos - positionWS);
+
+	// Get the largest distance.
+	float rawFogDistance = deviceDepth;
+#if CREST_WATER_VOLUME_HAS_BACKFACE
+	// Use the closest of the two.
+	float rawBackFaceZ = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_CrestWaterVolumeBackFaceTexture, positionNDC);
+	rawFogDistance = max(rawFogDistance, rawBackFaceZ);
+#endif
+
+	float fogDistance = CrestLinearEyeDepth(rawFogDistance);
+
+#if CREST_WATER_VOLUME
+#if CREST_WATER_VOLUME_HAS_BACKFACE
+	if (rawFrontFaceZ > 0.0)
+#endif
+	{
+		fogDistance -= CrestLinearEyeDepth(rawFrontFaceZ);
+	}
+#endif
+
+	half shadow = 1.0;
+#if CREST_SHADOWS_ON
+	{
+		// Offset slice so that we do not get high frequency detail. But never use last lod as this has crossfading.
+		int sliceIndex = clamp(_CrestDataSliceOffset, 0, _SliceCount - 2);
+		const float3 uv = CrestWorldToUV(_WorldSpaceCameraPos.xz, _CrestCascadeData[sliceIndex], sliceIndex);
+		// Camera should be at center of LOD system so no need for blending (alpha, weights, etc).
+		shadow = _LD_TexArray_Shadow.SampleLevel(LODData_linear_clamp_sampler, uv, 0.0).x;
+		shadow = saturate(1.0 - shadow);
+	}
+#endif // CREST_SHADOWS_ON
+
+	half3 scatterColor = CrestScatterColour
+	(
+		_CrestAmbientLighting,
+		lightColor,
+		lightDirection,
+		view,
+		shadow
+	);
+
+	color = lerp(color, scatterColor, saturate(1.0 - exp(-_CrestDepthFogDensity.xyz * fogDistance)) * multiplier);
+	return true;
+}
+
+#endif // !SHADER_TARGET_SURFACE_ANALYSIS
+#endif // CREST_UNDERWATER_EFFECT_INCLUDES_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectIncludes.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectIncludes.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 020541128f1bd4478b0dccc10f7ccaca
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskHorizonShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskHorizonShared.hlsl
@@ -48,8 +48,8 @@ half4 Frag(Varyings input) : SV_Target
 
 	float3 positionWS = ComputeWorldSpacePosition(input.uv, _FarPlaneOffset, UNITY_MATRIX_I_VP);
 	return (half4) positionWS.y > _OceanCenterPosWorld.y
-		? UNDERWATER_MASK_ABOVE_SURFACE
-		: UNDERWATER_MASK_BELOW_SURFACE;
+		? CREST_MASK_ABOVE_SURFACE
+		: CREST_MASK_BELOW_SURFACE;
 }
 
 #endif // CREST_UNDERWATER_MASK_HORIZON_SHARED_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
@@ -33,6 +33,9 @@ struct Varyings
 // i'm not sure why cracks are not visible in this case.
 float _ForceUnderwater;
 
+// Variable mask for when fog is applied before transparent pass and ocean tile might be culled.
+half _MaskBelowSurface;
+
 Varyings Vert(Attributes v)
 {
 	// This will work for all pipelines.
@@ -135,11 +138,11 @@ half4 Frag(const Varyings input, const bool i_isFrontFace : SV_IsFrontFace) : SV
 
 	if (IsUnderwater(i_isFrontFace, _ForceUnderwater))
 	{
-		return (half4)UNDERWATER_MASK_BELOW_SURFACE;
+		return (half4)_MaskBelowSurface;
 	}
 	else
 	{
-		return (half4)UNDERWATER_MASK_ABOVE_SURFACE;
+		return (half4)CREST_MASK_ABOVE_SURFACE;
 	}
 }
 


### PR DESCRIPTION
_**Status:** Needs some work but ready for early feedback_

Adds an "includes" file for developers to add the underwater fog to their transparent shaders.

When the "Enable Shader API" option is enabled on the _Underwater Renderer_, it will:
- render the underwater effect before the transparent pass
- enable underwater rendering on ocean shader (like how it was before the underwater PP)
- populate global shader data (uses three global keywords)

Second point is unfortunate as it was nice not having underwater rendering in the ocean shader, but this allows users to keep their transparent objects rendered once in the transparent pass.

**Todo:**

- [ ] Documentation
- [ ] Remove test data
- [ ] Add _Crest_ prefix to more shader things

The last one is a bit of a hassle now that most of the code is exposed. We can probably get away with not adding a Crest prefix to a few things like _LD_TexArray_Shadow. Not sure about CascadeParams though. Might be worth doing as a separate PR.

**Testing**

_Test.unity_ under _Test_ directory has it setup. I have included three shaders as examples of implementation for BIRP. ShaderGraph nodes will need to be added downstream.

