### PR TITLE
Use displaced position when sampling shadow maps

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/UpdateShadow.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/UpdateShadow.hlsl
@@ -51,10 +51,12 @@ half2 Frag(Varyings input) : SV_Target
 	half2 shadow = 0.0;
 
 	float4 positionWS = float4(input.positionWS.xyz, 1.0);
+	float3 displacement = 0.0;
 	{
 		float3 uv = WorldToUV(positionWS.xz, _CrestCascadeData[_LD_SliceIndex], _LD_SliceIndex);
 		// Offset world position by sea level offset.
 		positionWS.y += _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, uv, 0.0).y;
+		displacement = SampleLod(_LD_TexArray_AnimatedWaves, uv).xyz;
 	}
 
 	// Shadow from last frame.
@@ -85,6 +87,9 @@ half2 Frag(Varyings input) : SV_Target
 			}
 		}
 	}
+
+	// Add displacement so shorelines do not receive shadows incorrectly.
+	positionWS.xyz += displacement;
 
 	// This was calculated in vertex but we have to sample sea level offset in fragment.
 	float4 mainCameraCoordinates = mul(_MainCameraProjectionMatrix, positionWS);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -20,6 +20,8 @@ Changed
    -  Added new CPU-based collision provider - *Baked FFT Data*.
    -  Add *CREST_OCEAN* scripting defines symbol.
    -  Add *Depth Fog Density Factor* to *Underwater Renderer* which can be used to decrease underwater fog intensity when underwater.
+   -  Improve shadows by using displaced position when sampling shadow maps.
+      Greatly improves shadows at shorelines.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
Uses the displaced position in UpdateShadow to sample the shadow maps to improve shoreline (and elsewhere) shadowing. The improvement is less noticeable in HDRP as we don't use the shadow data for specular shadows. But improves SSS shadowing for every RP.


![1_1](https://user-images.githubusercontent.com/5249806/143021385-13a51131-ea1b-4c84-9dbf-27bfb7cdf29d.jpg)
![1_2](https://user-images.githubusercontent.com/5249806/143021390-4954fbed-04d1-45ab-911e-4b670698c905.jpg)
