### PR TITLE
Optional maximum wave attenuation

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -16,6 +16,7 @@ namespace Crest
     /// </summary>
     public class LodDataMgrSeaFloorDepth : LodDataMgr
     {
+        // NOTE: Must match CREST_OCEAN_DEPTH_BASELINE in OceanConstants.hlsl.
         internal const float k_DepthBaseline = 1_000f;
 
         public override string SimName => "SeaFloorDepth";

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -16,11 +16,13 @@ namespace Crest
     /// </summary>
     public class LodDataMgrSeaFloorDepth : LodDataMgr
     {
+        internal const float k_DepthBaseline = 1_000f;
+
         public override string SimName => "SeaFloorDepth";
         protected override GraphicsFormat RequestedTextureFormat => Settings._allowVaryingWaterLevel ? GraphicsFormat.R32G32_SFloat : GraphicsFormat.R16_SFloat;
         protected override bool NeedToReadWriteTextureData => false;
         // We want the clear colour to be the min terrain height (-1000m) in X, and sea level offset 0m in Y.
-        readonly static Color s_nullColor = Color.red * -1000f;
+        readonly static Color s_nullColor = Color.red * -k_DepthBaseline;
         static Texture2DArray s_nullTexture;
         protected override Texture2DArray NullTexture => s_nullTexture;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -192,7 +192,7 @@ namespace Crest
                 _camDepthCache.orthographic = true;
                 _camDepthCache.clearFlags = CameraClearFlags.SolidColor;
                 // Clear to 'very deep'
-                _camDepthCache.backgroundColor = Color.white * 1000f;
+                _camDepthCache.backgroundColor = Color.white * LodDataMgrSeaFloorDepth.k_DepthBaseline;
                 _camDepthCache.enabled = false;
                 _camDepthCache.allowMSAA = false;
                 // Stops behaviour from changing in VR. I tried disabling XR before/after camera render but it makes the editor

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -27,6 +27,11 @@ namespace Crest
         float _attenuationInShallows = 0.95f;
         public float AttenuationInShallows => _attenuationInShallows;
 
+        [Tooltip("Any deeper than this value will have no attenuation (ie full wave spectrum). Set to maximum value (1,000) to disable. If it is used, it will reduce the overall attenuation effectiveness.")]
+        [SerializeField, Range(0f, LodDataMgrSeaFloorDepth.k_DepthBaseline)]
+        float _maximumAttenuationDepth = LodDataMgrSeaFloorDepth.k_DepthBaseline;
+        public float MaximumAttenuationDepth => _maximumAttenuationDepth;
+
         public enum CollisionSources
         {
             None,

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -27,10 +27,10 @@ namespace Crest
         float _attenuationInShallows = 0.95f;
         public float AttenuationInShallows => _attenuationInShallows;
 
-        [Tooltip("Any deeper than this value will have no attenuation (ie full wave spectrum). Set to maximum value (1,000) to disable. If it is used, it will reduce the overall attenuation effectiveness.")]
-        [SerializeField, Range(0f, LodDataMgrSeaFloorDepth.k_DepthBaseline)]
-        float _maximumAttenuationDepth = LodDataMgrSeaFloorDepth.k_DepthBaseline;
-        public float MaximumAttenuationDepth => _maximumAttenuationDepth;
+        [Tooltip("Any water deeper than this will receive full wave strength. The lower the value, the less effective the depth cache will be at attenuating very large waves. Set to the maximum value (1,000) to disable.")]
+        [SerializeField, Range(1f, LodDataMgrSeaFloorDepth.k_DepthBaseline)]
+        float _shallowsMaxDepth = LodDataMgrSeaFloorDepth.k_DepthBaseline;
+        public float MaximumAttenuationDepth => _shallowsMaxDepth;
 
         public enum CollisionSources
         {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -176,6 +176,7 @@ namespace Crest
         static readonly int sp_WaveBufferSliceIndex = Shader.PropertyToID("_WaveBufferSliceIndex");
         static readonly int sp_AverageWavelength = Shader.PropertyToID("_AverageWavelength");
         static readonly int sp_RespectShallowWaterAttenuation = Shader.PropertyToID("_RespectShallowWaterAttenuation");
+        static readonly int sp_MaximumAttenuationDepth = Shader.PropertyToID("_MaximumAttenuationDepth");
         static readonly int sp_FeatherWaveStart = Shader.PropertyToID("_FeatherWaveStart");
         readonly int sp_AxisX = Shader.PropertyToID("_AxisX");
 
@@ -210,6 +211,7 @@ namespace Crest
             }
 
             _matGenerateWaves.SetFloat(sp_RespectShallowWaterAttenuation, _respectShallowWaterAttenuation);
+            _matGenerateWaves.SetFloat(sp_MaximumAttenuationDepth, OceanRenderer.Instance._lodDataAnimWaves.Settings.MaximumAttenuationDepth);
             _matGenerateWaves.SetFloat(sp_FeatherWaveStart, _featherWaveStart);
 
             // If using geo, the primary wave dir is used by the input shader to rotate the waves relative

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -199,6 +199,7 @@ namespace Crest
         static readonly int sp_AverageWavelength = Shader.PropertyToID("_AverageWavelength");
         static readonly int sp_RespectShallowWaterAttenuation = Shader.PropertyToID("_RespectShallowWaterAttenuation");
         static readonly int sp_FeatherWaveStart = Shader.PropertyToID("_FeatherWaveStart");
+        static readonly int sp_MaximumAttenuationDepth = Shader.PropertyToID("_MaximumAttenuationDepth");
         readonly int sp_AxisX = Shader.PropertyToID("_AxisX");
 
         readonly float _twoPi = 2f * Mathf.PI;
@@ -278,6 +279,7 @@ namespace Crest
 
             _matGenerateWaves.SetFloat(sp_RespectShallowWaterAttenuation, _respectShallowWaterAttenuation);
             _matGenerateWaves.SetFloat(sp_FeatherWaveStart, _featherWaveStart);
+            _matGenerateWaves.SetFloat(sp_MaximumAttenuationDepth, OceanRenderer.Instance._lodDataAnimWaves.Settings.MaximumAttenuationDepth);
             _matGenerateWaves.SetVector(sp_AxisX, PrimaryWaveDirection);
             // Seems like shader errors cause this to unbind if I don't set it every frame. Could be an editor only issue.
             _matGenerateWaves.SetTexture(sp_WaveBuffer, _waveBuffers);

--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -16,6 +16,7 @@
 // How light is attenuated deep in water
 #define DEPTH_OUTSCATTER_CONSTANT 0.25
 
+// NOTE: Must match k_DepthBaseline in LodDataMgrSeaFloorDepth.cs.
 // Bias ocean floor depth so that default (0) values in texture are not interpreted as shallow and generating foam everywhere
 #define CREST_OCEAN_DEPTH_BASELINE 1000.0
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
@@ -37,6 +37,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 			float _AttenuationInShallows;
 			float2 _AxisX;
 			float _RespectShallowWaterAttenuation;
+			half _MaximumAttenuationDepth;
 			CBUFFER_END
 
 			struct Attributes
@@ -76,6 +77,10 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 					_LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, float3(input.uv_uvWaves.xy, _LD_SliceIndex), 0.0).xy;
 				const half depth = _OceanCenterPosWorld.y - terrainHeight_seaLevelOffset.x + terrainHeight_seaLevelOffset.y;
 				half depth_wt = saturate(2.0 * depth / _AverageWavelength);
+				if (_MaximumAttenuationDepth < CREST_OCEAN_DEPTH_BASELINE)
+				{
+					depth_wt = lerp(depth_wt, 1.0, saturate(depth / _MaximumAttenuationDepth));
+				}
 				const float attenuationAmount = _AttenuationInShallows * _RespectShallowWaterAttenuation;
 				wt *= attenuationAmount * depth_wt + (1.0 - attenuationAmount);
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
@@ -76,6 +76,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
             float _AttenuationInShallows;
             float _Weight;
             float2 _AxisX;
+            half _MaximumAttenuationDepth;
             CBUFFER_END
 
             v2f vert(appdata v)
@@ -109,7 +110,11 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
                 // Attenuate if depth is less than half of the average wavelength
                 const half2 terrainHeight_seaLevelOffset = _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, input.uv_slice, 0.0).xy;
                 const half depth = _OceanCenterPosWorld.y - terrainHeight_seaLevelOffset.x + terrainHeight_seaLevelOffset.y;
-                const half depth_wt = saturate(2.0 * depth / _AverageWavelength);
+                half depth_wt = saturate(2.0 * depth / _AverageWavelength);
+                if (_MaximumAttenuationDepth < CREST_OCEAN_DEPTH_BASELINE)
+                {
+                    depth_wt = lerp(depth_wt, 1.0, saturate(depth / _MaximumAttenuationDepth));
+                }
                 const float attenuationAmount = _AttenuationInShallows * _RespectShallowWaterAttenuation;
                 wt *= attenuationAmount * depth_wt + (1.0 - attenuationAmount);
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -24,6 +24,7 @@ Changed
       Greatly improves shadows at shorelines.
    -  Add UV feathering option to Flow shaders.
    -  Add *Attenuation in Shallows* to *Dynamic Waves Sims Settings*.
+   -  Add *Shallows Max Depth* to *Sim Settings Animated Waves* as an alternative to having to extend terrain to 500m below sea level to avoid discontinuity issues.
 
 Fixed
 ^^^^^

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -44,6 +44,10 @@ Simulation Settings
 
 All of the settings below refer to the *Animated Waves Sim Settings* asset.
 
+-  **Attenuation In Shallows** - How much waves are dampened in shallow water.
+-  **Shallows Max Depth** - Any water deeper than this will receive full wave strength.
+   The lower the value, the less effective the depth cache will be at attenuating very large waves.
+   Set to the maximum value (1,000) to disable.
 -  **Collision Source** - Where to obtain ocean shape on CPU for physics / gameplay.
 -  **Max Query Count** - Maximum number of wave queries that can be performed when using ComputeShaderQueries.
 -  **Ping Pong Combine Pass** - Whether to use a graphics shader for combining the wave cascades together.

--- a/docs/user/shallows-and-shorelines.rst
+++ b/docs/user/shallows-and-shorelines.rst
@@ -14,6 +14,7 @@ By default this generation is done at run-time during startup, but the component
 
 The seabed affects the wave simulation in a physical way - the rule of thumb is *waves will be affected by the seabed when the water depth is less than half of their wavelength*.
 So for example when the water is 250m deep, this will start to dampen 500m wavelengths from the spectrum, so it is recommended that the seabed drop down to at least 500m away from islands so that there is a smooth transition between shallow and deep water without a 'step' in the sea floor which appears as a discontinuity in the surface waves and/or a line of foam.
+Alternatively, there is *Shallows Max Depth* on the :ref:`Sim Settings Animated Waves <animated_waves_settings>` asset which smooths the attenuation to a provided maximum depth where waves will be at full strength.
 
 Setup
 -----


### PR DESCRIPTION
One solution for #726.

Adds a maximum depth value for wave attenuation. Anything below this value will have no attenuation. Drawbacks is that wave attenuation is overall less effective. Moderate spectrums seem to work well enough. Completely optional as if the value is set to the maximum, the interpolation is skipped so this is a safe change.

TODO: documentation and release notes