### PR TITLE
Fix shadow bleeding at shorelines

### DIFF
--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -32,6 +32,7 @@ Fixed
    -  Fix XR `SPI` underwater rendering for Unity 2021.2 standalone.
    -  Fix *Underwater Renderer* not rendering on *Intel iGPUs*.
    -  Fix clip surface inputs losing accuracy with large waves.
+   -  Fix shadow bleeding at shorelines by using the *Sea Floor Depth* data to reject invalid shadows. :pr:`947`
 
    .. only:: hdrp
 


### PR DESCRIPTION
Jittering shadow sampling causes shadows to bleed as a sample can land inside of geometry where it is shadowed. Easier to explain with screenshots:

![3_1](https://user-images.githubusercontent.com/5249806/143534737-f50770d5-ec2a-4a9e-b0ec-5a10c9aefa02.jpg)
![3_2](https://user-images.githubusercontent.com/5249806/143534740-01620c0d-221e-422c-9b4e-d3dc1b7ea119.jpg)

![1_1](https://user-images.githubusercontent.com/5249806/143508287-bf84581a-7ed3-4e7d-8853-ef65f1bea198.jpg)
![1_2](https://user-images.githubusercontent.com/5249806/143508291-3a19dc4a-c1fe-4ea7-a91b-b7fc30eaf73d.jpg)

You may notice there is still leaking, but that is only because the data being rendered is from the vertex shader which doesn't have enough density at that distance. Below is if the shadows are moved to the pixel shader (not part of this PR):

![2_1](https://user-images.githubusercontent.com/5249806/143508293-c45fa50f-7de2-4a2c-9b67-b648685fe803.jpg)
![2_2](https://user-images.githubusercontent.com/5249806/143508297-57d49a11-263c-4fc4-99d5-ba3c46d25962.jpg)

## Performance

Adds about 0.04-0.05ms to the entire shadow sampling pass.

## Testing

I have left the shadows rendered on the ocean surface on (from the vertex shader). Toggle "Create Sea Floor Depth Data" to see before and after.