### PR TITLE
Fix server builds and LodData* toggling

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -502,8 +502,9 @@ namespace Crest
             CreateDestroySubSystems();
 
             // TODO: Have a BufferCount which will be the run-time buffer size or prune data.
+            // NOTE: Hardcode minimum (2) to avoid breaking server builds and LodData* toggles.
             // Gather the buffer size for shared data.
-            BufferSize = 0;
+            BufferSize = 2;
             foreach (var lodData in _lodDatas)
             {
                 if (lodData.enabled)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,8 @@ Fixed
    -  Fix *Underwater Renderer* not rendering on *Intel iGPUs*.
    -  Fix clip surface inputs losing accuracy with large waves.
    -  Fix shadow bleeding at shorelines by using the *Sea Floor Depth* data to reject invalid shadows. :pr:`947`
+   -  Fix exceptions thrown for server/headless builds.
+   -  Fix exceptions thrown if foam, dynamic waves and shadows all were disabled.
 
    .. only:: hdrp
 


### PR DESCRIPTION
The LodData buffering breaks server builds currently as I forgot to test it. This is just a quick fix. It sets the OceanRenderer.BufferSize to 2 as a minimum. This value sets the shared buffered size like for cascade params and doesn't affect the buffered size for individual LodDataMgrs.

Also, if no sims requiring buffer count of two were enabled, exceptions would also be thrown as it assumed two as minimum.

Will make a proper fix. I have also added checking server/headless options to the release process to catch this in the future.