### PR TITLE
Add Attenuation in Shallows setting to Dynamic Waves

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -36,6 +36,7 @@ namespace Crest
         readonly int sp_Damping = Shader.PropertyToID("_Damping");
         readonly int sp_Gravity = Shader.PropertyToID("_Gravity");
         readonly int sp_CourantNumber = Shader.PropertyToID("_CourantNumber");
+        readonly int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
 
         public override SimSettingsBase SettingsBase => Settings;
         public SettingsType Settings => _ocean._simSettingsDynamicWaves != null ? _ocean._simSettingsDynamicWaves : GetDefaultSettings<SettingsType>();
@@ -92,6 +93,7 @@ namespace Crest
             simMaterial.SetFloat(sp_Damping, Settings._damping);
             simMaterial.SetFloat(sp_Gravity, OceanRenderer.Instance.Gravity * Settings._gravityMultiplier);
             simMaterial.SetFloat(sp_CourantNumber, Settings._courantNumber);
+            simMaterial.SetFloat(sp_AttenuationInShallows, Settings._attenuationInShallows);
             simMaterial.SetVector(OceanRenderer.sp_oceanCenterPosWorld, OceanRenderer.Instance.Root.position);
 
             // assign sea floor depth - to slot 1 current frame data. minor bug here - this depth will actually be from the previous frame,

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsWave.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsWave.cs
@@ -37,6 +37,8 @@ namespace Crest
         public float _damping = 0.05f;
         [Range(0.1f, 1f), Tooltip("Stability control. Lower values means more stable sim, but may slow down some dynamic waves. This value should be set as large as possible until sim instabilities/flickering begin to appear. Default is 0.7.")]
         public float _courantNumber = 0.7f;
+        [Range(0f, 1f), Tooltip("How much waves are dampened in shallow water.")]
+        public float _attenuationInShallows = 1f;
 
         [Header("Displacement Generation")]
         [Range(0f, 20f), Tooltip("Induce horizontal displacements to sharpen simulated waves.")]

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -21,6 +21,7 @@ float _Gravity;
 float _SimDeltaTime;
 float _LODChange;
 float _CourantNumber;
+float _AttenuationInShallows;
 CBUFFER_END
 
 float ComputeWaveSpeed(float wavelength, float g)
@@ -122,13 +123,16 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	float ftp = ft + dt * vtp;
 	ftp *= weightEdge;
 
-	// attenuate waves based on ocean depth. if depth is greater than 0.5*wavelength, water is considered Deep and wave is
-	// unaffected. if depth is less than this, wave velocity decreases. waves will then bunch up and grow in amplitude and
-	// eventually break. i model "Deep" water, but then simply ramp down waves in non-deep water with a linear multiplier.
-	// http://hyperphysics.phy-astr.gsu.edu/hbase/Waves/watwav2.html
-	// http://hyperphysics.phy-astr.gsu.edu/hbase/watwav.html#c1
-	const float depthMul = 1.0 - (1.0 - saturate(2.0 * waterDepth / wavelength)) * dt * 2.0;
-	ftp *= depthMul;
+	if (_AttenuationInShallows > 0.0)
+	{
+		// attenuate waves based on ocean depth. if depth is greater than 0.5*wavelength, water is considered Deep and wave is
+		// unaffected. if depth is less than this, wave velocity decreases. waves will then bunch up and grow in amplitude and
+		// eventually break. i model "Deep" water, but then simply ramp down waves in non-deep water with a linear multiplier.
+		// http://hyperphysics.phy-astr.gsu.edu/hbase/Waves/watwav2.html
+		// http://hyperphysics.phy-astr.gsu.edu/hbase/watwav.html#c1
+		const float depthMul = 1.0 - (1.0 - saturate(2.0 * waterDepth / wavelength)) * dt * 2.0;
+		ftp *= _AttenuationInShallows * depthMul + (1.0 - _AttenuationInShallows);
+	}
 
 	_LD_TexArray_Target[id] = float2(ftp, vtp);
 }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,7 @@ Changed
    -  Improve shadows by using displaced position when sampling shadow maps.
       Greatly improves shadows at shorelines.
    -  Add UV feathering option to Flow shaders.
+   -  Add *Attenuation in Shallows* to *Dynamic Waves Sims Settings*.
 
 Fixed
 ^^^^^

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -137,6 +137,8 @@ All of the settings below refer to the *Dynamic Wave Sim Settings* asset.
 -  **Gravity Multiplier** - Multiplier for gravity.
    More gravity means dynamic waves will travel faster.
 
+-  **Attenuation in Shallows** - How much waves are dampened in shallow water.
+
 The *OceanDebugGUI* script gives the debug overlay in the example content scenes and reports the number of sim steps taken each frame.
 
 


### PR DESCRIPTION
Since we have one for animated waves, it makes sense to have it for dynamic waves too. Had feedback that the depth cache was dampening wakes which was undesirable.