### PR TITLE
Fix floating origin for ShapeGerstner and ShapeFFT

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -67,6 +67,10 @@ namespace Crest
 
         ParticleSystem.Particle[] _particleBuffer = null;
 
+        static readonly int sp_CrestFloatingOriginOffset = Shader.PropertyToID("_CrestFloatingOriginOffset");
+
+        Vector3 _originOffset;
+
         void LateUpdate()
         {
             var newOrigin = Vector3.zero;
@@ -77,6 +81,11 @@ namespace Crest
             {
                 MoveOrigin(newOrigin);
             }
+        }
+
+        void OnDisable()
+        {
+            Shader.SetGlobalVector(sp_CrestFloatingOriginOffset, Vector3.zero);
         }
 
         void MoveOrigin(Vector3 newOrigin)
@@ -153,6 +162,9 @@ namespace Crest
             if (OceanRenderer.Instance)
             {
                 OceanRenderer.Instance._lodTransform.SetOrigin(newOrigin);
+
+                Shader.SetGlobalVector(sp_CrestFloatingOriginOffset, _originOffset - newOrigin);
+                _originOffset -= newOrigin;
 
                 var fos = OceanRenderer.Instance.GetComponentsInChildren<IFloatingOrigin>();
                 foreach (var fo in fos)

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -20,7 +20,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP)]
-    public partial class ShapeGerstner : MonoBehaviour, IFloatingOrigin, LodDataMgrAnimWaves.IShapeUpdatable
+    public partial class ShapeGerstner : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
         , ISplinePointCustomDataSetup
 #if UNITY_EDITOR
         , IReceiveSplinePointOnDrawGizmosSelectedMessages
@@ -502,24 +502,6 @@ namespace Crest
             buf.SetComputeTextureParam(_shaderGerstner, _krnlGerstner, sp_WaveBuffer, _waveBuffers);
 
             buf.DispatchCompute(_shaderGerstner, _krnlGerstner, _waveBuffers.width / LodDataMgr.THREAD_GROUP_SIZE_X, _waveBuffers.height / LodDataMgr.THREAD_GROUP_SIZE_Y, _lastCascade - _firstCascade + 1);
-        }
-
-        public void SetOrigin(Vector3 newOrigin)
-        {
-            if (_phases == null || _phases2 == null) return;
-
-            var windAngle = _waveDirectionHeadingAngle;
-            for (int i = 0; i < _phases.Length; i++)
-            {
-                var direction = new Vector3(Mathf.Cos((windAngle + _angleDegs[i]) * Mathf.Deg2Rad), 0f, Mathf.Sin((windAngle + _angleDegs[i]) * Mathf.Deg2Rad));
-                var phaseOffsetMeters = Vector3.Dot(newOrigin, direction);
-
-                // wave number
-                var k = 2f * Mathf.PI / _wavelengths[i];
-
-                _phases[i] = Mathf.Repeat(_phases[i] + phaseOffsetMeters * k, Mathf.PI * 2f);
-                _phases2[i] = Mathf.Repeat(_phases2[i] + phaseOffsetMeters * k, Mathf.PI * 2f);
-            }
         }
 
         /// <summary>

--- a/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanGlobals.hlsl
@@ -20,6 +20,7 @@ float _CrestClipByDefault;
 float _CrestLodAlphaBlackPointFade;
 float _CrestLodAlphaBlackPointWhitePointFade;
 int _CrestDepthTextureOffset;
+float3 _CrestFloatingOriginOffset;
 
 float3 _PrimaryLightDirection;
 float3 _PrimaryLightIntensity;

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstner.shader
@@ -58,7 +58,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Gerstner Global"
 
 				o.uv_uvWaves.xy = GetFullScreenTriangleTexCoord(input.VertexID);
 
-				float2 worldPosXZ = UVToWorld( o.uv_uvWaves.xy, _LD_SliceIndex, _CrestCascadeData[_LD_SliceIndex] );
+				float2 worldPosXZ = UVToWorld( o.uv_uvWaves.xy, _LD_SliceIndex, _CrestCascadeData[_LD_SliceIndex] ) - _CrestFloatingOriginOffset.xz;
 
 				// UV coordinate into wave buffer
 				float2 wavePos = float2( dot(worldPosXZ, _AxisX), dot(worldPosXZ, float2(-_AxisX.y, _AxisX.x)) );

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
@@ -85,7 +85,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
 
                 const float3 positionOS = v.vertex.xyz;
                 o.vertex = UnityObjectToClipPos(positionOS);
-                const float3 worldPos = mul( unity_ObjectToWorld, float4(positionOS, 1.0) ).xyz;
+                const float3 worldPos = mul( unity_ObjectToWorld, float4(positionOS, 1.0) ).xyz - _CrestFloatingOriginOffset;
 
                 // UV coordinate into the cascade we are rendering into
                 o.uv_slice = WorldToUV(worldPos.xz, _CrestCascadeData[_LD_SliceIndex], _LD_SliceIndex);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -37,6 +37,7 @@ Fixed
    -  Fix shadow bleeding at shorelines by using the *Sea Floor Depth* data to reject invalid shadows. :pr:`947`
    -  Fix exceptions thrown for server/headless builds.
    -  Fix exceptions thrown if foam, dynamic waves and shadows all were disabled.
+   -  Fix *Floating Origin* for *Shape Gerstner* and *Shape FFT*.
 
    .. only:: hdrp
 


### PR DESCRIPTION
Adds an offset as a global shader vector which the Gerster/FFT shader uses. It's not perfect but same tolerance as ShapeGerstnerBatched. The benefit of the global shader vector is no need to search for Shape* components.