### PR TITLE
Fix scale smoothing on height change on teleports

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -71,8 +71,12 @@ namespace Crest
 
         Vector3 _originOffset;
 
+        public static Vector3 TeleportOriginThisFrame { get; private set; }
+
         void LateUpdate()
         {
+            TeleportOriginThisFrame = Vector3.zero;
+
             var newOrigin = Vector3.zero;
             if (Mathf.Abs(transform.position.x) > _threshold) newOrigin.x += transform.position.x;
             if (Mathf.Abs(transform.position.z) > _threshold) newOrigin.z += transform.position.z;
@@ -90,6 +94,8 @@ namespace Crest
 
         void MoveOrigin(Vector3 newOrigin)
         {
+            TeleportOriginThisFrame = newOrigin;
+
             MoveOriginTransforms(newOrigin);
             MoveOriginParticles(newOrigin);
             MoveOriginOcean(newOrigin);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -42,6 +42,8 @@ Fixed
    -  Fix exceptions thrown for server/headless builds.
    -  Fix exceptions thrown if foam, dynamic waves and shadows all were disabled.
    -  Fix *Floating Origin* for *Shape Gerstner* and *Shape FFT*.
+   -  Fix ocean scale smoothing on first frame and teleports.
+      This issue appears as the ocean detail being low and slowly becoming high detailed.
    -  Fix shadow data not always clearing.
    -  Fix shadow simulation not recovering after error being resolved in edit mode.
    -  Fix *Allow Null Light* option on *Sim Settings Shadows* not working.


### PR DESCRIPTION
For the varying water level feature, smoothing between the different levels was added. But it didn't take teleports into account.

So if I had the scene camera up very high above sea level and the game camera at sea level, and then entered play mode, the smoothing would be applied from the first frame. Or if I were to teleport from a beach to a lake at a higher elevation inland then, then it would also smooth which is not necessary.

This PR handles generic teleports with Floating Origin support. Since I don't know the best threshold, I exposed a property (_Teleport Threshold_) and set the default value to 10.