### PR TITLE
Add option for Ocean Renderer to ignore Water Body culling

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -175,6 +175,9 @@ namespace Crest
         float _gravityMultiplier = 1f;
         public float Gravity => _gravityMultiplier * Physics.gravity.magnitude;
 
+        [Tooltip("Whether 'Water Body' components will cull the ocean tiles. Disable if you want to use the 'Water Body' 'Material Override' feature and still have an ocean.")]
+        public bool _waterBodyCulling = true;
+
 
         [Header("Detail Params")]
 
@@ -1161,7 +1164,7 @@ namespace Crest
                         }
                     }
 
-                    isCulled = !overlappingOne && WaterBody.WaterBodies.Count > 0;
+                    isCulled = _waterBodyCulling && !overlappingOne && WaterBody.WaterBodies.Count > 0;
                 }
 
                 // Cull tiles the viewer cannot see through the underwater fog.

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -25,6 +25,8 @@ Changed
    -  Add *Attenuation in Shallows* to *Dynamic Waves Sims Settings*.
    -  Add *Shallows Max Depth* to *Sim Settings Animated Waves* as an alternative to having to extend terrain to 500m below sea level to avoid discontinuity issues.
    -  Add *Allow No Shadows* to *Sim Settings Shadows* to allow shadows to be enabled/disabled dynamically.
+   -  Add *Ocean Renderer >  Water Body Culling* option so the ocean can ignore culling.
+      Useful if using *Water Body > Override Material* and still want an ocean.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
With this option, the _Water Body Override Material_ option can be used whilst still having an ocean. I made it _public_ as I believe people may want to script this.