### PR TITLE
Improve Water Body overlap when using Override Material

### DIFF
--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -27,6 +27,7 @@ Changed
    -  Add *Allow No Shadows* to *Sim Settings Shadows* to allow shadows to be enabled/disabled dynamically.
    -  Add *Ocean Renderer >  Water Body Culling* option so the ocean can ignore culling.
       Useful if using *Water Body > Override Material* and still want an ocean.
+   -  Improve multiple *Water Body* overlapping case when *Water Body > Override Material* option is used.
 
 Fixed
 ^^^^^

--- a/docs/user/water-bodies.rst
+++ b/docs/user/water-bodies.rst
@@ -29,6 +29,7 @@ Crest can be configured to efficiently generate smaller bodies of water, using t
 
 Another advantage of the *WaterBody* component is it allows an optional override material to be provided, to change the appearance of the water.
 This currently only changes the appearance of the water surface, it does not currently affect the underwater effect.
+If you use this feature and which to still have an ocean, then disable *Water Body Culling* on the *Ocean Renderer*.
 
 Rivers
 ------


### PR DESCRIPTION
Calculates the overlapping area between water body and water tile to determine the best suited water body when using the material override feature. Makes this feature more predictable.

Before these changes, the water body which is first enabled would be chosen regardless of how significant the overlap was. This leaves the feature to the mercy of Unity's script execution order. And is quite confusing when toggling these components in the editor.