### PR TITLE
Underwater Renderer support for Water Body material

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
@@ -37,6 +37,7 @@ namespace Crest
 
         CommandBuffer _underwaterEffectCommandBuffer;
         PropertyWrapperMaterial _underwaterEffectMaterial;
+        Material _currentOceanMaterial;
         internal readonly UnderwaterSphericalHarmonicsData _sphericalHarmonicsData = new UnderwaterSphericalHarmonicsData();
 
         RenderTargetIdentifier _colorTarget = new RenderTargetIdentifier
@@ -243,7 +244,7 @@ namespace Crest
             }
         }
 
-        internal static void UpdatePostProcessMaterial(
+        internal void UpdatePostProcessMaterial(
             Mode mode,
             Camera camera,
             PropertyWrapperMaterial underwaterPostProcessMaterialWrapper,
@@ -256,10 +257,37 @@ namespace Crest
         )
         {
             Material underwaterPostProcessMaterial = underwaterPostProcessMaterialWrapper.material;
-            if (copyParamsFromOceanMaterial)
+
+            // Copy ocean material parameters to underwater material.
             {
-                // Measured this at approx 0.05ms on dell laptop
-                underwaterPostProcessMaterial.CopyPropertiesFromMaterial(OceanRenderer.Instance.OceanMaterial);
+                var material = OceanRenderer.Instance.OceanMaterial;
+                // Grab material from a water body if camera is within its XZ bounds.
+                foreach (var body in WaterBody.WaterBodies)
+                {
+                    if (body._overrideMaterial == null)
+                    {
+                        continue;
+                    }
+
+                    var bounds = body.AABB;
+                    var position = camera.transform.position;
+                    var contained =
+                        position.x >= bounds.min.x && position.x <= bounds.max.x &&
+                        position.z >= bounds.min.z && position.z <= bounds.max.z;
+                    if (contained)
+                    {
+                        material = body._overrideMaterial;
+                        // Water bodies should not overlap so grab the first one.
+                        break;
+                    }
+                }
+
+                if (copyParamsFromOceanMaterial || material != _currentOceanMaterial)
+                {
+                    // Measured this at approx 0.05ms on Dell laptop.
+                    underwaterPostProcessMaterial.CopyPropertiesFromMaterial(material);
+                    _currentOceanMaterial = material;
+                }
             }
 
             underwaterPostProcessMaterial.SetVector("_DepthFogDensity", OceanRenderer.Instance.UnderwaterDepthFogDensity);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -39,6 +39,7 @@ Changed
       Useful if using *Water Body > Override Material* and still want an ocean.
    -  Improve multiple *Water Body* overlapping case when *Water Body > Override Material* option is used.
    -  Water Body adds an inclusion to clipping (ie unclips) if *Default Clipping State* is *Everything Clipped*.
+   -  Add *Underwater Renderer* support for *Water Body > Override Material*.
    -  Add scroll bar to *Ocean Debug GUI* when using *Draw LOD Datas Actual Size*.
    -  Add support for *TrailRenderer*, *LineRenderer* and *ParticleSystem* to be used as ocean inputs in addition to *MeshRenderer*.
    -  Un-deprecate *ShapeGerstner* as it is useful in some situations for adding a small number of distinct waves with high degree of control.

--- a/docs/user/water-bodies.rst
+++ b/docs/user/water-bodies.rst
@@ -28,7 +28,6 @@ Crest can be configured to efficiently generate smaller bodies of water, using t
    It is recommended to cover a larger area than the lake itself, to give a protective margin against LOD effects in the distance.
 
 Another advantage of the *WaterBody* component is it allows an optional override material to be provided, to change the appearance of the water.
-This currently only changes the appearance of the water surface, it does not currently affect the underwater effect.
 If you use this feature and which to still have an ocean, then disable *Water Body Culling* on the *Ocean Renderer*.
 
 Rivers


### PR DESCRIPTION
Adds support for the water body material override. It grabs the material from one of the inner tiles. Seems to work well enough if we consider how it is used (WB should be far enough apart).

**EDIT:** Change the solution to something more accurate to the WB itself. Checking camera position is within the WB bounds in the UR. Other benefit is that it is code is contained within the UR which is nicer. Check the first commit to see original solution.