### PR TITLE
Prewarm foam sim on first frame and teleports

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFoam.cs
@@ -33,6 +33,7 @@ namespace Crest
         readonly int sp_WaveFoamCoverage = Shader.PropertyToID("_WaveFoamCoverage");
         readonly int sp_ShorelineFoamMaxDepth = Shader.PropertyToID("_ShorelineFoamMaxDepth");
         readonly int sp_ShorelineFoamStrength = Shader.PropertyToID("_ShorelineFoamStrength");
+        readonly int sp_NeedsPrewarming = Shader.PropertyToID("_NeedsPrewarming");
 
         public override SimSettingsBase SettingsBase => Settings;
         public SettingsType Settings => _ocean._simSettingsFoam != null ? _ocean._simSettingsFoam : GetDefaultSettings<SettingsType>();
@@ -60,6 +61,9 @@ namespace Crest
         {
             base.SetAdditionalSimParams(simMaterial);
 
+            // Prewarm simulation for first frame or teleporting. It will not be the same results as running the
+            // simulation for multiple frames - but good enough.
+            simMaterial.SetFloat(sp_NeedsPrewarming, Settings._prewarm && _needsPrewarmingThisStep ? 1f : 0f);
             simMaterial.SetFloat(sp_FoamFadeRate, Settings._foamFadeRate);
             simMaterial.SetFloat(sp_WaveFoamStrength, Settings._waveFoamStrength);
             simMaterial.SetFloat(sp_WaveFoamCoverage, Settings._waveFoamCoverage);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -30,6 +30,9 @@ namespace Crest
         readonly int sp_SimDeltaTime = Shader.PropertyToID("_SimDeltaTime");
         readonly int sp_SimDeltaTimePrev = Shader.PropertyToID("_SimDeltaTimePrev");
 
+        // Is this the first step since being enabled?
+        protected bool _needsPrewarmingThisStep = true;
+
         // This is how far the simulation time is behind unity's time
         float _timeToSimulate = 0f;
 
@@ -55,6 +58,7 @@ namespace Crest
                 return;
             }
             _renderSimProperties = new PropertyWrapperCompute();
+            _needsPrewarmingThisStep = true;
         }
 
         protected override void InitData()
@@ -119,6 +123,11 @@ namespace Crest
                     // and substeps are "sub-frame".
                     Helpers.Swap(ref _sources, ref current);
                 }
+                else
+                {
+                    // We only want to handle teleports for the first step.
+                    _needsPrewarmingThisStep = _needsPrewarmingThisStep || OceanRenderer.Instance._hasTeleportedThisFrame;
+                }
 
                 _renderSimProperties.Initialise(buf, _shader, krnl_ShaderSim);
 
@@ -164,6 +173,8 @@ namespace Crest
                     }
                 }
 
+                // The very first step since being enabled.
+                _needsPrewarmingThisStep = false;
                 _substepDtPrevious = substepDt;
             }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
@@ -27,6 +27,8 @@ namespace Crest
         public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#id5";
 
         [Header("General settings")]
+        [Tooltip("Prewarms the simulation on load and teleports. Results are only an approximation but are better than no foam.")]
+        public bool _prewarm = true;
         [Range(0f, 20f), Tooltip("Speed at which foam fades/dissipates.")]
         public float _foamFadeRate = 0.8f;
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -22,6 +22,7 @@ float _ShorelineFoamStrength;
 float _SimDeltaTime;
 float _SimDeltaTimePrev;
 float _LODChange;
+bool _NeedsPrewarming;
 CBUFFER_END
 
 [numthreads(THREAD_GROUP_SIZE_X, THREAD_GROUP_SIZE_Y, 1)]
@@ -70,6 +71,10 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	// fade
 	foam *= max(0.0, 1.0 - _FoamFadeRate * _SimDeltaTime);
 
+	// Prewarm wave foam. 1.0 / _FoamFadeRate perfectly matches a paused ocean in edit mode, but this is an unnatural
+	// accumulation of foam and causes overshoots when _WaveFoamStrength is less than 1.0.
+	float simDeltaTime = _NeedsPrewarming ? max(_SimDeltaTime, min(1.0, _WaveFoamStrength - 1.0) / _FoamFadeRate) : _SimDeltaTime;
+
 	// Sample displacement texture and generate foam from it
 	const float3 dd = float3(cascadeData._oneOverTextureRes, 0.0, cascadeData._texelWidth);
 	half4 data = SampleLod( _LD_TexArray_AnimatedWaves, uv_slice );
@@ -87,13 +92,17 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	const float2x2 jacobian = (float4(disp_x.xz, disp_z.xz) - disp.xzxz) / cascadeData._texelWidth;
 	// Determinant is < 1 for pinched, < 0 for overlap/inversion
 	const float det = determinant( jacobian );
-	foam += 5.0 * _SimDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase * 0.7 );
+	foam += 5.0 * simDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase * 0.7 );
+
+	// Prewarm shoreline foam. 1.0 / _FoamFadeRate perfectly matches a paused ocean in edit mode which is fine for
+	// shoreline foam.
+	simDeltaTime = _NeedsPrewarming ? (1.0 / _FoamFadeRate) : _SimDeltaTime;
 
 	// Add foam in shallow water. use the displaced position to ensure we add foam where world objects are.
 	const float3 uv_slice_displaced = WorldToUV(worldPosXZ + disp.xz, cascadeData, sliceIndex);
 	const half2 terrainHeight_seaLevelOffset = _LD_TexArray_SeaFloorDepth.SampleLevel(LODData_linear_clamp_sampler, uv_slice_displaced, 0.0).xy;
 	const half signedOceanDepth = _OceanCenterPosWorld.y - terrainHeight_seaLevelOffset.x + terrainHeight_seaLevelOffset.y + disp.y;
-	foam += _ShorelineFoamStrength * _SimDeltaTime * saturate(1.0 - signedOceanDepth / _ShorelineFoamMaxDepth);
+	foam += _ShorelineFoamStrength * simDeltaTime * saturate(1.0 - signedOceanDepth / _ShorelineFoamMaxDepth);
 
 	_LD_TexArray_Target[id] = saturate(foam);
 }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -41,6 +41,7 @@ Changed
    -  Un-deprecate *ShapeGerstner* as it is useful in some situations for adding a small number of distinct waves with high degree of control.
    -  Add *Reverse Wave Weight* setting to *ShapeGerstner* for fine control over generated wave pairs.
    -  Double sample count for *ShapeGerstner* waves to improve quality.
+   -  Add option (enabled by default) to prewarm foam simulation on load and camera teleports.
 
 Fixed
 ^^^^^


### PR DESCRIPTION
This prewarms the foam sim if it is the first step since being enabled or the first step for a teleport.

Currently foam can take a second or so to populate and the first moment has no foam. This PR mitigates that by prewarming the sim.

I worked out that swapping the `_SimDeltaTime` with `1.0 / _FoamFadeRate` will match the foam generated when the ocean is in a paused state in the editor (add a custom time provider and override time as zero or pause). So when entering play mode, it is seamless.

It's not the same as foam produced from running all the sims a few frames which would be the perfect solution, but that is probably costly for teleports.

![1_1_Target](https://user-images.githubusercontent.com/5249806/145707662-8431b0c7-eb93-4665-b048-9993fe0dd7c0.jpg)
Editor (ocean is at time zero)

![1_2_Current](https://user-images.githubusercontent.com/5249806/145707663-296e90f4-a2a9-4ce5-a28a-c19539838144.jpg)
First frame of play mode (current)

![1_3_Fixed](https://user-images.githubusercontent.com/5249806/145707664-ece97473-f065-4de4-b21a-f4c9c895b44c.jpg)
First frame of play mode (this PR)