### PR TITLE
Fix underwater high memory

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
@@ -98,8 +98,6 @@ namespace Crest
             _underwaterEffectCommandBuffer.DrawProcedural(Matrix4x4.identity, _underwaterEffectMaterial.material, -1, MeshTopology.Triangles, 3, 1);
 
             RenderTexture.ReleaseTemporary(temporaryColorBuffer);
-            // We no longer need the temporary mask textures so release them.
-            CleanUpMaskTextures(_underwaterEffectCommandBuffer);
         }
 
         internal static void UpdatePostProcessMaterial(

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -145,6 +145,7 @@ namespace Crest
 
         void Disable()
         {
+            CleanUpMaskTextures();
             _camera.RemoveCommandBuffer(CameraEvent.AfterForwardAlpha, _underwaterEffectCommandBuffer);
             _camera.RemoveCommandBuffer(CameraEvent.BeforeForwardAlpha, _oceanMaskCommandBuffer);
         }
@@ -153,7 +154,11 @@ namespace Crest
         {
             if (!IsActive)
             {
-                OnDisable();
+                if (Instance != null)
+                {
+                    OnDisable();
+                }
+
                 return;
             }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -53,6 +53,10 @@ Fixed
 
       -  Fix shadow simulation null exceptions if primary light becomes null. `[BIRP]`
 
+   .. only:: birp or urp
+
+      -  Fix *Underwater Renderer* high memory usage by reverting change of using temporary render textures. `[BIRP] [URP]`
+
    .. only:: hdrp
 
       -  Fix motion vectors not working by exposing motion vector toggle on ocean material. `[HDRP]`


### PR DESCRIPTION
Reverts #928

I used Unity's memory profiler and saw a ballooned amount of RT memory usage. There were multiple instances of the same temporary RTs. I have gone back to using creating RTs manually :^(

Unity has not gotten back to me yet (been over a month). Unity's temporary RT pool has another strange bug, where temporary RTs would be bound to the wrong variable, which they have confirmed. This was preventing me from finishing underwater portals so will be able to finally finish it.

If you're wondering why I am using a static reference, it is because URP shares these APIs. The UR will hold the RTs which URP will use. This will reduce friction when merging and when reverting back to temporary RTS once bug is fixed.