### PR TITLE
Underwater from geometry

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
@@ -32,6 +32,7 @@ namespace Crest
         {
             "_FULL_SCREEN_EFFECT",
             "_DEBUG_VIEW_OCEAN_MASK",
+            "_DEBUG_VIEW_STENCIL",
 
             // Unity 2021.2 considers this UserDefined."
             "STEREO_ENABLED_ON",

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -29,6 +29,32 @@ namespace Crest
         int _version = 0;
 #pragma warning restore 414
 
+        internal const string k_KeywordVolume = "CREST_WATER_VOLUME";
+        internal const string k_KeywordVolume2D = "CREST_WATER_VOLUME_2D";
+        internal const string k_KeywordVolumeHasBackFace = "CREST_WATER_VOLUME_HAS_BACKFACE";
+
+        // The underlying value matches UnderwaterRenderer.EffectPass.
+        // :UnderwaterRenderer.Mode
+        public enum Mode
+        {
+            // Infinite water as a full-screen triangle.
+            [InspectorNameAttribute("Full-Screen")]
+            FullScreen,
+            // Portal to infinite water rendered from front faces of geometry.
+            Portal,
+            // Volume of water rendered from front faces of geometry only. Back faces used for depth. Camera cannot see
+            // the effect from within the volume.
+            Volume,
+            // Volume of water rendered using front faces, back faces and full-screen triangle. Camera can see effect
+            // from within the volume.
+            [InspectorNameAttribute("Volume (Fly-Through)")]
+            VolumeFlyThrough,
+        }
+
+        [SerializeField]
+        [Tooltip("Rendering mode of the underwater effect (and ocean). See the documentation for more details.")]
+        internal Mode _mode;
+
         // This adds an offset to the cascade index when sampling ocean data, in effect smoothing/blurring it. Default
         // to shifting the maximum amount (shift from lod 0 to penultimate lod - dont use last lod as it cross-fades
         // data in/out), as more filtering was better in testing.
@@ -45,6 +71,17 @@ namespace Crest
         [Tooltip("Scales the depth fog density. Useful to reduce the intensity of the depth fog when underwater water only.")]
         float _depthFogDensityFactor = 1f;
         public float DepthFogDensityFactor => _depthFogDensityFactor;
+
+
+        [Header("Geometry")]
+
+        [SerializeField, Predicated("_mode", inverted: false, Mode.FullScreen), DecoratedField]
+        [Tooltip("Mesh to use to render the underwater effect.")]
+        internal MeshFilter _volumeGeometry;
+
+        [SerializeField, Predicated("_mode", inverted: true, Mode.Portal), DecoratedField]
+        [Tooltip("If enabled, the back faces of the mesh will be used instead of the front faces.")]
+        bool _invertCulling = false;
 
 
         [Header("Advanced")]
@@ -66,12 +103,16 @@ namespace Crest
         {
             public bool _viewOceanMask = false;
             public bool _disableOceanMask = false;
+            public bool _viewStencil = false;
             public bool _disableHeightAboveWaterOptimization = false;
             public bool _disableArtifactCorrection = false;
         }
 
         Camera _camera;
         bool _firstRender = true;
+
+        internal bool UseStencilBufferOnMask => _mode != Mode.FullScreen;
+        internal bool UseStencilBufferOnEffect => _mode == Mode.VolumeFlyThrough;
 
         Matrix4x4 _gpuInverseViewProjectionMatrix;
         Matrix4x4 _gpuInverseViewProjectionMatrixRight;
@@ -98,7 +139,7 @@ namespace Crest
                     return false;
                 }
 
-                if (!_debug._disableHeightAboveWaterOptimization && OceanRenderer.Instance.ViewerHeightAboveWater > 2f)
+                if (!_debug._disableHeightAboveWaterOptimization && _mode == Mode.FullScreen && OceanRenderer.Instance.ViewerHeightAboveWater > 2f)
                 {
                     return false;
                 }
@@ -115,7 +156,11 @@ namespace Crest
             }
 
 #if UNITY_EDITOR
-            Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog);
+            if (!Validate(OceanRenderer.Instance, ValidatedHelper.DebugLog))
+            {
+                enabled = false;
+                return;
+            }
 #endif
 
             // Setup here because it is the same across pipelines.
@@ -145,9 +190,17 @@ namespace Crest
 
         void Disable()
         {
-            CleanUpMaskTextures();
-            _camera.RemoveCommandBuffer(CameraEvent.AfterForwardAlpha, _underwaterEffectCommandBuffer);
-            _camera.RemoveCommandBuffer(CameraEvent.BeforeForwardAlpha, _oceanMaskCommandBuffer);
+            if (_underwaterEffectCommandBuffer != null)
+            {
+                _camera.RemoveCommandBuffer(CameraEvent.AfterForwardAlpha, _underwaterEffectCommandBuffer);
+            }
+
+            if (_oceanMaskCommandBuffer != null)
+            {
+                _camera.RemoveCommandBuffer(CameraEvent.BeforeForwardAlpha, _oceanMaskCommandBuffer);
+            }
+
+            OnDisableOceanMask();
         }
 
         void OnPreRender()
@@ -215,7 +268,21 @@ namespace Crest
         {
             var isValid = true;
 
-            // Intentionally left empty. Here for downstream.
+            if (_mode != Mode.FullScreen && _volumeGeometry == null)
+            {
+                showMessage
+                (
+                    $"<i>{_mode}</i> mode requires a <i>Mesh Filter</i> be set to <i>Volume Geometry</i>.",
+                    "Change <i>Mode</i> to <i>FullScreen</i>.",
+                    ValidatedHelper.MessageType.Error, this,
+                    (SerializedObject so) =>
+                    {
+                        so.FindProperty("_mode").enumValueIndex = (int)Mode.FullScreen;
+                    }
+                );
+
+                isValid = false;
+            }
 
             return isValid;
         }

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/Resources.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d696d54d051d2e4d90a0931ebaa50bc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/Resources/Utility.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/Resources/Utility.shader
@@ -1,0 +1,102 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Provides utility passes for rendering like clearing the stencil buffer.
+
+Shader "Hidden/Crest/Helpers/Utility"
+{
+	HLSLINCLUDE
+	#pragma vertex Vertex
+	#pragma fragment Fragment
+
+	#include "UnityCG.cginc"
+
+	#include "../BIRP/Core.hlsl"
+	#include "../BIRP/InputsDriven.hlsl"
+
+	#include "../../OceanShaderHelpers.hlsl"
+
+	struct Attributes
+	{
+		float4 positionOS : POSITION;
+	};
+
+	struct Varyings
+	{
+		float4 positionCS : SV_POSITION;
+	};
+
+	TEXTURE2D_X(_CameraDepthTexture);
+
+	Varyings Vertex(Attributes input)
+	{
+		Varyings output;
+		output.positionCS = UnityObjectToClipPos(input.positionOS);
+		return output;
+	}
+	ENDHLSL
+
+	SubShader
+	{
+		Cull Off ZWrite On ZTest Always
+
+		Pass
+		{
+			// Copies the depth from the camera depth texture. Clears the stencil for convenience.
+			Name "Copy Depth / Clear Stencil"
+
+			ZWrite On
+			ZTest Always
+			Cull Off
+
+			Stencil
+			{
+				Ref 0
+				Comp Always
+				Pass Replace
+			}
+
+			HLSLPROGRAM
+			float Fragment(Varyings input) : SV_Depth
+			{
+				return LOAD_DEPTH_TEXTURE_X(_CameraDepthTexture, input.positionCS.xy);
+			}
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// Clears the depth buffer without clearing the stencil.
+			Name "Clear Depth"
+
+			ZWrite On
+			ZTest Always
+			Cull Off
+
+			HLSLPROGRAM
+			float Fragment(Varyings input) : SV_Depth
+			{
+				return 0.0;
+			}
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// Clears the stencil buffer without clearing depth
+			Name "Clear Stencil"
+
+			ZWrite Off
+			ZTest Always
+			Cull Off
+
+			Stencil
+			{
+				Ref 0
+				Comp Always
+				Pass Replace
+			}
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/Resources/Utility.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/Resources/Utility.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 825bb4b9bc2eb8f44a87858bd8350731
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/WaterVolume.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/WaterVolume.hlsl
@@ -1,0 +1,52 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+#ifndef CREST_WATER_VOLUME_INCLUDED
+#define CREST_WATER_VOLUME_INCLUDED
+
+TEXTURE2D_X(_CrestWaterVolumeFrontFaceTexture);
+TEXTURE2D_X(_CrestWaterVolumeBackFaceTexture);
+
+#if CREST_WATER_VOLUME
+void ApplyVolumeToOceanSurface(const float4 i_positionCS)
+{
+#if CREST_WATER_VOLUME_HAS_BACKFACE
+	// Discard ocean after volume or when not on pixel.
+	float rawBackFaceZ = LOAD_DEPTH_TEXTURE_X(_CrestWaterVolumeBackFaceTexture, i_positionCS.xy);
+	if (rawBackFaceZ == 0.0 || rawBackFaceZ > i_positionCS.z)
+	{
+		discard;
+	}
+#endif // CREST_WATER_VOLUME_VOLUME
+
+	// Discard ocean before volume.
+	float rawFrontFaceZ = LOAD_DEPTH_TEXTURE_X(_CrestWaterVolumeFrontFaceTexture, i_positionCS.xy);
+	if (rawFrontFaceZ > 0.0 && rawFrontFaceZ < i_positionCS.z)
+	{
+		discard;
+	}
+
+#if CREST_WATER_VOLUME_2D
+	// Discard ocean when plane is not in view.
+	if (rawFrontFaceZ == 0.0)
+	{
+		discard;
+	}
+#endif // CREST_WATER_VOLUME_2D
+}
+#endif
+
+#if CREST_WATER_VOLUME
+void ApplyVolumeToOceanMask(const float4 i_positionCS)
+{
+	// Discard any pixels in front of the volume geometry otherwise the mask will be incorrect at eye level.
+	float rawFrontFaceZ = LOAD_DEPTH_TEXTURE_X(_CrestWaterVolumeFrontFaceTexture, i_positionCS.xy);
+	if (rawFrontFaceZ > 0.0 && rawFrontFaceZ < i_positionCS.z)
+	{
+		discard;
+	}
+}
+#endif
+
+#endif // CREST_WATER_VOLUME_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Helpers/WaterVolume.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/WaterVolume.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: faee2d09546cfcf45a3ce6b61a251044
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanConstants.hlsl
@@ -32,10 +32,29 @@
 // Water rendered from above.
 #define UNDERWATER_MASK_ABOVE_SURFACE  1.0
 
+// No mask.
+#define UNDERWATER_MASK_NONE 0.0
+
+// The maximum distance the meniscus will be rendered. Only valid when rendering underwater from geometry. The value is
+// used to scale the meniscus as it is calculate using a pixel offset which can make the meniscus large at a distance.
+#define MENISCUS_MAXIMUM_DISTANCE 15.0
+
+
 #if defined(STEREO_INSTANCING_ON) || defined(STEREO_MULTIVIEW_ON)
 #define CREST_HANDLE_XR 1
 #else
 #define CREST_HANDLE_XR 0
 #endif
+
+#if defined(CREST_WATER_VOLUME_3D) || defined(CREST_WATER_VOLUME_VOLUME)
+#define CREST_WATER_VOLUME_HAS_BACKFACE 1
+#endif
+#if defined(CREST_WATER_VOLUME_2D) || defined(CREST_WATER_VOLUME_3D)
+#define CREST_WATER_VOLUME_IS_FRONTFACE 1
+#endif
+#if defined(CREST_WATER_VOLUME_HAS_BACKFACE) || defined(CREST_WATER_VOLUME_IS_FRONTFACE)
+#define CREST_WATER_VOLUME 1
+#endif
+
 
 #endif // CREST_CONSTANTS_H

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterEffect.shader
@@ -19,18 +19,128 @@ Shader "Hidden/Crest/Underwater/Underwater Effect"
 	#pragma multi_compile_local __ _PROJECTION_PERSPECTIVE _PROJECTION_ORTHOGRAPHIC
 
 	#pragma multi_compile_local __ CREST_MENISCUS
-	#pragma multi_compile_local __ _FULL_SCREEN_EFFECT
 	#pragma multi_compile_local __ _DEBUG_VIEW_OCEAN_MASK
+	#pragma multi_compile_local __ _DEBUG_VIEW_STENCIL
 	ENDHLSL
 
 	SubShader
 	{
-		// No culling or depth
-		Cull Off ZWrite Off ZTest Always
+		ZWrite Off
 
 		Pass
 		{
+			Name "Full Screen"
+			Cull Off
+			ZTest Always
+
 			HLSLPROGRAM
+			// Both "__" and "_FULL_SCREEN_EFFECT" are fullscreen triangles. The latter only denotes an optimisation of
+			// whether to skip the horizon calculation.
+			#pragma multi_compile_local __ _FULL_SCREEN_EFFECT
+
+			#include "../UnderwaterEffect.hlsl"
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// Only adds fog to the front face and in effect anything behind it.
+			Name "Volume: Front Face (2D)"
+			Cull Back
+			ZTest LEqual
+
+			HLSLPROGRAM
+			#define CREST_WATER_VOLUME 1
+			#define CREST_WATER_VOLUME_FRONT_FACE 1
+			#include "../UnderwaterEffect.hlsl"
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// Only adds fog to the front face and in effect anything behind it.
+			Name "Volume: Front Face (3D)"
+			Cull Back
+			ZTest LEqual
+
+			HLSLPROGRAM
+			#define CREST_WATER_VOLUME 1
+			#define CREST_WATER_VOLUME_HAS_BACKFACE 1
+			#define CREST_WATER_VOLUME_FRONT_FACE 1
+			#include "../UnderwaterEffect.hlsl"
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// Only adds fog to the front face and in effect anything behind it.
+			Name "Volume: Front Face (Fly-Through)"
+			Cull Back
+			ZTest LEqual
+
+			Stencil
+			{
+				// Must match k_StencilValueVolume in:
+				// Scripts/Underwater/UnderwaterRenderer.Mask.cs
+				Ref 5
+				Comp Always
+				Pass Replace
+				ZFail IncrSat
+			}
+
+			HLSLPROGRAM
+			#define CREST_WATER_VOLUME 1
+			#define CREST_WATER_VOLUME_HAS_BACKFACE 1
+			#define CREST_WATER_VOLUME_FRONT_FACE 1
+			#include "../UnderwaterEffect.hlsl"
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// Back face will only render if view is within the volume and there is no scene in front. It will only add
+			// fog to the back face (and in effect anything behind it). No caustics.
+			Name "Volume: Back Face"
+			Cull Front
+			ZTest LEqual
+
+			Stencil
+			{
+				// Must match k_StencilValueVolume in:
+				// Scripts/Underwater/UnderwaterRenderer.Mask.cs
+				Ref 5
+				Comp NotEqual
+				Pass Replace
+				ZFail IncrSat
+			}
+
+			HLSLPROGRAM
+			#define CREST_WATER_VOLUME 1
+			#define CREST_WATER_VOLUME_BACK_FACE 1
+			#include "../UnderwaterEffect.hlsl"
+			ENDHLSL
+		}
+
+		Pass
+		{
+			// When inside a volume, this pass will render to the scene within the volume.
+			Name "Volume: Scene (Full Screen)"
+			Cull Back
+			ZTest Always
+			Stencil
+			{
+				// We want to render over the scene that's inside the volume, but not over already fogged areas. It will
+				// handle all of the scene within the geometry once the camera is within the volume.
+				// 0 = Outside of geometry as neither face passes have touched it.
+				// 1 = Only back face z failed which means scene is in front of back face but not front face.
+				// 2 = Both front and back face z failed which means outside geometry.
+				Ref 1
+				Comp Equal
+				Pass Replace
+			}
+
+			HLSLPROGRAM
+			#define CREST_WATER_VOLUME_FULL_SCREEN 1
 			#include "../UnderwaterEffect.hlsl"
 			ENDHLSL
 		}

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMask.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/UnderwaterMask.shader
@@ -4,6 +4,12 @@
 
 Shader "Hidden/Crest/Underwater/Ocean Mask"
 {
+	Properties
+	{
+		// Needed so it can be scripted.
+		_StencilRef("Stencil Reference", Int) = 0
+	}
+
 	SubShader
 	{
 		Pass
@@ -13,11 +19,19 @@ Shader "Hidden/Crest/Underwater/Ocean Mask"
 			// use it for underwater rendering features.
 			Cull Off
 
+			Stencil
+			{
+				Ref [_StencilRef]
+				Comp Equal
+			}
+
 			CGPROGRAM
 			#pragma vertex Vert
 			#pragma fragment Frag
 			// for VFACE
 			#pragma target 3.0
+
+			#pragma multi_compile_local _ CREST_WATER_VOLUME
 
 			#include "UnityCG.cginc"
 
@@ -35,6 +49,12 @@ Shader "Hidden/Crest/Underwater/Ocean Mask"
 			ZWrite Off
 			// Horizon must be rendered first or it will overwrite the mask with incorrect values. ZTest not needed.
 			ZTest Always
+
+			Stencil
+			{
+				Ref [_StencilRef]
+				Comp Equal
+			}
 
 			CGPROGRAM
 			#pragma vertex Vert

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/WaterVolumeGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/WaterVolumeGeometry.shader
@@ -1,0 +1,81 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+Shader "Hidden/Crest/Water Volume Geometry"
+{
+	SubShader
+	{
+		CGINCLUDE
+		#pragma vertex Vert
+		#pragma fragment Frag
+
+		// #pragma enable_d3d11_debug_symbols
+
+		#include "UnityCG.cginc"
+
+		struct Attributes
+		{
+			float3 positionOS : POSITION;
+			UNITY_VERTEX_INPUT_INSTANCE_ID
+		};
+
+		struct Varyings
+		{
+			float4 positionCS : SV_POSITION;
+			UNITY_VERTEX_OUTPUT_STEREO
+		};
+
+		Varyings Vert(Attributes input)
+		{
+			// This will work for all pipelines.
+			Varyings o = (Varyings)0;
+			UNITY_SETUP_INSTANCE_ID(input);
+			UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+			o.positionCS = UnityObjectToClipPos(input.positionOS);
+
+			return o;
+		}
+
+		half4 Frag(Varyings input) : SV_Target
+		{
+			return 1.0;
+		}
+		ENDCG
+
+		Pass
+		{
+			Name "Front Faces"
+			Cull Back
+
+			Stencil
+			{
+				// Must match k_StencilValueVolume in:
+				// Scripts/Underwater/UnderwaterRenderer.Mask.cs
+				Ref 5
+				Pass Replace
+			}
+
+			CGPROGRAM
+			ENDCG
+		}
+
+		Pass
+		{
+			Name "Back Faces"
+			Cull Front
+
+			Stencil
+			{
+				// Must match k_StencilValueVolume in:
+				// Scripts/Underwater/UnderwaterRenderer.Mask.cs
+				Ref 5
+				Pass Replace
+			}
+
+			CGPROGRAM
+			ENDCG
+		}
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/WaterVolumeGeometry.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/Resources/WaterVolumeGeometry.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3b257e4de803141d7860029fa166888e
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffect.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffect.hlsl
@@ -16,6 +16,8 @@
 #include "../FullScreenTriangle.hlsl"
 #include "../OceanEmission.hlsl"
 
+#include "../../Helpers/WaterVolume.hlsl"
+
 TEXTURE2D_X(_CrestCameraColorTexture);
 TEXTURE2D_X(_CrestOceanMaskTexture);
 TEXTURE2D_X(_CrestOceanMaskDepthTexture);
@@ -24,14 +26,22 @@ TEXTURE2D_X(_CrestOceanMaskDepthTexture);
 
 struct Attributes
 {
+#if CREST_WATER_VOLUME
+	float3 positionOS : POSITION;
+#else
 	uint id : SV_VertexID;
+#endif
 	UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct Varyings
 {
 	float4 positionCS : SV_POSITION;
+#if CREST_WATER_VOLUME
+	float4 screenPosition : TEXCOORD0;
+#else
 	float2 uv : TEXCOORD0;
+#endif
 	UNITY_VERTEX_OUTPUT_STEREO
 };
 
@@ -43,8 +53,14 @@ Varyings Vert (Attributes input)
 	UNITY_INITIALIZE_OUTPUT(Varyings, output);
 	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
 
+#if CREST_WATER_VOLUME
+	// Use actual geometry instead of full screen triangle.
+	output.positionCS = UnityObjectToClipPos(float4(input.positionOS, 1.0));
+	output.screenPosition = ComputeScreenPos(output.positionCS);
+#else
 	output.positionCS = GetFullScreenTriangleVertexPosition(input.id);
 	output.uv = GetFullScreenTriangleTexCoord(input.id);
+#endif
 
 	return output;
 }
@@ -54,16 +70,30 @@ fixed4 Frag (Varyings input) : SV_Target
 	// We need this when sampling a screenspace texture.
 	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 
+#if CREST_WATER_VOLUME
+	float2 uv = input.screenPosition.xy / input.screenPosition.w;
+#else
+	float2 uv = input.uv;
+#endif
+
 	const int2 positionSS = input.positionCS.xy;
 	half3 sceneColour = LOAD_TEXTURE2D_X(_CrestCameraColorTexture, positionSS).rgb;
 	float rawDepth = LOAD_TEXTURE2D_X(_CameraDepthTexture, positionSS).r;
 	const float mask = LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS).r;
 	const float rawOceanDepth = LOAD_TEXTURE2D_X(_CrestOceanMaskDepthTexture, positionSS).r;
 
-	bool isOceanSurface; bool isUnderwater; float sceneZ;
-	GetOceanSurfaceAndUnderwaterData(positionSS, rawOceanDepth, mask, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
+#if _DEBUG_VIEW_STENCIL
+	return DebugRenderStencil(sceneColour);
+#endif // _DEBUG_VIEW_STENCIL
 
-	float wt = ComputeMeniscusWeight(positionSS, mask, _HorizonNormal, sceneZ);
+	bool isOceanSurface; bool isUnderwater; float sceneZ;
+	GetOceanSurfaceAndUnderwaterData(input.positionCS, positionSS, rawOceanDepth, mask, rawDepth, isOceanSurface, isUnderwater, sceneZ, 0.0);
+
+	float fogDistance = sceneZ;
+	float meniscusDepth = 0.0;
+#if CREST_WATER_VOLUME
+	ApplyWaterVolumeToUnderwaterFogAndMeniscus(input.positionCS, fogDistance, meniscusDepth);
+#endif
 
 #if _DEBUG_VIEW_OCEAN_MASK
 	return DebugRenderOceanMask(isOceanSurface, isUnderwater, mask, sceneColour);
@@ -73,13 +103,15 @@ fixed4 Frag (Varyings input) : SV_Target
 	{
 		// Position needs to be reconstructed in the fragment shader to avoid precision issues as per
 		// Unity's lead. Fixes caustics stuttering when far from zero.
-		const float3 positionWS = ComputeWorldSpacePosition(input.uv, rawDepth, UNITY_MATRIX_I_VP);
+		const float3 positionWS = ComputeWorldSpacePosition(uv, rawDepth, UNITY_MATRIX_I_VP);
 		const half3 view = normalize(_WorldSpaceCameraPos - positionWS);
 		float3 scenePos = _WorldSpaceCameraPos - view * sceneZ / dot(unity_CameraToWorld._m02_m12_m22, -view);
 		const float3 lightDir = _WorldSpaceLightPos0.xyz;
 		const half3 lightCol = _LightColor0;
-		sceneColour = ApplyUnderwaterEffect(positionSS, scenePos, sceneColour, lightCol, lightDir, rawDepth, sceneZ, view, isOceanSurface);
+		sceneColour = ApplyUnderwaterEffect(positionSS, scenePos, sceneColour, lightCol, lightDir, rawDepth, sceneZ, fogDistance, view, isOceanSurface);
 	}
+
+	float wt = ComputeMeniscusWeight(positionSS, mask, _HorizonNormal, meniscusDepth);
 
 	return half4(wt * sceneColour, 1.0);
 }

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
@@ -21,7 +21,36 @@ float4 DebugRenderOceanMask(const bool isOceanSurface, const bool isUnderwater, 
 	}
 }
 
-half ComputeMeniscusWeight(const int2 positionSS, const float mask, const float2 horizonNormal, const float sceneZ)
+float4 DebugRenderStencil(float3 sceneColour)
+{
+	float3 stencil = 1.0;
+#if CREST_WATER_VOLUME_FRONT_FACE
+	stencil = float3(1.0, 0.0, 0.0);
+#elif CREST_WATER_VOLUME_BACK_FACE
+	stencil = float3(0.0, 1.0, 0.0);
+#elif CREST_WATER_VOLUME_FULL_SCREEN
+	stencil = float3(0.0, 0.0, 1.0);
+#endif
+	return float4(sceneColour * stencil, 1.0);
+}
+
+float MeniscusSampleOceanMask(const float mask, const int2 positionSS, const float2 offset, const float magnitude, const float scale)
+{
+	float2 uv = positionSS + offset * magnitude
+#if CREST_WATER_VOLUME
+	* scale
+#endif
+	;
+
+	float newMask = LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, uv).r;
+#if CREST_WATER_VOLUME
+	// No mask means no underwater effect so ignore the value.
+	return (newMask == UNDERWATER_MASK_NONE ? mask : newMask);
+#endif
+	return newMask;
+}
+
+half ComputeMeniscusWeight(const int2 positionSS, const float mask, const float2 horizonNormal, const float meniscusDepth)
 {
 	float weight = 1.0;
 #if CREST_MENISCUS
@@ -31,11 +60,26 @@ half ComputeMeniscusWeight(const int2 positionSS, const float mask, const float2
 	float2 offset = (float2)-mask * horizonNormal;
 	float multiplier = 0.9;
 
+#if CREST_WATER_VOLUME
+	// The meniscus at the boundary can be at a distance. We need to scale the offset as 1 pixel at a distance is much
+	// larger than 1 pixel up close.
+	const float scale = 1.0 - saturate(meniscusDepth / MENISCUS_MAXIMUM_DISTANCE);
+
+	// Exit early.
+	if (scale == 0.0)
+	{
+		return 1.0;
+	}
+#else
+	// Dummy value.
+	const float scale = 0.0;
+#endif
+
 	// Sample three pixels along the normal. If the sample is different than the current mask, apply meniscus.
 	// Offset must be added to positionSS as floats.
-	weight *= (LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS + offset * 1.0).r != mask) ? multiplier : 1.0;
-	weight *= (LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS + offset * 2.0).r != mask) ? multiplier : 1.0;
-	weight *= (LOAD_TEXTURE2D_X(_CrestOceanMaskTexture, positionSS + offset * 3.0).r != mask) ? multiplier : 1.0;
+	weight *= (MeniscusSampleOceanMask(mask, positionSS, offset, 1.0, scale) != mask) ? multiplier : 1.0;
+	weight *= (MeniscusSampleOceanMask(mask, positionSS, offset, 2.0, scale) != mask) ? multiplier : 1.0;
+	weight *= (MeniscusSampleOceanMask(mask, positionSS, offset, 3.0, scale) != mask) ? multiplier : 1.0;
 #endif // _FULL_SCREEN_EFFECT
 #endif // CREST_MENISCUS
 	return weight;
@@ -43,6 +87,7 @@ half ComputeMeniscusWeight(const int2 positionSS, const float mask, const float2
 
 void GetOceanSurfaceAndUnderwaterData
 (
+	const float4 positionCS,
 	const int2 positionSS,
 	const float rawOceanDepth,
 	const float mask,
@@ -53,18 +98,49 @@ void GetOceanSurfaceAndUnderwaterData
 	const float oceanDepthTolerance
 )
 {
-	isOceanSurface = (rawDepth < rawOceanDepth + oceanDepthTolerance);
+	isOceanSurface = false;
 	isUnderwater = mask == UNDERWATER_MASK_BELOW_SURFACE;
 
-	// Merge ocean depth with scene depth.
-	if (isOceanSurface)
+#if defined(CREST_WATER_VOLUME_HAS_BACKFACE) || defined(CREST_WATER_VOLUME_BACK_FACE)
+	const float rawGeometryDepth =
+#if CREST_WATER_VOLUME_HAS_BACKFACE
+	// 3D has a back face texture for the depth.
+	LOAD_DEPTH_TEXTURE_X(_CrestWaterVolumeBackFaceTexture, positionSS);
+#else
+	// Volume is rendered using the back face so that is the depth.
+	positionCS.z;
+#endif // CREST_WATER_VOLUME_HAS_BACKFACE
+	;
+
+	// Use backface depth if closest.
+	if (rawDepth < rawGeometryDepth && rawOceanDepth < rawGeometryDepth)
 	{
+		// Cancels out caustics.
+		isOceanSurface = true;
+		rawDepth = rawGeometryDepth;
+		// No need to multi-sample.
+		sceneZ = CrestLinearEyeDepth(rawDepth);
+		return;
+	}
+#endif // CREST_WATER_VOLUME
+
+	// Merge ocean depth with scene depth.
+	if (rawDepth < rawOceanDepth + oceanDepthTolerance)
+	{
+		isOceanSurface = true;
 		rawDepth = rawOceanDepth;
 		sceneZ = CrestLinearEyeDepth(CREST_MULTILOAD_DEPTH(_CrestOceanMaskDepthTexture, positionSS, rawDepth));
 	}
 	else
 	{
+#if CREST_WATER_VOLUME_HAS_BACKFACE
+		// If multi-loaded, the deepest depth could be behind the back face. Need a combined depth. But would also need
+		// to redesign the passes to not render caustics on the back face.
+		sceneZ = CrestLinearEyeDepth(rawDepth);
+#else
+		// For small water volumes this will have the opposite effect.
 		sceneZ = CrestLinearEyeDepth(CREST_MULTILOAD_SCENE_DEPTH(positionSS, rawDepth));
+#endif
 	}
 }
 
@@ -78,6 +154,7 @@ half3 ApplyUnderwaterEffect
 	const float3 lightDir,
 	const float rawDepth,
 	const float sceneZ,
+	const float fogDistance,
 	const half3 view,
 	const bool isOceanSurface
 )
@@ -145,8 +222,18 @@ half3 ApplyUnderwaterEffect
 	}
 #endif // _CAUSTICS_ON
 
-	return lerp(sceneColour, scatterCol, saturate(1.0 - exp(-_DepthFogDensity.xyz * sceneZ)));
+	return lerp(sceneColour, scatterCol, saturate(1.0 - exp(-_DepthFogDensity.xyz * fogDistance)));
 }
 #endif // CREST_OCEAN_EMISSION_INCLUDED
+
+void ApplyWaterVolumeToUnderwaterFogAndMeniscus(float4 positionCS, inout float fogDistance, inout float meniscusDepth)
+{
+#if CREST_WATER_VOLUME_FRONT_FACE
+	float depth = CrestLinearEyeDepth(positionCS.z);
+	// Meniscus is rendered at the boundary so use the geometry z.
+	meniscusDepth = depth;
+	fogDistance -= depth;
+#endif
+}
 
 #endif // CREST_UNDERWATER_EFFECT_SHARED_INCLUDED

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskHorizonShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskHorizonShared.hlsl
@@ -9,6 +9,9 @@
 
 #include "../OceanConstants.hlsl"
 #include "../OceanGlobals.hlsl"
+#include "../OceanShaderHelpers.hlsl"
+
+#include "../Helpers/WaterVolume.hlsl"
 
 // Driven by scripting. It is a non-linear converted from a linear 0-1 value.
 float _FarPlaneOffset;

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
@@ -12,6 +12,8 @@
 #include "../OceanVertHelpers.hlsl"
 #include "../OceanShaderHelpers.hlsl"
 
+#include "../Helpers/WaterVolume.hlsl"
+
 struct Attributes
 {
 	// The old unity macros require this name and type.
@@ -117,6 +119,12 @@ Varyings Vert(Attributes v)
 
 half4 Frag(const Varyings input, const bool i_isFrontFace : SV_IsFrontFace) : SV_Target
 {
+	UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+#if CREST_WATER_VOLUME
+	ApplyVolumeToOceanMask(input.positionCS);
+#endif
+
 	// @MSAAOutlineFix:
 	// The edge of the ocean surface at the near plane will be MSAA'd leaving a noticeable edge. By rendering the mask
 	// with a slightly further near plane, it exposes the edge to having the underwater fog applied which is much nicer.

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,6 +13,13 @@ Release Notes
 |version|
 ---------
 
+Preview
+^^^^^^^
+.. bullet_list::
+
+   -  Add portals and volumes to *Underwater Renderer* (affects both underwater and ocean surface).
+      See :ref:`portals-volumes` for more information.
+
 Changed
 ^^^^^^^
 .. bullet_list::

--- a/docs/user/underwater.rst
+++ b/docs/user/underwater.rst
@@ -70,7 +70,14 @@ Setup
 Parameters
 ^^^^^^^^^^
 
-|  **Depth Fog Density Factor:** Reduces the underwater depth fog density by a factor.
+-  **Mode:** How the underwater effect (and ocean surface) is rendered:
+
+   -  **Full-Screen:** Full screen effect.
+   -  **Portal:** Renders the underwater effect and ocean surface from the geometry's front-face and behind it.
+   -  **Volume:** Renders the underwater effect and ocean surface from the geometry's front-face to its back-face.
+   -  **Volume (Fly-Through):** Renders the underwater effect and ocean surface from the geometry's front-face to its back-face - even from within the volume.
+
+-  **Depth Fog Density Factor:** Reduces the underwater depth fog density by a factor.
    Useful to reduce the intensity of the fog independently from the ocean surface.
 
 
@@ -92,6 +99,33 @@ Parameters
       See *Ocean-Underwater.mat* for an example.
 
    -  Place *UnderWaterCurtainGeom* and *UnderWaterMeniscus* prefabs under the camera (with cleared transform).
+
+.. _detecting_above_or_below_water:
+
+Detecting Above or Below Water
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The *OceanRenderer* component has the *ViewerHeightAboveWater* property which can be accessed with ``OceanRenderer.Instance.ViewerHeightAboveWater``.
+It will return the signed height from the ocean surface of the camera rendering the ocean.
+Internally this uses the *SampleHeightHelper* class which can be found in *SamplingHelpers.cs*.
+
+There is also the *OceanSampleHeightEvents* example component (requires example content to be imported) which uses :link:`UnityEvents <{UnityDocLink}/UnityEvents.html>` to provide a scriptless approach to triggering changes.
+Simply attach it to a game object, and it will invoke a UnityEvent when the attached game object is above or below the ocean surface once per state change. A common use case is to use it to trigger different audio when above or below the surface.
+
+
+.. _portals-volumes:
+
+Portals & Volumes
+^^^^^^^^^^^^^^^^^
+
+.. admonition:: Preview
+
+   This feature is in preview and may change in the future.
+
+The underwater effect can be rendered from a provided mesh which will effectively become a portal (2D) or volume (3D).
+Change the *Mode* property to one of your choosing and set the *Volume Geometry* to a *Mesh Filter* (it will use its transform).
+This feature also clips the ocean surface to match.
+A common use case would be a window on a boat.
 
 
 .. only:: hdrp
@@ -131,16 +165,3 @@ Parameters
    #. Configure the ocean material for underwater rendering.
       Ensure that *Double-Sided* is enabled under *Surface Options* on the ocean material so that the underside of the ocean surface renders.
       See *Ocean-Underwater.mat* for an example.
-
-
-.. _detecting_above_or_below_water:
-
-Detecting Above or Below Water
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The *OceanRenderer* component has the *ViewerHeightAboveWater* property which can be accessed with ``OceanRenderer.Instance.ViewerHeightAboveWater``.
-It will return the signed height from the ocean surface of the camera rendering the ocean.
-Internally this uses the *SampleHeightHelper* class which can be found in *SamplingHelpers.cs*.
-
-There is also the *OceanSampleHeightEvents* example component (requires example content to be imported) which uses :link:`UnityEvents <{UnityDocLink}/UnityEvents.html>` to provide a scriptless approach to triggering changes.
-Simply attach it to a game object, and it will invoke a UnityEvent when the attached game object is above or below the ocean surface once per state change. A common use case is to use it to trigger different audio when above or below the surface.


### PR DESCRIPTION
Adds a feature to render the underwater effect from a provided mesh. New options highlighted in yellow:

<img width="2032" alt="Portals" src="https://user-images.githubusercontent.com/5249806/146740420-fc42d9e4-b775-4da9-9335-649f874b0e8b.png">

There are four modes:
- Full Screen: Same as before
- Geometry 2D: Only front face. Fog depth is to the far plane
- Geometry 3D: Front face and back face to create a volume of water
- Geometry Volume: As above but can fly through

For the _Geometry Volume_ option, the stencil buffer is used. It is a separate stencil buffer context so it will not interfere with the global stencil buffer.

Two global keywords have been used. But these are unlimited in 2022.

## Performance

- Higher memory usage due to extra variants for ocean shader and extra passes for underwater. They are not stripped from builds so it is a new baseline cost **(1MB)**
- Every frame SetUpBoundary is called which is new cost but probably negligible
- Full screen should have same performance as before **(Yes)**
- 2D has 1 extra SS texture for front-faces and extra pass to populate. Might be more expensive due to mesh vs FST
- 3D in addition has another extra SS texture for back faces and extra pass to populate
- Volume in addition uses the stencil buffer which requires copy/clear passes to populate and make separate from global stencil buffer. It has two extra passes to fog things but no passes retreads old ground

### Memory Cost

I didn't see anything unexpected. 1MB new baseline cost due to shader passes/variants. And just the cost for each texture.

### Shader Cost

1660 Ti. Following times are for the entire transparent pass.

- Full-Screen Before: ~3.12ms
- Full-Screen After: ~3.08ms
- Portal (Quad): ~3.54ms
- Volume (Sphere): ~3.12ms
- Volume FT (Sphere): ~3.36ms

Portal, Volume and Volume FT are averages of three runs. Fluctuated quite a bit from 2.64ms to 4.11ms (fluctuation was mostly in the mask). But it appears that we are looking at a ~0.5ms extra cost when using one of these modes.

~~Will check shader and memory costs soon.~~

## TODO

- [x] Caustics fade away at a distance due to scene depth applied to depth of field.
- [ ] Remove test data
- [x] Profile

## Testing

Open the _Demo_ scene. Anything under Demo will be deleted before merging.