### PR TITLE
Allow any renderer as Ocean Input

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -58,7 +58,7 @@ namespace Crest
     {
 #if UNITY_EDITOR
         [SerializeField, Tooltip("Check that the shader applied to this object matches the input type (so e.g. an Animated Waves input object has an Animated Waves input shader.")]
-        [Predicated(typeof(MeshRenderer)), DecoratedField]
+        [Predicated(typeof(Renderer)), DecoratedField]
         bool _checkShaderName = true;
 #endif
 
@@ -90,7 +90,7 @@ namespace Crest
             return registered;
         }
 
-        protected Renderer _renderer;
+        internal Renderer _renderer;
         protected Material _material;
         SampleHeightHelper _sampleHelper = new SampleHeightHelper();
 
@@ -106,7 +106,7 @@ namespace Crest
 #if UNITY_EDITOR
                 if (Application.isPlaying && _checkShaderName && verifyShader)
                 {
-                    ValidatedHelper.ValidateRenderer(gameObject, ValidatedHelper.DebugLog, ShaderPrefix);
+                    ValidatedHelper.ValidateRenderer<Renderer>(gameObject, ValidatedHelper.DebugLog, ShaderPrefix);
                 }
 #endif
 
@@ -183,7 +183,7 @@ namespace Crest
     {
         protected const string k_displacementCorrectionTooltip = "Whether this input data should displace horizontally with waves. If false, data will not move from side to side with the waves. Adds a small performance overhead when disabled.";
 
-        [SerializeField, Predicated(typeof(MeshRenderer)), DecoratedField]
+        [SerializeField, Predicated(typeof(Renderer)), DecoratedField]
         bool _disableRenderer = true;
 
         protected abstract Color GizmoColor { get; }
@@ -209,7 +209,17 @@ namespace Crest
                 var rend = GetComponent<Renderer>();
                 if (rend)
                 {
-                    rend.enabled = false;
+                    if (rend is TrailRenderer || rend is LineRenderer)
+                    {
+                        // If we disable using "enabled" then the line/trail positions will not be updated. This keeps
+                        // the scripting side of the component running and just disables the rendering. Similar to
+                        // disabling the Renderer module on the Particle System.
+                        rend.forceRenderingOff = true;
+                    }
+                    else
+                    {
+                        rend.enabled = false;
+                    }
                 }
             }
 
@@ -412,7 +422,7 @@ namespace Crest
 
         public virtual bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
-            var isValid = ValidatedHelper.ValidateRenderer(gameObject, showMessage, RendererRequired, RendererOptional, ShaderPrefix);
+            var isValid = ValidatedHelper.ValidateRenderer<Renderer>(gameObject, showMessage, RendererRequired, RendererOptional, ShaderPrefix);
 
             if (ocean != null && !FeatureEnabled(ocean))
             {
@@ -437,7 +447,25 @@ namespace Crest
     }
 
     [CustomEditor(typeof(RegisterLodDataInputBase), true), CanEditMultipleObjects]
-    class RegisterLodDataInputBaseEditor : ValidatedEditor { }
+    class RegisterLodDataInputBaseEditor : ValidatedEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            // Show a note of what renderer we are currently using.
+            var target = this.target as RegisterLodDataInputBase;
+            if (target._renderer != null)
+            {
+                // Enable rich text in help boxes. Store original so we can revert since this might be a "hack".
+                var styleRichText = GUI.skin.GetStyle("HelpBox").richText;
+                GUI.skin.GetStyle("HelpBox").richText = true;
+                EditorGUILayout.HelpBox($"Using renderer of type <i>{target._renderer.GetType()}</i>", MessageType.Info);
+                // Revert skin since it persists.
+                GUI.skin.GetStyle("HelpBox").richText = styleRichText;
+            }
+
+            base.OnInspectorGUI();
+        }
+    }
 
     public abstract partial class RegisterLodDataInputWithSplineSupport<LodDataType, SplinePointCustomData>
     {
@@ -452,7 +480,7 @@ namespace Crest
             {
                 showMessage
                 (
-                    "A <i>Crest Spline</i> component is required to drive this data. Alternatively a <i>MeshRenderer</i> can be added. Neither is currently attached to ocean input.",
+                    "A <i>Crest Spline</i> component is required to drive this data. Alternatively a <i>Renderer</i> can be added. Neither is currently attached to ocean input.",
                     "Attach a <i>Crest Spline</i> component.",
                     ValidatedHelper.MessageType.Error, gameObject,
                     ValidatedHelper.FixAttachComponent<Spline.Spline>

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -112,14 +112,14 @@ namespace Crest
             PackageManagerHelpers.AddMissingPackage("com.unity.burst");
         }
 
-        public static bool ValidateRenderer(GameObject gameObject, ShowMessage showMessage, string shaderPrefix)
+        public static bool ValidateRenderer<T>(GameObject gameObject, ShowMessage showMessage, string shaderPrefix) where T : Renderer
         {
-            return ValidateRenderer(gameObject, showMessage, isRendererRequired: true, isRendererOptional: false, shaderPrefix);
+            return ValidateRenderer<T>(gameObject, showMessage, isRendererRequired: true, isRendererOptional: false, shaderPrefix);
         }
 
-        public static bool ValidateRenderer(GameObject gameObject, ShowMessage showMessage, bool isRendererRequired, bool isRendererOptional, string shaderPrefix = null)
+        public static bool ValidateRenderer<T>(GameObject gameObject, ShowMessage showMessage, bool isRendererRequired, bool isRendererOptional, string shaderPrefix = null) where T : Renderer
         {
-            gameObject.TryGetComponent<MeshRenderer>(out var renderer);
+            gameObject.TryGetComponent<T>(out var renderer);
 
             if (isRendererRequired)
             {
@@ -131,9 +131,18 @@ namespace Crest
                         return true;
                     }
 
+                    var type = typeof(T);
+                    var name = type.Name;
+
+                    // Give users a hint as to what "Renderer" really means.
+                    if (type == typeof(Renderer))
+                    {
+                        name += " (Mesh, Trail etc)";
+                    }
+
                     showMessage
                     (
-                        "A MeshRenderer component is required but none is attached to ocean input.",
+                        $"A <i>{name}</i> component is required but none is attached to ocean input.",
                         "Attach a <i>MeshRenderer</i> component.",
                         MessageType.Error, gameObject,
                         FixAttachComponent<MeshRenderer>

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -880,7 +880,7 @@ namespace Crest
             // Renderer
             if (_mode == GerstnerMode.Geometry)
             {
-                isValid = ValidatedHelper.ValidateRenderer(gameObject, showMessage, "Crest/Inputs/Animated Waves/Gerstner");
+                isValid = ValidatedHelper.ValidateRenderer<MeshRenderer>(gameObject, showMessage, "Crest/Inputs/Animated Waves/Gerstner");
             }
             else if (_mode == GerstnerMode.Global && GetComponent<MeshRenderer>() != null)
             {

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -37,6 +37,7 @@ Changed
    -  Improve multiple *Water Body* overlapping case when *Water Body > Override Material* option is used.
    -  Water Body adds an inclusion to clipping (ie unclips) if *Default Clipping State* is *Everything Clipped*.
    -  Add scroll bar to *Ocean Debug GUI* when using *Draw LOD Datas Actual Size*.
+   -  Add support for *TrailRenderer*, *LineRenderer* and *ParticleSystem* to be used as ocean inputs in addition to *MeshRenderer*.
 
 Fixed
 ^^^^^

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -12,6 +12,10 @@ user input, as covered in this video:
 
    Basics of Adding Ocean Inputs
 
+.. tip::
+
+   For inputs, you are not limited to only using a :link:`MeshRenderer <{UnityDocsLinkBase}class-MeshRenderer.html>`.
+   Almost any renderer can be used like a :link:`TrailRenderer <{UnityDocsLinkBase}class-TrailRenderer.html>`, :link:`LineRenderer <{UnityDocsLinkBase}class-LineRenderer.html>` or :link:`ParticleSystem <{UnityDocsLinkBase}class-ParticleSystem.html>`.
 
 The following shaders can be used with any ocean input:
 


### PR DESCRIPTION
Validation only allowed MeshRenderer to be used as an Ocean Input. Now anything deriving from Renderer (include particles) can be used. Also changes the behaviour of "disabled renderer" for trails and lines to only disable the rendering so the trails continue to update.

Foam and TrailRenderer go really well together.

The downside to this PR is that it could be a breaking change if someone has multiple renderers on the same GO. I've added a help box to the top of the component to inform the user of what renderer it is using.

Also, they aren't straightforward to use as the are quads so they need to be aligned the right way. But we have that issue with mesh renderer too.