### PR TITLE
Add TiledTexture shader struct

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Ocean.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Ocean.shader
@@ -266,6 +266,8 @@ Shader "Crest/Ocean"
 			#include "Helpers/BIRP/Core.hlsl"
 			#include "Helpers/BIRP/InputsDriven.hlsl"
 
+			#include "ShaderLibrary/Common.hlsl"
+
 			#include "OceanGlobals.hlsl"
 			#include "OceanInputsDriven.hlsl"
 			#include "OceanShaderData.hlsl"
@@ -552,9 +554,9 @@ Shader "Crest/Ocean"
 
 				#if _APPLYNORMALMAPPING_ON
 				#if _FLOW_ON
-				ApplyNormalMapsWithFlow(positionXZWSUndisplaced, input.flow_shadow.xy, lodAlpha, cascadeData0, instanceData, n_pixel);
+				ApplyNormalMapsWithFlow(_NormalsTiledTexture, positionXZWSUndisplaced, input.flow_shadow.xy, lodAlpha, cascadeData0, instanceData, n_pixel);
 				#else
-				n_pixel.xz += SampleNormalMaps(positionXZWSUndisplaced, lodAlpha, cascadeData0, instanceData);
+				n_pixel.xz += SampleNormalMaps(_NormalsTiledTexture, positionXZWSUndisplaced, lodAlpha, cascadeData0, instanceData);
 				#endif
 				#endif
 
@@ -637,7 +639,6 @@ Shader "Crest/Ocean"
 					sceneZ,
 					rawDepth,
 					bubbleCol,
-					_Normals,
 					underwater,
 					scatterCol,
 					cascadeData0,

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -56,11 +56,12 @@ half3 ScatterColour
 #if _CAUSTICS_ON
 void ApplyCaustics
 (
+	in const WaveHarmonic::Crest::TiledTexture i_causticsTexture,
+	in const WaveHarmonic::Crest::TiledTexture i_distortionTexture,
 	in const int2 i_positionSS,
 	in const float3 i_scenePos,
 	in const half3 i_lightDir,
 	in const float i_sceneZ,
-	in sampler2D i_normals,
 	in const bool i_underwater,
 	inout half3 io_sceneColour,
 	in const CascadeParams cascadeData0,
@@ -87,9 +88,9 @@ void ApplyCaustics
 	// Removing the fudge factor (4.0) will cause the caustics to move around more with the waves. But this will also
 	// result in stretched/dilated caustics in certain areas. This is especially noticeable on angled surfaces.
 	float2 surfacePosXZ = i_scenePos.xz + i_lightDir.xz * sceneDepth / (4.*i_lightDir.y);
-	half2 causticN = _CausticsDistortionStrength * UnpackNormal(tex2D(i_normals, surfacePosXZ / _CausticsDistortionScale)).xy;
-	float4 cuv1 = float4((surfacePosXZ / _CausticsTextureScale + 1.3 *causticN + float2(0.044*_CrestTime + 17.16, -0.169*_CrestTime)), 0., mipLod);
-	float4 cuv2 = float4((1.37*surfacePosXZ / _CausticsTextureScale + 1.77*causticN + float2(0.248*_CrestTime, 0.117*_CrestTime)), 0., mipLod);
+	half2 causticN = _CausticsDistortionStrength * UnpackNormal(i_distortionTexture.Sample(surfacePosXZ / _CausticsDistortionScale)).xy;
+	float3 cuv1 = float3((surfacePosXZ / i_causticsTexture._scale + 1.3 * causticN + float2(0.044 * _CrestTime + 17.16, -0.169 * _CrestTime)), mipLod);
+	float3 cuv2 = float3((1.37 * surfacePosXZ / i_causticsTexture._scale + 1.77 * causticN + float2(0.248 * _CrestTime, 0.117 * _CrestTime)), mipLod);
 
 	half causticsStrength = _CausticsStrength;
 
@@ -105,7 +106,11 @@ void ApplyCaustics
 #endif // _SHADOWS_ON
 
 	io_sceneColour.xyz *= 1.0 + causticsStrength *
-		(0.5*tex2Dlod(_CausticsTexture, cuv1).xyz + 0.5*tex2Dlod(_CausticsTexture, cuv2).xyz - _CausticsTextureAverage);
+	(
+		0.5 * i_causticsTexture.SampleLevel(cuv1.xy, cuv1.z).xyz +
+		0.5 * i_causticsTexture.SampleLevel(cuv2.xy, cuv2.z).xyz -
+		_CausticsTextureAverage
+	);
 }
 #endif // _CAUSTICS_ON
 
@@ -123,7 +128,6 @@ half3 OceanEmission
 	in const float i_sceneZ,
 	const float i_rawDepth,
 	in const half3 i_bubbleCol,
-	in sampler2D i_normals,
 	in const bool i_underwater,
 	in const half3 i_scatterCol,
 	in const CascadeParams cascadeData0,
@@ -173,7 +177,7 @@ half3 OceanEmission
 		sceneColour = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_BackgroundTexture, uvBackgroundRefract).rgb;
 #if _CAUSTICS_ON
 		float3 scenePos = _WorldSpaceCameraPos - i_view * i_sceneZ / dot(unity_CameraToWorld._m02_m12_m22, -i_view);
-		ApplyCaustics(i_positionSS, scenePos, i_lightDir, i_sceneZ, i_normals, i_underwater, sceneColour, cascadeData0, cascadeData1);
+		ApplyCaustics(_CausticsTiledTexture, _CausticsDistortionTiledTexture, i_positionSS, scenePos, i_lightDir, i_sceneZ, i_underwater, sceneColour, cascadeData0, cascadeData1);
 #endif
 		alpha = 1.0 - exp(-_DepthFogDensity.xyz * depthFogDistance);
 	}

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
@@ -17,17 +17,12 @@ float4 _CameraDepthTexture_TexelSize;
 
 TEXTURE2D_X(_CrestScreenSpaceShadowTexture);
 
-// NOTE: _Normals is used outside of _APPLYNORMALMAPPING_ON so we cannot surround it here.
-sampler2D _Normals;
 sampler2D _ReflectionTex;
 #if _OVERRIDEREFLECTIONCUBEMAP_ON
 samplerCUBE _ReflectionCubemapOverride;
 #endif
 #if _FOAM_ON
 sampler2D _FoamTexture;
-#endif
-#if _CAUSTICS_ON
-sampler2D _CausticsTexture;
 #endif
 
 /////////////////////////////
@@ -58,10 +53,19 @@ half4 _DepthFogDensity;
 // Normals
 // ----------------------------------------------------------------------------
 
+#if defined(_APPLYNORMALMAPPING_ON) || defined(_CAUSTICS_ON)
+// NOTE: _Normals is used outside of _APPLYNORMALMAPPING_ON so we cannot surround it here.
+Texture2D _Normals;
+SamplerState sampler_Normals;
+float4 _Normals_TexelSize;
+#endif
+
 half _NormalsStrengthOverall;
 #if _APPLYNORMALMAPPING_ON
 half _NormalsStrength;
 half _NormalsScale;
+static const WaveHarmonic::Crest::TiledTexture _NormalsTiledTexture =
+    WaveHarmonic::Crest::TiledTexture::Make(_Normals, sampler_Normals, _Normals_TexelSize, _NormalsScale);
 #endif
 
 // ----------------------------------------------------------------------------
@@ -149,6 +153,15 @@ half _CausticsFocalDepth;
 half _CausticsDepthOfField;
 half _CausticsDistortionScale;
 half _CausticsDistortionStrength;
+
+Texture2D _CausticsTexture;
+SamplerState sampler_CausticsTexture;
+float4 _CausticsTexture_TexelSize;
+
+static const WaveHarmonic::Crest::TiledTexture _CausticsTiledTexture =
+    WaveHarmonic::Crest::TiledTexture::Make(_CausticsTexture, sampler_CausticsTexture, _CausticsTexture_TexelSize, _CausticsTextureScale);
+static const WaveHarmonic::Crest::TiledTexture _CausticsDistortionTiledTexture =
+    WaveHarmonic::Crest::TiledTexture::Make(_Normals, sampler_Normals, _Normals_TexelSize, _CausticsDistortionScale);
 #endif
 
 // Hack - due to SV_IsFrontFace occasionally coming through as true for backfaces,

--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Common.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Common.hlsl
@@ -1,0 +1,5 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+#include "./Texture.hlsl"

--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Common.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Common.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: c64353b737aa24f1f83ce6ef3bcebf11
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Texture.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Texture.hlsl
@@ -1,0 +1,45 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace WaveHarmonic
+{
+	namespace Crest
+	{
+		struct TiledTexture
+		{
+			Texture2D _texture;
+			SamplerState _sampler;
+			half _size;
+			half _scale;
+
+			static TiledTexture Make
+			(
+				in const Texture2D i_texture,
+				in const SamplerState i_sampler,
+				in const float4 i_size,
+				in const half i_scale
+			)
+			{
+				// "texture" is a reserved word.
+				TiledTexture _texture;
+				_texture._texture = i_texture;
+				_texture._sampler = i_sampler;
+				_texture._scale = i_scale;
+				// Safely assume a square texture.
+				_texture._size = i_size.z;
+				return _texture;
+			}
+
+			half4 Sample(float2 uv)
+			{
+				return _texture.Sample(_sampler, uv);
+			}
+
+			half4 SampleLevel(float2 uv, float lod)
+			{
+				return _texture.SampleLevel(_sampler, uv, lod);
+			}
+		};
+	}
+}

--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Texture.hlsl.meta
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Texture.hlsl.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e2a3338b1e1fd4a3dab1749fd2847f1c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -51,6 +51,8 @@ Shader "Crest/Underwater Curtain"
 
 			#include "../Helpers/BIRP/Core.hlsl"
 
+			#include "../ShaderLibrary/Common.hlsl"
+
 			#include "../OceanGlobals.hlsl"
 			#include "../OceanInputsDriven.hlsl"
 			#include "../OceanShaderData.hlsl"
@@ -219,7 +221,7 @@ Shader "Crest/Underwater Curtain"
 				if (sceneZ01 != 0.0)
 				{
 					float3 scenePos = _WorldSpaceCameraPos - view * sceneZ / dot(unity_CameraToWorld._m02_m12_m22, -view);
-					ApplyCaustics(input.positionCS.xy, scenePos, lightDir, sceneZ, _Normals, true, sceneColour, cascadeData0, cascadeData1);
+					ApplyCaustics(_CausticsTiledTexture, _CausticsDistortionTiledTexture, input.positionCS.xy, scenePos, lightDir, sceneZ, true, sceneColour, cascadeData0, cascadeData1);
 				}
 #endif // _CAUSTICS_ON
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffect.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffect.hlsl
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+#include "../ShaderLibrary/Common.hlsl"
+
 #include "../OceanGlobals.hlsl"
 #include "../OceanInputsDriven.hlsl"
 #include "../OceanShaderData.hlsl"

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
@@ -209,11 +209,12 @@ half3 ApplyUnderwaterEffect
 	{
 		ApplyCaustics
 		(
+			_CausticsTiledTexture,
+			_CausticsDistortionTiledTexture,
 			i_positionSS,
 			scenePos,
 			lightDir,
 			sceneZ,
-			_Normals,
 			true,
 			sceneColour,
 			_CrestCascadeData[sliceIndex],


### PR DESCRIPTION
Refactors our tiled (foam, caustics etc) texture usage.

Key points:
- creates a TiledTexture struct which holds all of the relevant data
- migrates from tex2D and friends to Texture2D
- will be further expanded in #951 which prompted this refactor
- uses namespaces (prompted by #943) and statics

I will be adding functions to the struct for handling floating origin. Not using a struct has become clunky.

As for namespaces, #943 means that our code is included in other people's shaders which could mean naming conflicts. We could just prefix everything but this is much nicer. It looks verbose right because I haven't added the namespace everywhere which would remove the need WaveHarmonic::Crest everywhere. Will do that in another PR.

A final note is that there is proxy methods for Sample and SampleLevel. From what I read, all functions get inlined so this should have zero cost.

LMKWYT!