### PR TITLE
ShapeGerstner revival

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -783,16 +783,6 @@ namespace Crest
                 );
             }
 
-            if (showMessage == ValidatedHelper.HelpBox)
-            {
-                showMessage
-                (
-                    "The <i>ShapeGerstner</i> component is now obsolete.",
-                    "Prefer using <i>ShapeFFT</i> instead.",
-                    ValidatedHelper.MessageType.Warning, this
-                );
-            }
-
             return isValid;
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -57,6 +57,9 @@ namespace Crest
         [Tooltip("How much these waves respect the shallow water attenuation setting in the Animated Waves Settings. Set to 0 to ignore shallow water."), SerializeField, Range(0f, 1f)]
         public float _respectShallowWaterAttenuation = 1f;
 
+        [Tooltip("Each Gerstner wave is actually a pair of waves travelling in opposite directions (similar to FFT). This weight is applied to the wave travelling in against-wind direction. Set to 0 to obtain simple single waves."), Range(0f, 1f)]
+        public float _reverseWaveWeight = 0.5f;
+
         [Header("Generation Settings")]
         [Delayed, Tooltip("How many wave components to generate in each octave.")]
         public int _componentsPerOctave = 8;
@@ -552,7 +555,7 @@ namespace Crest
             {
                 var amp = _weight * _activeSpectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave, windSpeed, out _powers[i]);
                 _amplitudes[i] = Random.value * amp;
-                _amplitudes2[i] = Random.value * amp * 0.5f;
+                _amplitudes2[i] = Random.value * amp * _reverseWaveWeight;
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -250,8 +250,8 @@ namespace Crest
         {
             var diameter = 0.5f * (1 << cascadeIdx);
             var texelSize = diameter / _resolution;
-            // Nyquist rate
-            return texelSize * 2f;
+            // Nyquist rate x 2, for higher quality
+            return texelSize * 4f;
         }
 
         public void CrestUpdate(CommandBuffer buf)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -38,6 +38,7 @@ Changed
    -  Water Body adds an inclusion to clipping (ie unclips) if *Default Clipping State* is *Everything Clipped*.
    -  Add scroll bar to *Ocean Debug GUI* when using *Draw LOD Datas Actual Size*.
    -  Add support for *TrailRenderer*, *LineRenderer* and *ParticleSystem* to be used as ocean inputs in addition to *MeshRenderer*.
+   -  Un-deprecate *ShapeGerstner* as it is useful in some situations for adding a small number of distinct waves with high degree of control.
 
 Fixed
 ^^^^^

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -39,6 +39,7 @@ Changed
    -  Add scroll bar to *Ocean Debug GUI* when using *Draw LOD Datas Actual Size*.
    -  Add support for *TrailRenderer*, *LineRenderer* and *ParticleSystem* to be used as ocean inputs in addition to *MeshRenderer*.
    -  Un-deprecate *ShapeGerstner* as it is useful in some situations for adding a small number of distinct waves with high degree of control.
+   -  Add *Reverse Wave Weight* setting to *ShapeGerstner* for fine control over generated wave pairs.
 
 Fixed
 ^^^^^

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -40,6 +40,7 @@ Changed
    -  Add support for *TrailRenderer*, *LineRenderer* and *ParticleSystem* to be used as ocean inputs in addition to *MeshRenderer*.
    -  Un-deprecate *ShapeGerstner* as it is useful in some situations for adding a small number of distinct waves with high degree of control.
    -  Add *Reverse Wave Weight* setting to *ShapeGerstner* for fine control over generated wave pairs.
+   -  Double sample count for *ShapeGerstner* waves to improve quality.
 
 Fixed
 ^^^^^

--- a/docs/user/wave-conditions.rst
+++ b/docs/user/wave-conditions.rst
@@ -17,6 +17,8 @@ Wave Systems
 
 The *ShapeFFT* component is used to generate waves in Crest.
 
+For advanced situations where a high level of control is required over the wave shape, the *ShapeGerstner* component can be used to add specific wave components.
+
 .. _wave-authoring-section:
 
 Authoring


### PR DESCRIPTION
Based on discord discussions - bring ShapeGerstner back from the grave as it is useful for situations where a small number of highly controlled wave trains are required:

* Discrete shoreline wave trains
* Adding a few large wavelength "layout" waves that set the overall shape of the ocean

Also adds control over "reverse" waves so that pure trochoids can be produced if desired.
