### PR TITLE
Underwater rendering in Edit Mode

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
@@ -53,6 +53,21 @@ namespace Crest.EditorHelpers
                 UnityEditorInternal.InternalEditorUtility.layers);
             return UnityEditorInternal.InternalEditorUtility.ConcatenatedLayersMaskToLayerMask(temporary);
         }
+
+        /// <summary>Attempts to get the scene view this camera is rendering.</summary>
+        /// <returns>The scene view or null if not found.</returns>
+        public static SceneView GetSceneViewFromSceneCamera(Camera camera)
+        {
+            foreach (SceneView sceneView in SceneView.sceneViews)
+            {
+                if (sceneView.camera == camera)
+                {
+                    return sceneView;
+                }
+            }
+
+            return null;
+        }
     }
 }
 

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -269,7 +269,7 @@ namespace Crest
 
         [SerializeField]
 #pragma warning disable 414
-        bool _showOceanProxyPlane = false;
+        internal bool _showOceanProxyPlane = false;
 #pragma warning restore 414
 #if UNITY_EDITOR
         GameObject _proxyPlane;
@@ -1157,9 +1157,12 @@ namespace Crest
             {
                 definitelyUnderwater = ViewerHeightAboveWater < -5f;
                 var density = UnderwaterDepthFogDensity = _material.GetVector("_DepthFogDensity") * UnderwaterRenderer.Instance.DepthFogDensityFactor;
-                var minimumFogDensity = Mathf.Min(Mathf.Min(density.x, density.y), density.z);
-                var underwaterCullLimit = Mathf.Clamp(_underwaterCullLimit, UNDERWATER_CULL_LIMIT_MINIMUM, UNDERWATER_CULL_LIMIT_MAXIMUM);
-                volumeExtinctionLength = -Mathf.Log(underwaterCullLimit) / minimumFogDensity;
+                if (Application.isPlaying)
+                {
+                    var minimumFogDensity = Mathf.Min(Mathf.Min(density.x, density.y), density.z);
+                    var underwaterCullLimit = Mathf.Clamp(_underwaterCullLimit, UNDERWATER_CULL_LIMIT_MINIMUM, UNDERWATER_CULL_LIMIT_MAXIMUM);
+                    volumeExtinctionLength = -Mathf.Log(underwaterCullLimit) / minimumFogDensity;
+                }
             }
 
             var canSkipCulling = WaterBody.WaterBodies.Count == 0 && _canSkipCulling;
@@ -1233,7 +1236,7 @@ namespace Crest
                 }
 
                 // Cull tiles the viewer cannot see through the underwater fog.
-                if (!isCulled && isUnderwaterActive)
+                if (!isCulled && isUnderwaterActive && Application.isPlaying)
                 {
                     isCulled = definitelyUnderwater && (Viewpoint.position - tile.Rend.bounds.ClosestPoint(Viewpoint.position)).magnitude >= volumeExtinctionLength;
                 }

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
@@ -84,6 +84,20 @@ namespace Crest
                 OceanRenderer.Instance.OceanMaterial.DisableKeyword("_OLD_UNDERWATER");
             }
 
+#if UNITY_EDITOR
+            // Check if scene view has disabled fog rendering.
+            if (_camera.cameraType == CameraType.SceneView)
+            {
+                var sceneView = EditorHelpers.EditorHelpers.GetSceneViewFromSceneCamera(_camera);
+                // Skip rendering if fog is disabled or for some reason we could not find the scene view.
+                if (sceneView == null || !sceneView.sceneViewState.fogEnabled)
+                {
+                    _underwaterEffectCommandBuffer?.Clear();
+                    return;
+                }
+            }
+#endif
+
             RenderTextureDescriptor descriptor = XRHelpers.GetRenderTextureDescriptor(_camera);
             descriptor.useDynamicScale = _camera.allowDynamicResolution;
 
@@ -174,7 +188,7 @@ namespace Crest
 
         internal void ExecuteEffect(CommandBuffer buffer, Material material, MaterialPropertyBlock properties = null)
         {
-            if (_mode == Mode.FullScreen)
+            if (_mode == Mode.FullScreen || _volumeGeometry == null)
             {
                 buffer.DrawProcedural
                 (
@@ -196,7 +210,7 @@ namespace Crest
 
                 buffer.DrawMesh
                 (
-                    _volumeGeometry.mesh,
+                    _volumeGeometry.sharedMesh,
                     _volumeGeometry.transform.localToWorldMatrix,
                     material,
                     submeshIndex: 0,
@@ -213,7 +227,7 @@ namespace Crest
                 {
                     buffer.DrawMesh
                     (
-                        _volumeGeometry.mesh,
+                        _volumeGeometry.sharedMesh,
                         _volumeGeometry.transform.localToWorldMatrix,
                         material,
                         submeshIndex: 0,

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -25,6 +25,8 @@ Changed
 .. bullet_list::
 
    -  Added new CPU-based collision provider - *Baked FFT Data*.
+   -  Add support for rendering in edit mode (camera preview and scene view) to *Underwater Renderer*.
+      It can be enabled/disabled with the fog scene view toggle.
    -  Add *CREST_OCEAN* scripting defines symbol.
    -  Add *Depth Fog Density Factor* to *Underwater Renderer* which can be used to decrease underwater fog intensity when underwater.
       Greatly improves shadows at shorelines.

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -94,6 +94,10 @@ Does Crest support orthographic projection?
 -------------------------------------------
 Yes. Please see :ref:`orthographic_projection`.
 
+How do I disable underwater fog rendering in the scene view?
+------------------------------------------------------------
+You can enable/disable rendering in the scene view by toggling fog in the :link:`scene view control bar <{UnityDocLink}/ViewModes.html>`.
+
 Can the density of the fog in the water be reduced?
 ---------------------------------------------------
 The density of the fog underwater can be controlled using the *Fog Density* parameter on the ocean material.

--- a/docs/user/underwater.rst
+++ b/docs/user/underwater.rst
@@ -30,6 +30,10 @@ Only the camera rendering the ocean surface will be used.
 Underwater Renderer
 -------------------
 
+.. note::
+
+   You can enable/disable rendering in the scene view by toggling fog in the :link:`scene view control bar <{UnityDocLink}/ViewModes.html>`.
+
 The *Underwater Renderer* component executes a fullscreen underwater effect between the transparent pass and post-processing pass.
 
 It is similar to a post-processing effect, but has the benefit of allowing other renderers to execute after it and still receive post-processing.


### PR DESCRIPTION
<img width="2032" alt="123" src="https://user-images.githubusercontent.com/5249806/148022961-7a32ffa3-c0e0-4e2b-9b00-56bd616c4aec.png">

Adds optional (enabled by default) underwater rendering to scene and preview cameras.

I've implemented it in the simplest way without impacting the standalone player. I believe it will be even simpler for SRPs.

It has some drawbacks:
- RT reference is shared but the RTs aren't due to different RT requirements. So RTs are recreated every frame each view is open (not an issue for HDRP now or URP in 2022)
- Disabled underwater being disabled when high enough above surface in edit mode
- Disable fog extinction culling in edit mode

It seems reliable which is surprising as adding edit mode support normally introduces many issues and complexities.