### PR TITLE
For scale changes, pull in 0.0 values at cascade start/end

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -45,10 +45,11 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	// Slice to sample previous frames data from. LOD change takes into account shifting of the cascades in scale.
 	const float sliceIndexSource = id.z + _LODChange;
 
-	// Off either end of the cascade - not useful to sample
+	// Off either end of the cascade - not useful to sample anything from previous frame. Always initialise
+	// with 0 values.
 	if (sliceIndexSource < 0.0 || sliceIndexSource >= depth - 1.0)
 	{
-		_LD_TexArray_Target[id] = 0;
+		_LD_TexArray_Target[id] = (float2)0;
 		return;
 	}
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateDynWaves.compute
@@ -41,8 +41,16 @@ void UpdateDynWaves(uint3 id : SV_DispatchThreadID)
 	{
 		_LD_TexArray_DynamicWaves_Source.GetDimensions(width, height, depth);
 	}
+
 	// Slice to sample previous frames data from. LOD change takes into account shifting of the cascades in scale.
-	const float sliceIndexSource = clamp(id.z + _LODChange, 0.0, depth - 1.0);
+	const float sliceIndexSource = id.z + _LODChange;
+
+	// Off either end of the cascade - not useful to sample
+	if (sliceIndexSource < 0.0 || sliceIndexSource >= depth - 1.0)
+	{
+		_LD_TexArray_Target[id] = 0;
+		return;
+	}
 
 	const float2 input_uv = IDtoUV(id.xy, width, height);
 	const CascadeParams cascadeData = _CrestCascadeData[sliceIndex];

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -71,7 +71,7 @@ Fixed
    -  Fix underwater rendering when the camera's culling mask excludes the *Ocean Renderer > Layer*.
    -  Fix visible "rings" in dynamic wave sim resulting from fast moving objects that have the *Sphere Water Interaction* component attached. Simulation frequency can be increased to improve result further, at the cost of more simulation steps per frame.
    -  Fix *Sphere Water Interaction* component not working in standalone builds.
-
+   -  Fix pop/discontinuity issue with dynamic waves.
 
    .. only:: birp
 


### PR DESCRIPTION
WIthout this fix, when scale is e.g. reduced, lod0 was getting populated with the previous lod0 data. This essentially dupes lod0 (lod0 data from previous frame ends up in both lod0 and lod1 in current frame), creating a pop and large displacement.

