### PR TITLE
Fix non Mesh Renderer inputs and add Albedo shader

### DIFF
--- a/crest/Assets/Crest/Crest/Materials/OceanInputs/AlbedoColor.mat
+++ b/crest/Assets/Crest/Crest/Materials/OceanInputs/AlbedoColor.mat
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: AlbedoColor
+  m_Shader: {fileID: 4800000, guid: d3bc7e6f962aa473db869b8d8b97427c, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _Texture:
+        m_Texture: {fileID: 2800000, guid: d254fdcebc9d1ce45a2d81cb7928a699, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BlendModeSource: 5
+    - _BlendModeTarget: 10
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/crest/Assets/Crest/Crest/Materials/OceanInputs/AlbedoColor.mat.meta
+++ b/crest/Assets/Crest/Crest/Materials/OceanInputs/AlbedoColor.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80f27b57f26a14e1d98b158bef86a27a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/BuildCommandBuffer.cs
@@ -111,6 +111,12 @@ namespace Crest
 
             BuildLodData(OceanRenderer.Instance, _buf);
 
+            if (OceanRenderer.Instance.ViewCamera != null)
+            {
+                // Fixes flickering non mesh renderer renderers (like particles). Method is undocumented.
+                Camera.SetupCurrent(OceanRenderer.Instance.ViewCamera);
+            }
+
             // This will execute at the beginning of the frame before the graphics queue
             Graphics.ExecuteCommandBuffer(_buf);
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
@@ -29,7 +29,7 @@ namespace Crest
 
         protected override Color GizmoColor => new Color(1f, 0f, 1f, 0.5f);
 
-        protected override string ShaderPrefix => string.Empty;
+        protected override string ShaderPrefix => "Crest/Inputs/Albedo";
 
         protected override bool FollowHorizontalMotion => false;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -78,6 +78,8 @@ namespace Crest
         // The clip surface samples at the displaced position in the ocean shader, so the displacement correction is not needed.
         protected override bool FollowHorizontalMotion => true;
 
+        protected override bool SupportsMultiPassShaders => _material != null && _material.shader.name == "Crest/Inputs/Clip Surface/Convex Hull";
+
         PropertyWrapperMPB _mpb;
         SampleHeightHelper _sampleHeightHelper = new SampleHeightHelper();
 
@@ -187,7 +189,16 @@ namespace Crest
             }
             else
             {
-                buf.DrawRenderer(_renderer, _material);
+                var shaderPass = SupportsMultiPassShaders ? -1 : 0;
+                for (var i = 0; i < _renderer.sharedMaterials.Length; i++)
+                {
+                    // Empty material slots is a user error. Unity complains about it so we should too.
+                    Debug.AssertFormat(_renderer.sharedMaterials[i] != null, _renderer,
+                        "Crest: {0} has empty material slots. Remove these slots or fill them with a material.", _renderer);
+
+                    buf.DrawRenderer(_renderer, _renderer.sharedMaterials[i], submeshIndex: i, shaderPass);
+                }
+
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -148,7 +148,15 @@ namespace Crest
                     buf.SetGlobalVector(sp_DisplacementAtInputPosition, Vector3.zero);
                 }
 
-                buf.DrawRenderer(_renderer, _material);
+                for (var i = 0; i < _renderer.sharedMaterials.Length; i++)
+                {
+                    // Empty material slots is a user error. Unity complains about it so we should too.
+                    Debug.AssertFormat(_renderer.sharedMaterials[i] != null, _renderer,
+                        "Crest: {0} has empty material slots. Remove these slots or fill them with a material.", _renderer);
+
+                    // Submesh count generally must equal number of materials.
+                    buf.DrawRenderer(_renderer, _renderer.sharedMaterials[i], submeshIndex: i);
+                }
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -154,8 +154,10 @@ namespace Crest
                     Debug.AssertFormat(_renderer.sharedMaterials[i] != null, _renderer,
                         "Crest: {0} has empty material slots. Remove these slots or fill them with a material.", _renderer);
 
+                    // By default, shaderPass is -1 which is all passes. Shader Graph will produce multi-pass shaders
+                    // for depth etc so we should only render one pass. Unlit SG will have the unlit pass first.
                     // Submesh count generally must equal number of materials.
-                    buf.DrawRenderer(_renderer, _renderer.sharedMaterials[i], submeshIndex: i);
+                    buf.DrawRenderer(_renderer, _renderer.sharedMaterials[i], submeshIndex: i, shaderPass: 0);
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AlbedoColor.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AlbedoColor.shader
@@ -1,0 +1,66 @@
+Shader "Crest/Inputs/Albedo/Color"
+{
+    Properties
+    {
+        _Texture("Albedo", 2D) = "white" {}
+        _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+
+        [Enum(UnityEngine.Rendering.BlendMode)] _BlendModeSource("Source Blend Mode", Int) = 5
+        [Enum(UnityEngine.Rendering.BlendMode)] _BlendModeTarget("Target Blend Mode", Int) = 10
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+
+        Pass
+        {
+            Blend [_BlendModeSource] [_BlendModeTarget]
+
+            ZWrite Off
+
+            CGPROGRAM
+            #pragma vertex Vertex
+            #pragma fragment Fragment
+
+            #include "UnityCG.cginc"
+
+            struct Attributes
+            {
+                float4 vertex : POSITION;
+                fixed4 color : COLOR;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct Varyings
+            {
+                float4 vertex : SV_POSITION;
+                fixed4 color : COLOR;
+                float2 uv : TEXCOORD0;
+            };
+
+            sampler2D _Texture;
+            float4 _Texture_ST;
+
+            half4 _Color;
+            half _Cutoff;
+
+            Varyings Vertex(Attributes input)
+            {
+                Varyings output;
+                output.vertex = UnityObjectToClipPos(input.vertex);
+                output.uv = TRANSFORM_TEX(input.uv, _Texture);
+                output.color = input.color;
+                return output;
+            }
+
+            fixed4 Fragment(Varyings i) : SV_Target
+            {
+                fixed4 color = tex2D(_Texture, i.uv) * _Color;
+                clip(color.a - _Cutoff + 0.0001);
+                return color * i.color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/AlbedoColor.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/AlbedoColor.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d3bc7e6f962aa473db869b8d8b97427c
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,6 +13,14 @@ Release Notes
 |version|
 ---------
 
+Breaking
+^^^^^^^^
+.. bullet_list::
+
+   -  Ocean inputs will now only execute the first shader pass (pass zero).
+      Before all passes were executed in sequence which caused incompatibilities with `URP` unlit *Shader Graph*.
+      This is only a concern to those who are using custom shaders with multiple passes which we believe is very few.
+
 Preview
 ^^^^^^^
 .. bullet_list::
@@ -91,6 +99,10 @@ Fixed
    .. only:: birp or urp
 
       -  Fix *Underwater Renderer* high memory usage by reverting change of using temporary render textures. `[BIRP] [URP]`
+
+   .. only:: urp
+
+      -  Fix ocean input incompatibilities with unlit *Shader Graph*. `[URP]`
 
    .. only:: hdrp or urp
 

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -12,6 +12,11 @@ user input, as covered in this video:
 
    Basics of Adding Ocean Inputs
 
+.. note::
+
+   Inputs only execute the first shader pass (pass zero).
+   It is recommended to use unlit shader templates or unlit *Shader Graph* (`URP` only) if not using one of ours.
+
 .. tip::
 
    For inputs, you are not limited to only using a :link:`MeshRenderer <{UnityDocsLinkBase}class-MeshRenderer.html>`.
@@ -484,6 +489,12 @@ URP 2022 has a decal system but it does not support transparent surfaces like wa
 
 User Inputs
 ^^^^^^^^^^^
+
+.. note::
+
+   Inputs only execute the first shader pass (pass zero).
+   It is recommended to use unlit shader templates or unlit *Shader Graph* (`URP` only) if not using one of ours.
+   Shaders provided by *Unity* generally will not work as their primary pass is not zero - even for unlit shaders.
 
 Any geometry or particle system can add colour to the water. It will be projected from a top down perspective onto the water surface.
 


### PR DESCRIPTION
I could not get particles to work with Albedo so I had to fix something and fixed a few other things:
- Albedo shader as most other shaders are multi-pass and we render all passes with DrawRenderer
- Render all sub-meshes so we can support particle trails
- Add a weird fix (Camera.SetupCurrent) to stop some things from flickering. I was given this by someone trying to get particles working for HDRP so looks like we need it anyway. Not sure what it does exactly but I think it sets up Camera.current.

![123](https://user-images.githubusercontent.com/5249806/149862421-65d75c5b-3f37-449c-bbb3-f91c9e204c49.jpg)
Particles on surface in Demo scene.

This should work for SRPs too. But can always come back and modify or create another shader there.