### PR TITLE
Fix Underwater Renderer not using sun when other light shining on transparent object

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
@@ -22,6 +22,8 @@ namespace Crest
         static readonly int sp_AmbientLighting = Shader.PropertyToID("_AmbientLighting");
         static readonly int sp_HorizonNormal = Shader.PropertyToID("_HorizonNormal");
         static readonly int sp_DataSliceOffset = Shader.PropertyToID("_DataSliceOffset");
+        static readonly int sp_LightColor0 = Shader.PropertyToID("_LightColor0");
+        static readonly int sp_WorldSpaceLightPos0 = Shader.PropertyToID("_WorldSpaceLightPos0");
 
         // If changed then see how mode is used to select the front-face pass and whether a mapping is required.
         // :UnderwaterRenderer.Mode
@@ -122,6 +124,13 @@ namespace Crest
             SetInverseViewProjectionMatrix(_underwaterEffectMaterial.material);
 
             _underwaterEffectCommandBuffer.Clear();
+
+            if (RenderSettings.sun != null)
+            {
+                // Unity does not set up lighting for us so we will get the last value which could incorrect.
+                _underwaterEffectCommandBuffer.SetGlobalVector(sp_LightColor0, RenderSettings.sun.color.linear * RenderSettings.sun.intensity);
+                _underwaterEffectCommandBuffer.SetGlobalVector(sp_WorldSpaceLightPos0, -RenderSettings.sun.transform.forward);
+            }
 
             // Create a separate stencil buffer context by copying the depth texture.
             if (UseStencilBufferOnEffect)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -84,6 +84,7 @@ Fixed
    .. only:: birp
 
       -  Fix shadow simulation null exceptions if primary light becomes null. `[BIRP]`
+      -  Fix *Underwater Renderer* using a non directional light when a transparent object is in range of light and in view of camera. `[BIRP]`
 
    .. only:: birp or urp
 


### PR DESCRIPTION
Unity doesn't set up lighting for us when using command buffers to draw things. When rendering the underwater effect, we were getting the last values which often will be the sun. But if there is another light which shines on a transparent object, and said transparent object is in view, then the last values will be from the ForwardAdd passes which is not the sun.