### PR TITLE
Fix caustics no rendering if shadow data is disabled

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -120,6 +120,12 @@ namespace Crest
         {
             base.OnDisable();
 
+            // Built-in RP only.
+            {
+                // Black for shadows. White for unshadowed.
+                Shader.SetGlobalTexture(sp_CrestScreenSpaceShadowTexture, Texture2D.whiteTexture);
+            }
+
             CleanUpShadowCommandBuffers();
         }
 
@@ -434,7 +440,17 @@ namespace Crest
             }
         }
 
-        public static void BindNullToGraphicsShaders() => Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
+        public static void BindNullToGraphicsShaders()
+        {
+            Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
+
+            // Built-in RP only.
+            {
+                // Black for shadows. White for unshadowed.
+                Shader.SetGlobalTexture(sp_CrestScreenSpaceShadowTexture, Texture2D.whiteTexture);
+            }
+        }
+
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void InitStatics()

--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -100,7 +100,8 @@ void ApplyCaustics
 		{
 			// Normally, we would use SHADOW_ATTENUATION(), but SHADOWS_SCREEN and UNITY_NO_SCREENSPACE_SHADOWS are not
 			// handled for the transparent pass.
-			causticsStrength *= LOAD_TEXTURE2D_X(_CrestScreenSpaceShadowTexture, i_positionSS).r;
+			// Null texture is a small white texture which will be smaller than the screen size.
+			causticsStrength *= LOAD_TEXTURE2D_X(_CrestScreenSpaceShadowTexture,  min(i_positionSS, (int2)_CrestScreenSpaceShadowTexture_TexelSize.zw - 1)).r;
 		}
 	}
 #endif // _SHADOWS_ON

--- a/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanShaderData.hlsl
@@ -16,6 +16,7 @@ UNITY_DECLARE_SCREENSPACE_TEXTURE(_BackgroundTexture);
 float4 _CameraDepthTexture_TexelSize;
 
 TEXTURE2D_X(_CrestScreenSpaceShadowTexture);
+float4 _CrestScreenSpaceShadowTexture_TexelSize;
 
 sampler2D _ReflectionTex;
 #if _OVERRIDEREFLECTIONCUBEMAP_ON

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -95,6 +95,7 @@ Fixed
 
       -  Fix shadow simulation null exceptions if primary light becomes null. `[BIRP]`
       -  Fix *Underwater Renderer* using a non directional light when a transparent object is in range of light and in view of camera. `[BIRP]`
+      -  Fix caustics not rendering if shadow data is disabled. `[BIRP]`
 
    .. only:: birp or urp
 


### PR DESCRIPTION
When shadow data is disabled the SS shadow texture was not set. This PR binds that texture to a white texture if disabled.