### PR TITLE
Fix "Underwater Renderer > Filter Ocean Data" not being applied to caustics

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -64,13 +64,13 @@ void ApplyCaustics
 	in const float i_sceneZ,
 	in const bool i_underwater,
 	inout half3 io_sceneColour,
-	in const CascadeParams cascadeData0,
-	in const CascadeParams cascadeData1
+	in const int i_sliceIndex,
+	in const CascadeParams cascadeData
 )
 {
 	// could sample from the screen space shadow texture to attenuate this..
 	// underwater caustics - dedicated to P
-	const float3 scenePosUV = WorldToUV(i_scenePos.xz, cascadeData1, _LD_SliceIndex + 1);
+	const float3 scenePosUV = WorldToUV(i_scenePos.xz, cascadeData, i_sliceIndex);
 
 	float3 disp = 0.0;
 	// this gives height at displaced position, not exactly at query position.. but it helps. i cant pass this from vert shader
@@ -177,7 +177,7 @@ half3 OceanEmission
 		sceneColour = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_BackgroundTexture, uvBackgroundRefract).rgb;
 #if _CAUSTICS_ON
 		float3 scenePos = _WorldSpaceCameraPos - i_view * i_sceneZ / dot(unity_CameraToWorld._m02_m12_m22, -i_view);
-		ApplyCaustics(_CausticsTiledTexture, _CausticsDistortionTiledTexture, i_positionSS, scenePos, i_lightDir, i_sceneZ, i_underwater, sceneColour, cascadeData0, cascadeData1);
+		ApplyCaustics(_CausticsTiledTexture, _CausticsDistortionTiledTexture, i_positionSS, scenePos, i_lightDir, i_sceneZ, i_underwater, sceneColour, _LD_SliceIndex + 1, cascadeData1);
 #endif
 		alpha = 1.0 - exp(-_DepthFogDensity.xyz * depthFogDistance);
 	}

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterCurtain.shader
@@ -221,7 +221,7 @@ Shader "Crest/Underwater Curtain"
 				if (sceneZ01 != 0.0)
 				{
 					float3 scenePos = _WorldSpaceCameraPos - view * sceneZ / dot(unity_CameraToWorld._m02_m12_m22, -view);
-					ApplyCaustics(_CausticsTiledTexture, _CausticsDistortionTiledTexture, input.positionCS.xy, scenePos, lightDir, sceneZ, true, sceneColour, cascadeData0, cascadeData1);
+					ApplyCaustics(_CausticsTiledTexture, _CausticsDistortionTiledTexture, input.positionCS.xy, scenePos, lightDir, sceneZ, true, sceneColour, _LD_SliceIndex + 1, cascadeData1);
 				}
 #endif // _CAUSTICS_ON
 

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterEffectShared.hlsl
@@ -217,8 +217,8 @@ half3 ApplyUnderwaterEffect
 			sceneZ,
 			true,
 			sceneColour,
-			_CrestCascadeData[sliceIndex],
-			_CrestCascadeData[sliceIndex + 1]
+			sliceIndex,
+			_CrestCascadeData[sliceIndex]
 		);
 	}
 #endif // _CAUSTICS_ON

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -99,6 +99,7 @@ Fixed
    .. only:: birp or urp
 
       -  Fix *Underwater Renderer* high memory usage by reverting change of using temporary render textures. `[BIRP] [URP]`
+      -  Fix *Underwater Renderer* not using *Filter Ocean Data* for caustics. `[BIRP] [URP]`
 
    .. only:: urp
 


### PR DESCRIPTION
Fixes "Underwater Renderer > Filter Ocean Data" option not being applied to caustics. It was using slice index + 1, but the cascade data had the filter applied so by default it would be much higher.