### PR TITLE
Fix Underwater Renderer self intersecting waves in mask

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -408,7 +408,7 @@ namespace Crest
         readonly static int sp_lodAlphaBlackPointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointFade");
         readonly static int sp_lodAlphaBlackPointWhitePointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointWhitePointFade");
         readonly static int sp_CrestDepthTextureOffset = Shader.PropertyToID("_CrestDepthTextureOffset");
-        readonly static int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
+        public static readonly int sp_ForceUnderwater = Shader.PropertyToID("_ForceUnderwater");
 
         public static class ShaderIDs
         {
@@ -1016,11 +1016,13 @@ namespace Crest
         {
             if (OceanMaterial != null)
             {
+                // Override isFrontFace when camera is far enough from the ocean surface to fix self intersecting waves.
                 // Hack - due to SV_IsFrontFace occasionally coming through as true for back faces,
                 // add a param here that forces ocean to be in underwater state. I think the root
                 // cause here might be imprecision or numerical issues at ocean tile boundaries, although
                 // i'm not sure why cracks are not visible in this case.
-                OceanMaterial.SetFloat(sp_ForceUnderwater, ViewerHeightAboveWater < -2f ? 1f : 0f);
+                var height = ViewerHeightAboveWater;
+                OceanMaterial.SetFloat(sp_ForceUnderwater, height < -2f ? 1f : height > 2f ? -1f : 0f);
             }
 
             _cascadeParams.Flip();

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
@@ -347,6 +347,14 @@ namespace Crest
 
             GeometryUtility.CalculateFrustumPlanes(camera, frustumPlanes);
 
+            {
+                // Override isFrontFace when camera is far enough from the ocean surface to fix self intersecting waves.
+                // Mostly used when mode is not full-screen as normally the UR is disabled above 2m or does not use the
+                // mask below -2m.
+                var height = OceanRenderer.Instance.ViewerHeightAboveWater;
+                oceanMaskMaterial.SetFloat(OceanRenderer.sp_ForceUnderwater, height < -2f ? 1f : height > 2f ? -1f : 0f);
+            }
+
             // Get all ocean chunks and render them using cmd buffer, but with mask shader.
             if (!debugDisableOceanMask)
             {

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpersNew.hlsl
@@ -257,7 +257,19 @@ void ApplyOceanClipSurface(in const float3 io_positionWS, in const float i_lodAl
 
 bool IsUnderwater(const bool i_isFrontFace, const float i_forceUnderwater)
 {
-	return !i_isFrontFace || i_forceUnderwater > 0.0;
+	// We are well below water.
+	if (i_forceUnderwater > 0.0)
+	{
+		return true;
+	}
+
+	// We are well above water.
+	if (i_forceUnderwater < 0.0)
+	{
+		return false;
+	}
+
+	return !i_isFrontFace;
 }
 
 half UnderwaterShadowSSS(const float2 i_positionXZ)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -92,6 +92,7 @@ Fixed
    -  Fix pop/discontinuity issue with dynamic waves.
    -  Fix underwater culling when *Ocean Renderer > Viewpoint* is set and different from the camera.
    -  Fix several minor exceptions in cases where components were not set up correctly.
+   -  Fix possible cases of underwater effect being inverted on self-intersecting waves when further than 2m from ocean surface.
 
    .. only:: birp
 


### PR DESCRIPTION
Helps with #931 having underwater appear where it shouldn't due to self intersecting waves. This wasn't really a problem since the UR is disabled for above 2m and doesn't use the mask below -2m. I've added a release note for it anyway since the former could be disabled with a debug.