### PR TITLE
Control over force underwater

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -40,21 +40,6 @@ namespace Crest
         [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;
 
-        static int s_Count;
-        internal static int Count => s_Count;
-
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-            s_Count++;
-        }
-
-        protected override void OnDisable()
-        {
-            base.OnDisable();
-            s_Count--;
-        }
-
         protected override void Update()
         {
             base.Update();

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
@@ -232,7 +232,6 @@ namespace Crest
                 _cameraFrustumPlanes,
                 _oceanMaskMaterial.material,
                 _farPlaneMultiplier,
-                _mode,
                 _debug._disableOceanMask
             );
 
@@ -319,7 +318,6 @@ namespace Crest
             Plane[] frustumPlanes,
             Material oceanMaskMaterial,
             float farPlaneMultiplier,
-            Mode mode,
             bool debugDisableOceanMask
         )
         {
@@ -349,14 +347,8 @@ namespace Crest
 
             GeometryUtility.CalculateFrustumPlanes(camera, frustumPlanes);
 
-            {
-                // Override isFrontFace when camera is far enough from the ocean surface to fix self intersecting waves.
-                // Mostly used when mode is not full-screen as normally the UR is disabled above 2m or does not use the
-                // mask below -2m. Disable if portal or volume and there are height inputs in play.
-                var height = OceanRenderer.Instance.ViewerHeightAboveWater;
-                oceanMaskMaterial.SetFloat(OceanRenderer.sp_ForceUnderwater, mode != Mode.FullScreen &&
-                    RegisterHeightInput.Count > 0 ? 0f : height < -2f ? 1f : height > 2f ? -1f : 0f);
-            }
+            // Apply isFrontFace override from OceanRenderer.
+            oceanMaskMaterial.SetFloat(OceanRenderer.sp_ForceUnderwater, OceanRenderer.Instance.OceanMaterial.GetFloat(OceanRenderer.sp_ForceUnderwater));
 
             // Get all ocean chunks and render them using cmd buffer, but with mask shader.
             if (!debugDisableOceanMask)


### PR DESCRIPTION
![Screenshot (392)](https://user-images.githubusercontent.com/5249806/153702780-089f6dd7-8dfe-4dc7-86da-583e4c548e6b.png)

My previous fix #986 was a bit shortsighted and so was a subsequent fix 59fb1b623e70b0cc7e677dff16f1c74c75ef83ab.

This PR gives a reasonable level of control of the __ForceUnderwater_ variable.

This control is only really needed when using the portals/volumes feature as it can easily expose the underside of the surface and is even worse in combination with varying water levels.

_Automatic_ just enables/disables __ForceUnderwater_ if portals/volumes feature is used which is a sane default.

I've added a not-so-nice method for UnityEvent support as they do not support Enums :^(

LMKWYT.