### PR TITLE
Fix ShapeFFT popping when enabled with zero weight

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -265,7 +265,8 @@ namespace Crest
 
         void ReportMaxDisplacement()
         {
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxHorizontalDisplacement, _maxVerticalDisplacement, _maxVerticalDisplacement);
+            // Apply weight or will cause popping due to scale change.
+            OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxHorizontalDisplacement * _weight, _maxVerticalDisplacement * _weight, _maxVerticalDisplacement * _weight);
         }
 
         void InitBatches()

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -104,6 +104,7 @@ Fixed
    -  Fix possible cases of underwater effect being inverted on self-intersecting waves when further than 2m from ocean surface.
    -  Fix a per frame GC allocation.
    -  Fix ocean input validation incorrectly reporting that there is no spline attached when game object is disabled.
+   -  Fix *Shape FFT* with zero weight causing visible changes or pops to the ocean surface.
 
    .. only:: birp
 


### PR DESCRIPTION
Weight was not being applied to reporting causing scale pop. Reported on Discord by scrappy.