### PR TITLE
Fix ShapeGerstner weight not updating with _spectrumFixedAtRuntime

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -553,7 +553,7 @@ namespace Crest
 
             for (int i = 0; i < _wavelengths.Length; i++)
             {
-                var amp = _weight * _activeSpectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave, windSpeed, out _powers[i]);
+                var amp = _activeSpectrum.GetAmplitude(_wavelengths[i], _componentsPerOctave, windSpeed, out _powers[i]);
                 _amplitudes[i] = Random.value * amp;
                 _amplitudes2[i] = Random.value * amp * _reverseWaveWeight;
             }
@@ -596,6 +596,10 @@ namespace Crest
             {
                 ampSum += _amplitudes[i] * _activeSpectrum._chopScales[i / _componentsPerOctave];
             }
+
+            // Apply weight or will cause popping due to scale change.
+            ampSum *= _weight;
+
             OceanRenderer.Instance.ReportMaxDisplacementFromShape(ampSum * _activeSpectrum._chop, ampSum, ampSum);
         }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -106,6 +106,9 @@ Fixed
    -  Fix ocean input validation incorrectly reporting that there is no spline attached when game object is disabled.
    -  Fix *Shape FFT* with zero weight causing visible changes or pops to the ocean surface.
    -  Fix *Shape FFT* waves animating too quickly when two or more are in the scene with different resolutions.
+   -  Fix *Shape Gerstner* weight not updating correctly if less than one on game load.
+   -  Fix *Shape Gerstner* weight being applied twice instead of once.
+      You may need to adjust your weight if between zero and one.
 
    .. only:: birp
 


### PR DESCRIPTION
Removed from scripting as it would get stuck at zero. And the weight was being applied twice which is incorrect.

I was thinking of mentioning the latter as a breaking change but on second thought a slight behaviour change probably doesn't warrant it.

ShapeGerstnerBatched has the same problem but will leave it as deprecated and has CPU queries which I would have to apply the weight too.