### PR TITLE
Fix FFT speed boosting when two or more are active in scene

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
@@ -362,6 +362,9 @@ namespace Crest
         /// </summary>
         void UpdateSpectrum(CommandBuffer buf, float time)
         {
+            // Always set _Size as the compute shader returned from Resource.Load is the same asset every time and more
+            // than one ShapeFFT will overwrite this value.
+            buf.SetComputeIntParam(_shaderSpectrum, "_Size", _resolution);
             buf.SetComputeFloatParam(_shaderSpectrum, "_Time", time * _spectrum._gravityScale);
             buf.SetComputeFloatParam(_shaderSpectrum, "_Chop", _spectrum._chop);
             buf.SetComputeFloatParam(_shaderSpectrum, "_Period", _loopPeriod);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -105,6 +105,7 @@ Fixed
    -  Fix a per frame GC allocation.
    -  Fix ocean input validation incorrectly reporting that there is no spline attached when game object is disabled.
    -  Fix *Shape FFT* with zero weight causing visible changes or pops to the ocean surface.
+   -  Fix *Shape FFT* waves animating too quickly when two or more are in the scene with different resolutions.
 
    .. only:: birp
 


### PR DESCRIPTION
If there is more than one ShapeFFT with different resolutions, the __Size_ will be wrong and cause FFT to speedup/jitter. Can also happen with only one ShapeFFT active at a time but one enabled after the other will overwrite it incorrectly.