### PR TITLE
Maximum Buoyancy Force

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
+++ b/crest/Assets/Crest/Crest-Examples/BoatDev/Scripts/BoatAlignNormal.cs
@@ -32,6 +32,8 @@ public class BoatAlignNormal : FloatingObjectBase
     public float _boyancyTorque = 8f;
     [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), Crest.Range(0, 1)]
     public float _accelerateDownhill = 0f;
+    [Tooltip("Clamps the buoyancy force to this value. Useful for handling fully submerged objects. Use Infinity to disable.")]
+    public float _maximumBuoyancyForce = Mathf.Infinity;
 
     [Header("Engine Power")]
     [Tooltip("Vertical offset for where engine force should be applied.")]
@@ -139,6 +141,10 @@ public class BoatAlignNormal : FloatingObjectBase
         }
 
         var buoyancy = -Physics.gravity.normalized * _buoyancyCoeff * bottomDepth * bottomDepth * bottomDepth;
+        if (_maximumBuoyancyForce < Mathf.Infinity)
+        {
+            buoyancy = Vector3.ClampMagnitude(buoyancy, _maximumBuoyancyForce);
+        }
         _rb.AddForce(buoyancy, ForceMode.Acceleration);
 
         // Approximate hydrodynamics of sliding along water

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -40,6 +40,8 @@ namespace Crest
         public float _minSpatialLength = 12f;
         [Range(0, 1)]
         public float _turningHeel = 0.35f;
+        [Tooltip("Clamps the buoyancy force to this value. Useful for handling fully submerged objects. Use Infinity to disable.")]
+        public float _maximumBuoyancyForce = Mathf.Infinity;
 
         [Header("Drag")]
         public float _dragInWaterUp = 3f;
@@ -214,7 +216,12 @@ namespace Crest
                 var heightDiff = waterHeight - _queryPoints[i].y;
                 if (heightDiff > 0)
                 {
-                    _rb.AddForceAtPosition(archimedesForceMagnitude * heightDiff * Vector3.up * _forcePoints[i]._weight * _forceMultiplier / _totalWeight, _queryPoints[i]);
+                    var force = archimedesForceMagnitude * heightDiff * Vector3.up * _forcePoints[i]._weight * _forceMultiplier / _totalWeight;
+                    if (_maximumBuoyancyForce < Mathf.Infinity)
+                    {
+                        force = Vector3.ClampMagnitude(force, _maximumBuoyancyForce);
+                    }
+                    _rb.AddForceAtPosition(force, _queryPoints[i]);
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SimpleFloatingObject.cs
@@ -33,6 +33,8 @@ namespace Crest
         public float _boyancyTorque = 8f;
         [Tooltip("Approximate hydrodynamics of 'surfing' down waves."), Range(0, 1)]
         public float _accelerateDownhill = 0f;
+        [Tooltip("Clamps the buoyancy force to this value. Useful for handling fully submerged objects. Use Infinity to disable.")]
+        public float _maximumBuoyancyForce = Mathf.Infinity;
 
         [Header("Wave Response")]
         [Tooltip("Diameter of object, for physics purposes. The larger this value, the more filtered/smooth the wave response will be.")]
@@ -111,6 +113,10 @@ namespace Crest
             }
 
             var buoyancy = -Physics.gravity.normalized * _buoyancyCoeff * bottomDepth * bottomDepth * bottomDepth;
+            if (_maximumBuoyancyForce < Mathf.Infinity)
+            {
+                buoyancy = Vector3.ClampMagnitude(buoyancy, _maximumBuoyancyForce);
+            }
             _rb.AddForce(buoyancy, ForceMode.Acceleration);
 
             // Approximate hydrodynamics of sliding along water

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -65,6 +65,7 @@ Changed
    -  Add new example scene *BoatWakes* to showcase improvements to *SphereWaterInteraction* component.
    -  Allow scaling FFT waves on spline (not supported previously). *SplinePointDataGerstner* has been renamed to *SplinePointDataWaves* which works for both *ShapeFFT* and *ShapeGerstner*.
    -  Add *Surface Self-Intersection Fix Mode* (advanced option) to control how self-intersections of the ocean surface caused by intense/choppy waves are handled.
+   -  Add *Maximum Buoyancy Force* for preventing objects from having too much force being applied when fully submerged.
    -  Updated all example scenes.
 
    .. only:: hdrp


### PR DESCRIPTION
Adds a _Maximum Buoyancy Force_ to clamp buoyancy.

Useful when buoyant objects are submerged a decent depth which can cause them to gain too much force and launch into the stratosphere.

By default, it is set to Infinity (ie no effect) so users will have to opt in.