### PR TITLE
Fix UR XR in 2021.2 builds

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
@@ -36,8 +36,16 @@ namespace Crest
             "CREST_UNDERWATER_BEFORE_TRANSPARENT",
             "CREST_FLOATING_ORIGIN",
 
-            // Unity 2021.2 considers this UserDefined."
+            // XR keywords.
             "STEREO_ENABLED_ON",
+            "STEREO_INSTANCING_ON",
+            "UNITY_SINGLE_PASS_STEREO",
+            "STEREO_MULTIVIEW_ON",
+
+            // URP keywords.
+            "_MAIN_LIGHT_SHADOWS",
+            "_MAIN_LIGHT_SHADOWS_CASCADE",
+            "_SHADOWS_SOFT",
         };
 
         bool IsUnderwaterShader(string shaderName)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,6 +13,12 @@ Release Notes
 |version|
 ---------
 
+Fixed
+^^^^^
+.. bullet_list::
+
+   -  Fix *Underwater Renderer* stereo rendering not working in builds for Unity 2021.2.
+
 
 4.15.1
 ------


### PR DESCRIPTION
XR wasn't working for UR because keywords were being stripped as they have changed or keyword system has changed.

I've also brought file up-to-date with downstream.