### PR TITLE
Give feedback instead of errors due to bad SWI shader move

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/ObsoleteShaderGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/ObsoleteShaderGUI.cs
@@ -24,13 +24,21 @@ namespace Crest
             var styleRichText = GUI.skin.GetStyle("HelpBox").richText;
             GUI.skin.GetStyle("HelpBox").richText = true;
 
-            var message = "This shader is deprecated and will be removed in a future version.";
+            var message = "";
+
+            {
+                var property = FindProperty("_Message", properties, propertyIsMandatory: false);
+                if (property != null)
+                {
+                    message += property.displayName;
+                }
+            }
 
             {
                 var property = FindProperty("_ObsoleteMessage", properties, propertyIsMandatory: false);
                 if (property != null)
                 {
-                    message += " " + property.displayName;
+                    message += "This shader is deprecated and will be removed in a future version. " + property.displayName;
                 }
             }
 

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesSphereWaterInteraction.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesSphereWaterInteraction.shader
@@ -1,0 +1,23 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// This is a stub for a shader that got moved.
+
+Shader "Hidden/Crest/Moved"
+{
+	Properties
+	{
+		[HideInInspector] _Message("This shader has moved. Use <i>Crest/Inputs/Dynamic Waves/Sphere-Water Interaction</i> instead.", Float) = 0
+	}
+
+	SubShader
+	{
+		Pass
+		{
+			ColorMask 0
+		}
+	}
+
+	CustomEditor "Crest.ObsoleteShaderGUI"
+}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesSphereWaterInteraction.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/DynWavesSphereWaterInteraction.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a6924df2681e04e2d9af96d5e8d3174e
+timeCreated: 1520630076
+licenseType: Free
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/DynWavesSphereWaterInteraction.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/DynWavesSphereWaterInteraction.shader
@@ -1,0 +1,23 @@
+﻿// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// This is a stub for a shader that got moved.
+
+Shader "Hidden/Crest/Moved"
+{
+	Properties
+	{
+		[HideInInspector] _Message("This shader has moved. Use <i>Crest/Inputs/Dynamic Waves/Sphere-Water Interaction</i> instead.", Float) = 0
+	}
+
+	SubShader
+	{
+		Pass
+		{
+			ColorMask 0
+		}
+	}
+
+	CustomEditor "Crest.ObsoleteShaderGUI"
+}

--- a/crest/Assets/Crest/Crest/Shaders/Resources/DynWavesSphereWaterInteraction.shader.meta
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/DynWavesSphereWaterInteraction.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 90ad6014e170d4d85a964ea93c9b3f64
+timeCreated: 1520630076
+licenseType: Free
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -17,6 +17,7 @@ Fixed
 ^^^^^
 .. bullet_list::
 
+   -  Provide feedback on how to solve errors from *Sphere-Water Interaction* moving file locations.
    -  Fix *Underwater Renderer* stereo rendering not working in builds for Unity 2021.2.
 
 


### PR DESCRIPTION
Related #971 

We moved this shader into a Resources folder one level down and corrected the path for an include. But we forgot to add a dummy/stub shader in the original location which has caused a few upgrade issues.

This adds the dummy/stub shader to two locations and provides instructions on how users can fix it themselves.

I've added one to _Crest/Crest/Shaders/OceanInputs/_ and _Crest/Crest/Shaders/Resources_ since I was recommending people move it there before 4.15 was released.

<img width="689" alt="1" src="https://user-images.githubusercontent.com/5249806/161516212-e3db6db7-38a9-48a2-8b8b-7a90b0516fb5.png">