### PR TITLE
Fix texture leaks

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -139,6 +139,28 @@ namespace Crest
             RenderTargetIdentifierXR(ref texture, ref target);
         }
 
+        /// <summary>
+        /// Creates an RT with an RTD if it does not exist or assigns RTD to RT (RT should be released first). This
+        /// prevents reference leaks.
+        /// </summary>
+        /// <remarks>
+        /// Afterwards call <a href="https://docs.unity3d.com/ScriptReference/RenderTexture.Create.html">Create</a> if
+        /// necessary or <a href="https://docs.unity3d.com/ScriptReference/RenderTexture-active.html">let Unity handle
+        /// it</a>.
+        /// </remarks>
+        public static void SafeCreateRenderTexture(ref RenderTexture texture, RenderTextureDescriptor descriptor)
+        {
+            // Do not overwrite reference or it will create reference leak.
+            if (texture == null)
+            {
+                texture = new RenderTexture(descriptor);
+            }
+            else
+            {
+                texture.descriptor = descriptor;
+            }
+        }
+
         public static bool RenderTargetTextureNeedsUpdating(RenderTexture texture, RenderTextureDescriptor descriptor)
         {
             return

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -120,7 +120,7 @@ namespace Crest
         static void CreateBlackTexArray()
         {
             _blackTextureArray = CreateTexture2DArray(Texture2D.blackTexture);
-            _blackTextureArray.name = "Black Texture2DArray";
+            _blackTextureArray.name = "Crest Black Texture2DArray";
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -278,6 +278,13 @@ namespace Crest
         {
             // Unbind from all graphics shaders (not compute)
             Shader.SetGlobalTexture(GetParamIdSampler(), NullTexture);
+
+            // Release resources and destroy object to avoid reference leak.
+            _targets.RunLambda(x =>
+            {
+                x.Release();
+                Helpers.Destroy(x);
+            });
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -80,6 +80,15 @@ namespace Crest
             Start();
         }
 
+        internal override void OnDisable()
+        {
+            base.OnDisable();
+            _waveBuffers.Release();
+            Helpers.Destroy(_waveBuffers);
+            _combineBuffer.Release();
+            Helpers.Destroy(_combineBuffer);
+        }
+
         protected override void InitData()
         {
             base.InitData();
@@ -138,7 +147,7 @@ namespace Crest
             result.filterMode = FilterMode.Bilinear;
             result.anisoLevel = 0;
             result.useMipMap = false;
-            result.name = "CombineBuffer";
+            result.name = "CrestCombineBuffer";
             result.dimension = TextureDimension.Tex2D;
             result.volumeDepth = 1;
             result.enableRandomWrite = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrPersistent.cs
@@ -49,6 +49,14 @@ namespace Crest
             CreateProperties();
         }
 
+        internal override void OnDisable()
+        {
+            base.OnDisable();
+
+            _sources.Release();
+            Helpers.Destroy(_sources);
+        }
+
         void CreateProperties()
         {
             _shader = ComputeShaderHelpers.LoadShader(ShaderSim);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -103,8 +103,10 @@ namespace Crest
         {
             // Depth textures use HDR values
             var texture = TextureArrayHelpers.CreateTexture2D(s_nullColor, UnityEngine.TextureFormat.RGB9e5Float);
+            texture.name = "Sea Floor Depth Null Texture2D";
             s_nullTexture = TextureArrayHelpers.CreateTexture2DArray(texture);
-            s_nullTexture.name = "Sea Floor Depth Null Texture";
+            s_nullTexture.name = "Sea Floor Depth Null Texture2DArray";
+            Helpers.Destroy(texture);
         }
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTBaker.cs
@@ -72,10 +72,12 @@ namespace Crest
             var kernel = waveCombineShader.FindKernel("FFTBakeMultiRes");
 
             var bakedWaves = new RenderTexture(fftWaves._resolution, fftWaves._resolution * lodCount, 1, RenderTextureFormat.ARGBFloat, 0);
+            bakedWaves.name = "CrestFFTBakedWaves";
             bakedWaves.enableRandomWrite = true;
             bakedWaves.Create();
 
             var stagingTexture = new Texture2D(fftWaves._resolution, fftWaves._resolution * lodCount, TextureFormat.RGBAHalf, false, true);
+            stagingTexture.name = "CrestFFTBakedStaging";
 
             var frameCount = (int)(resolutionTime * loopPeriod);
             var frames = new half[frameCount][];
@@ -117,6 +119,10 @@ namespace Crest
 
                 frames[timeIndex] = stagingTexture.GetRawTextureData<half>().ToArray();
             }
+
+            bakedWaves.Release();
+            Helpers.Destroy(bakedWaves);
+            Helpers.Destroy(stagingTexture);
 
             var framesFlattened = frames.SelectMany(x => x).ToArray();
             //Debug.Log($"Crest: Width: {fftWaves._resolution}, frame count: {frameCount}, slices: {lodCount}, floats per frame: {frames[0].Length}, total floats: {framesFlattened.Length}");

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
@@ -125,23 +125,31 @@ namespace Crest
             rtd.colorFormat = RenderTextureFormat.ARGBFloat;
             rtd.msaaSamples = 1;
 
-            _spectrumInit = new RenderTexture(rtd);
+            Helpers.SafeCreateRenderTexture(ref _spectrumInit, rtd);
+            _spectrumInit.name = "CrestFFTSpectrumInit";
             _spectrumInit.Create();
 
             rtd.colorFormat = RenderTextureFormat.RGFloat;
 
-            _spectrumHeight = new RenderTexture(rtd);
+
+            Helpers.SafeCreateRenderTexture(ref _spectrumHeight, rtd);
+            _spectrumHeight.name = "CrestFFTSpectrumHeight";
             _spectrumHeight.Create();
-            _spectrumDisplaceX = new RenderTexture(rtd);
+            Helpers.SafeCreateRenderTexture(ref _spectrumDisplaceX, rtd);
+            _spectrumDisplaceX.name = "CrestFFTSpectrumDisplaceX";
             _spectrumDisplaceX.Create();
-            _spectrumDisplaceZ = new RenderTexture(rtd);
+            Helpers.SafeCreateRenderTexture(ref _spectrumDisplaceZ, rtd);
+            _spectrumDisplaceZ.name = "CrestFFTSpectrumDisplaceZ";
             _spectrumDisplaceZ.Create();
 
-            _tempFFT1 = new RenderTexture(rtd);
+            Helpers.SafeCreateRenderTexture(ref _tempFFT1, rtd);
+            _tempFFT1.name = "CrestFFTOutput1";
             _tempFFT1.Create();
-            _tempFFT2 = new RenderTexture(rtd);
+            Helpers.SafeCreateRenderTexture(ref _tempFFT2, rtd);
+            _tempFFT2.name = "CrestFFTOutput2";
             _tempFFT2.Create();
-            _tempFFT3 = new RenderTexture(rtd);
+            Helpers.SafeCreateRenderTexture(ref _tempFFT3, rtd);
+            _tempFFT3.name = "CrestFFTOutput3";
             _tempFFT3.Create();
 
             // Raw wave data buffer

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -21,6 +21,8 @@ Fixed
    -  Fix *Underwater Renderer* stereo rendering not working in builds for Unity 2021.2.
    -  Fix *Underwater Renderer* stereo rendering issue where both eyes are same for color and/or depth with certain features enabled.
    -  Fix stereo rendering for *Examples* scene.
+   -  Fix several material and mesh memory leaks and reference leaks.
+   -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
 
 .. only:: urp
 
@@ -35,7 +37,6 @@ Fixed
 .. bullet_list::
 
    -  Fix shader compiler error.
-   -  Fix several material and mesh memory leaks and reference leaks.
 
 
 4.15


### PR DESCRIPTION
Helps solve #999.

These are leaks that happen during a single scene session as Unity will unload them on scene switch. But still nice to have them cleared. I have separated them into commits but can be reviewed as a whole.