### PR TITLE
Fix leaks due to hide flags usage

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -132,10 +132,7 @@ namespace Crest
             {
                 // Dummy values. We are only creating an RT reference, not an RT native object. RT should be configured
                 // properly before using or calling Create.
-                texture = new RenderTexture(0, 0, 0)
-                {
-                    hideFlags = HideFlags.HideAndDontSave,
-                };
+                texture = new RenderTexture(0, 0, 0);
             }
 
             // Always call this in case of recompilation as RTI will lose its reference to the RT.

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/PropertyWrapper.cs
@@ -34,19 +34,13 @@ namespace Crest
         public PropertyWrapperMaterial(Shader shader)
         {
             Debug.Assert(shader != null, "Crest: PropertyWrapperMaterial: Cannot create required material because shader is null");
-            material = new Material(shader)
-            {
-                hideFlags = HideFlags.HideAndDontSave,
-            };
+            material = new Material(shader);
         }
         public PropertyWrapperMaterial(string shaderPath)
         {
             Shader shader = Shader.Find(shaderPath);
             Debug.AssertFormat(shader != null, $"Crest.PropertyWrapperMaterial: {PropertyWrapperConstants.NO_SHADER_MESSAGE}", shaderPath);
-            material = new Material(shader)
-            {
-                hideFlags = HideFlags.HideAndDontSave,
-            };
+            material = new Material(shader);
         }
 
         public void SetFloat(int param, float value) => material.SetFloat(param, value);

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -245,7 +245,6 @@ namespace Crest
             }
 
             var mesh = new Mesh();
-            mesh.hideFlags = HideFlags.DontSave;
             mesh.name = "Grid2D_" + divs0 + "x" + divs1;
             mesh.vertices = verts;
             mesh.uv = uvs;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -142,7 +142,6 @@ namespace Crest
             if (_signedDistancedMaterial == null)
             {
                 _signedDistancedMaterial = new Material(Shader.Find(k_SignedDistanceShaderPath));
-                _signedDistancedMaterial.hideFlags = HideFlags.HideAndDontSave;
             }
 
             // Could refactor using hashy.

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -343,7 +343,6 @@ namespace Crest
             // create mesh
 
             Mesh mesh = new Mesh();
-            mesh.hideFlags = HideFlags.DontSave;
             if (verts != null && verts.Count > 0)
             {
                 Vector3[] arrV = new Vector3[verts.Count];
@@ -453,7 +452,6 @@ namespace Crest
             {
                 // instantiate and place patch
                 var patch = new GameObject($"Tile_L{lodIndex}_{patchTypes[i]}");
-                patch.hideFlags = HideFlags.DontSave;
                 patch.layer = oceanLayer;
                 patch.transform.parent = parent;
                 Vector2 pos = offsets[i];

--- a/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Reflection/OceanPlanarReflection.cs
@@ -321,7 +321,6 @@ namespace Crest
                 {
                     name = "__WaterReflection" + GetHashCode(),
                     isPowerOfTwo = true,
-                    hideFlags = HideFlags.DontSave
                 };
                 _reflectionTexture.Create();
                 PreparedReflections.Register(currentCamera.GetHashCode(), _reflectionTexture);

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -298,7 +298,6 @@ namespace Crest
                 if (_matGenerateWavesGlobal == null)
                 {
                     _matGenerateWavesGlobal = new Material(Shader.Find("Hidden/Crest/Inputs/Animated Waves/Gerstner Global"));
-                    _matGenerateWavesGlobal.hideFlags = HideFlags.HideAndDontSave;
                 }
 
                 _matGenerateWaves = _matGenerateWavesGlobal;
@@ -308,7 +307,6 @@ namespace Crest
                 if (_matGenerateWavesGeometry == null)
                 {
                     _matGenerateWavesGeometry = new Material(Shader.Find("Crest/Inputs/Animated Waves/Gerstner Geometry"));
-                    _matGenerateWavesGeometry.hideFlags = HideFlags.HideAndDontSave;
                 }
 
                 _matGenerateWaves = _matGenerateWavesGeometry;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -632,7 +632,6 @@ namespace Crest
                 if (_matGenerateWavesGlobal == null)
                 {
                     _matGenerateWavesGlobal = new Material(Shader.Find("Hidden/Crest/Inputs/Animated Waves/Gerstner Global"));
-                    _matGenerateWavesGlobal.hideFlags = HideFlags.HideAndDontSave;
                 }
 
                 _matGenerateWaves = _matGenerateWavesGlobal;
@@ -642,7 +641,6 @@ namespace Crest
                 if (_matGenerateWavesGeometry == null)
                 {
                     _matGenerateWavesGeometry = new Material(Shader.Find("Crest/Inputs/Animated Waves/Gerstner Geometry"));
-                    _matGenerateWavesGeometry.hideFlags = HideFlags.HideAndDontSave;
                 }
 
                 _matGenerateWaves = _matGenerateWavesGeometry;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -22,6 +22,7 @@ Fixed
 .. bullet_list::
 
    -  Fix shader compiler error.
+   -  Fix several material and mesh memory leaks and reference leaks.
 
 
 4.15


### PR DESCRIPTION
Helps solve #999.

Fixes several leaks that will persist during an entire Unity session due to using [HideFlags.DontSave](https://docs.unity3d.com/ScriptReference/HideFlags.DontSave.html) or [HideFlags.HideAndDontSave](https://docs.unity3d.com/ScriptReference/HideFlags.HideAndDontSave.html).

