### PR TITLE
Fix XR SPI both eyes being the same

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Helpers/Resources/Utility.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Helpers/Resources/Utility.shader
@@ -61,6 +61,8 @@ Shader "Hidden/Crest/Helpers/Utility"
 
 			float4 Fragment(Varyings input) : SV_Target
 			{
+				// We need this when sampling a screenspace texture.
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 				return LOAD_TEXTURE2D_X(_CameraColorTexture, input.positionCS.xy);
 			}
 			ENDHLSL
@@ -86,6 +88,8 @@ Shader "Hidden/Crest/Helpers/Utility"
 			TEXTURE2D_X(_CameraDepthTexture);
 			float Fragment(Varyings input) : SV_Depth
 			{
+				// We need this when sampling a screenspace texture.
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
 				return LOAD_DEPTH_TEXTURE_X(_CameraDepthTexture, input.positionCS.xy);
 			}
 			ENDHLSL

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -19,6 +19,7 @@ Fixed
 
    -  Provide feedback on how to solve errors from *Sphere-Water Interaction* moving file locations.
    -  Fix *Underwater Renderer* stereo rendering not working in builds for Unity 2021.2.
+   -  Fix *Underwater Renderer* stereo rendering issue where both eyes are same for color and/or depth with certain features enabled.
 
 .. only:: urp
 


### PR DESCRIPTION
I forgot to add XR things to the utility shader which broke stereo rendering.