### PR TITLE
Fix FFT leaks

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/FFTCompute.cs
@@ -172,6 +172,27 @@ namespace Crest
             _isInitialised = true;
         }
 
+        void CleanUp()
+        {
+            // Destroy to clear references.
+            Helpers.Destroy(_spectrumInit);
+            Helpers.Destroy(_spectrumHeight);
+            Helpers.Destroy(_spectrumDisplaceX);
+            Helpers.Destroy(_spectrumDisplaceZ);
+            Helpers.Destroy(_tempFFT1);
+            Helpers.Destroy(_tempFFT2);
+            Helpers.Destroy(_tempFFT3);
+        }
+
+        internal static void CleanUpAll()
+        {
+            foreach (var generator in _generators)
+            {
+                generator.Value.Release();
+                generator.Value.CleanUp();
+            }
+        }
+
         static Dictionary<int, FFTCompute> _generators = new Dictionary<int, FFTCompute>();
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -181,6 +181,8 @@ namespace Crest
         static readonly int sp_FeatherWaveStart = Shader.PropertyToID("_FeatherWaveStart");
         readonly int sp_AxisX = Shader.PropertyToID("_AxisX");
 
+        static int s_Count = 0;
+
         /// <summary>
         /// Min wavelength for a cascade in the wave buffer. Does not depend on viewpoint.
         /// </summary>
@@ -319,6 +321,20 @@ namespace Crest
                 if (i == -1) break;
                 _batches[i] = new FFTBatch(this, MinWavelength(i), i, _matGenerateWaves, _meshForDrawingWaves);
                 registered.Add(0, _batches[i]);
+            }
+        }
+
+        void Awake()
+        {
+            s_Count++;
+        }
+
+        void OnDestroy()
+        {
+            // Since FFTCompute resources are shared we will clear after last ShapeFFT is destroyed.
+            if (--s_Count <= 0)
+            {
+                FFTCompute.CleanUpAll();
             }
         }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -21,6 +21,7 @@ Fixed
    -  Fix *Underwater Renderer* stereo rendering not working in builds for Unity 2021.2.
    -  Fix *Underwater Renderer* stereo rendering issue where both eyes are same for color and/or depth with certain features enabled.
    -  Fix stereo rendering for *Examples* scene.
+   -  Fix *ShapeFFT* memory leaks.
    -  Fix several material and mesh memory leaks and reference leaks.
    -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
 


### PR DESCRIPTION
Fixes the last of #999

FFTCompute resources are not released so I am releasing/destroying resources when the last ShapeFFT is destroyed.