### PR TITLE
Fix long build times when underwater is not used

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
@@ -125,6 +125,12 @@ namespace Crest
                 return;
             }
 
+            // Since shader is in Resources folder, Unity will not strip it when not used so we have to.
+            if (_underwaterRenderers.Count == 0)
+            {
+                data.Clear();
+            }
+
 #if CREST_DEBUG
             var shaderVariantCount = data.Count;
             var shaderVarientStrippedCount = 0;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -24,6 +24,7 @@ Fixed
    -  Fix *ShapeFFT* memory leaks.
    -  Fix several material and mesh memory leaks and reference leaks.
    -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
+   -  Fix excessively long build times when no *Underwater Renderer* is present in scene.
 
 .. only:: urp
 


### PR DESCRIPTION
When no UR is present, shader stripping is skipped. The shader being in the Resources folder prevents Unity from stripping it.