### PR TITLE
Re-enable height queries in edit mode

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -311,6 +311,10 @@ namespace Crest
         bool _followSceneCamera = true;
 #pragma warning restore 414
 
+        [Tooltip("Whether height queries are enabled in edit mode."), SerializeField]
+        bool _heightQueries = true;
+
+
         [Header("Server Settings")]
         [Tooltip("Emulate batch mode which models running without a display (but with a GPU available). Equivalent to running standalone build with -batchmode argument."), SerializeField]
         bool _forceBatchMode = false;
@@ -1021,7 +1025,8 @@ namespace Crest
 #if UNITY_EDITOR
             // Issue #630 - seems to be a terrible memory leak coming from creating async gpu readbacks. We don't rely on queries in edit mode AFAIK
             // so knock this out.
-            if (EditorApplication.isPlaying)
+            // This was marked as resolved by Unity and confirmed fixed by forum posts.
+            if (_heightQueries || EditorApplication.isPlaying)
 #endif
             {
                 CollisionProvider?.UpdateQueries();

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,6 +13,14 @@ Release Notes
 |version|
 ---------
 
+Changed
+^^^^^^^
+.. bullet_list::
+
+   -  Re-enable height queries in edit-mode which allows several height based components to work in edit-mode.
+      They can still be disabled with the new *Height Queries* toggle on the *Ocean Renderer*.
+
+
 Fixed
 ^^^^^
 .. bullet_list::
@@ -25,6 +33,7 @@ Fixed
    -  Fix several material and mesh memory leaks and reference leaks.
    -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
    -  Fix excessively long build times when no *Underwater Renderer* is present in scene.
+   -  Fix *Underwater Renderer* not working with varying water level.
 
 .. only:: birp
 


### PR DESCRIPTION
Related #630

Two cases of memory leaks have been fixed by Unity related to queries for a while now:
https://issuetracker.unity3d.com/issues/asyncgpureadback-can-leak-memory-under-certain-circumstances
https://issuetracker.unity3d.com/issues/asyncgpureadback-dot-request-never-releases-unused-allocated-memory

To be safe I have added a toggle for edit mode queries (enabled by default):
![123](https://user-images.githubusercontent.com/5249806/166126852-5feac99a-76a5-488a-97cc-41ab3f875b06.jpg)

Re-enabling these is useful for visualising height queries and edit mode underwater rendering when height is modified.