### PR TITLE
Scale samples-per-wave with FFT res

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -72,7 +72,7 @@ namespace Crest
 
         [Header("Generation Settings")]
         [Tooltip("Resolution to use for wave generation buffers. Low resolutions are more efficient but can result in noticeable patterns in the shape."), Delayed]
-        public int _resolution = 32;
+        public int _resolution = 128;
 
         [Tooltip("In Editor, shows the wave generation buffers on screen."), SerializeField]
 #pragma warning disable 414
@@ -187,10 +187,14 @@ namespace Crest
         public float MinWavelength(int cascadeIdx)
         {
             var diameter = 0.5f * (1 << cascadeIdx);
-            var texelSize = diameter / _resolution;
             // Matches constant with same name in FFTSpectrum.compute
-            float SAMPLES_PER_WAVE = 4f;
-            return texelSize * SAMPLES_PER_WAVE;
+            var WAVE_SAMPLE_FACTOR = 8f;
+            return diameter / WAVE_SAMPLE_FACTOR;
+
+            // This used to be:
+            //var texelSize = diameter / _resolution;
+            //float samplesPerWave = _resolution / 8;
+            //return texelSize * samplesPerWave;
         }
 
         public void CrestUpdate(CommandBuffer buf)
@@ -366,6 +370,12 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
+        private void OnValidate()
+        {
+            _resolution = Mathf.ClosestPowerOfTwo(_resolution);
+            _resolution = Mathf.Max(_resolution, 16);
+        }
+
         private void OnDrawGizmosSelected()
         {
             DrawMesh();

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTSpectrum.compute
@@ -19,9 +19,6 @@
 #define SPECTRUM_OCTAVE_COUNT		14.0
 #define SPECTRUM_SMALLEST_WL_POW_2	-4.0
 
-// Matches variable with same name in ShapeFFT.cs
-#define SAMPLES_PER_WAVE 4
-
 uint _Size;
 float _WindSpeed;
 float _Turbulence;
@@ -135,13 +132,20 @@ void SpectrumInitalize(uint3 id : SV_DispatchThreadID)
 
 	uint maxCoord = int( max( abs( coord.x ), abs( coord.y ) ) );
 
+	// Matches variable with same name in ShapeFFT.cs
+	uint WAVE_SAMPLE_FACTOR = 8;
+
 	// If not largest cascade which will get all wavelengths, then limit
-	// so we split range of frequencies with no overlaps
+	// so we split range of frequencies with no overlaps.
+	// The check on maxCoord below looks pretty magic. It is optimised version of:
+	// uint samplesPerWave = _Size / WAVE_SAMPLE_FACTOR;
+	// Too low wavelength (maxCoord < _Size / (2 * samplesPerWave) ||
+	// Too high wavelength maxCoord >= _Size / samplesPerWave)
 	if ( id.z < (depth - 1) &&
 		// Too low wavelength
-		( maxCoord < _Size / (2 * SAMPLES_PER_WAVE) ||
+		maxCoord < WAVE_SAMPLE_FACTOR / 2 ||
 		// Too high wavelength
-		maxCoord >= _Size / SAMPLES_PER_WAVE )
+		maxCoord >= WAVE_SAMPLE_FACTOR
 		)
 	{
 		_ResultInit[id] = 0.0;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -17,6 +17,8 @@ Changed
 ^^^^^^^
 .. bullet_list::
 
+   -  Default FFT resolution increased to match quality standards.
+   -  FFT samples-per-wave now scales proportionally to FFT resolution, meaning overall quality scales gracefully with the resolution setting.
    -  Re-enable height queries in edit-mode which allows several height based components to work in edit-mode.
       They can still be disabled with the new *Height Queries* toggle on the *Ocean Renderer*.
 


### PR DESCRIPTION
Now if you increase the resolution of the FFT, the waves will receive more samples, so the quality ramps with the FFT res. This is how it should have been all along, and it makes for a more natural implementation.

Increased FFT default res to 128 to help improve default quality. This is still cheaper than doing a single 512x512 FFT which would be standard in many systems.

I tried a few test scenes and it did not seem to break the results but a second pair of eyes might be useful.

Finally it adds validation to ensure the ShapeFFT behaves gracefully for invalid settings.