### PR TITLE
Fix memory/reference leaks

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -50,7 +50,15 @@ namespace Crest
 
         static readonly Dictionary<System.Type, string> s_simNames = new Dictionary<System.Type, string>();
 
-        static Dictionary<RenderTexture, Material> s_textureArrayMaterials = new Dictionary<RenderTexture, Material>();
+        static Material s_DebugArrayMaterial;
+        static Material DebugArrayMaterial
+        {
+            get
+            {
+                if (s_DebugArrayMaterial == null) s_DebugArrayMaterial = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
+                return s_DebugArrayMaterial;
+            }
+        }
 
         static OceanDebugGUI s_Instance;
 
@@ -90,6 +98,12 @@ namespace Crest
         void OnDisable()
         {
             s_Instance = null;
+        }
+
+        void OnDestroy()
+        {
+            // Safe as there should only be one instance at a time.
+            Helpers.Destroy(s_DebugArrayMaterial);
         }
 
         Vector3 _viewerPosLastFrame;
@@ -389,18 +403,11 @@ namespace Crest
                         float y = idx * h;
                         if (isRightmost) w += b;
 
-                        s_textureArrayMaterials.TryGetValue(lodData.DataTexture, out var material);
-                        if (material == null)
-                        {
-                            material = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
-                            s_textureArrayMaterials.Add(lodData.DataTexture, material);
-                        }
-
                         // Render specific slice of 2D texture array
-                        material.SetInt("_Depth", idx);
-                        material.SetFloat("_Scale", scale);
-                        material.SetFloat("_Bias", bias);
-                        Graphics.DrawTexture(new Rect(x + b, (y + b / 2f) - scroll, h - b, h - b), lodData.DataTexture, material);
+                        DebugArrayMaterial.SetInt("_Depth", idx);
+                        DebugArrayMaterial.SetFloat("_Scale", scale);
+                        DebugArrayMaterial.SetFloat("_Bias", bias);
+                        Graphics.DrawTexture(new Rect(x + b, (y + b / 2f) - scroll, h - b, h - b), lodData.DataTexture, DebugArrayMaterial);
                     }
                 }
             }
@@ -434,18 +441,11 @@ namespace Crest
                         float y = idx * h;
                         if (offset == 1f) w += b;
 
-                        s_textureArrayMaterials.TryGetValue(data, out var material);
-                        if (material == null)
-                        {
-                            material = new Material(Shader.Find("Hidden/Crest/Debug/TextureArray"));
-                            s_textureArrayMaterials.Add(data, material);
-                        }
-
                         // Render specific slice of 2D texture array
-                        material.SetInt("_Depth", idx);
-                        material.SetFloat("_Scale", scale);
-                        material.SetFloat("_Bias", bias);
-                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), data, material);
+                        DebugArrayMaterial.SetInt("_Depth", idx);
+                        DebugArrayMaterial.SetFloat("_Scale", scale);
+                        DebugArrayMaterial.SetFloat("_Bias", bias);
+                        Graphics.DrawTexture(new Rect(x + b, y + b / 2f, h - b, h - b), data, DebugArrayMaterial);
                     }
                 }
             }
@@ -461,7 +461,6 @@ namespace Crest
         {
             // Init here from 2019.3 onwards
             s_simNames.Clear();
-            s_textureArrayMaterials.Clear();
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -115,6 +115,21 @@ namespace Crest
         float _windDirRadOld;
         OceanWaveSpectrum _spectrumOld;
 
+        static OceanWaveSpectrum s_DefaultSpectrum;
+        protected static OceanWaveSpectrum DefaultSpectrum
+        {
+            get
+            {
+                if (s_DefaultSpectrum == null)
+                {
+                    s_DefaultSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
+                    s_DefaultSpectrum.name = "Default Waves (auto)";
+                }
+
+                return s_DefaultSpectrum;
+            }
+        }
+
         public class FFTBatch : ILodDataInput
         {
             ShapeFFT _shapeFFT;
@@ -254,8 +269,7 @@ namespace Crest
 
             if (_activeSpectrum == null)
             {
-                _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
-                _activeSpectrum.name = "Default Waves (auto)";
+                _activeSpectrum = DefaultSpectrum;
             }
 
             // Unassign mesh
@@ -335,6 +349,11 @@ namespace Crest
             if (--s_Count <= 0)
             {
                 FFTCompute.CleanUpAll();
+
+                if (s_DefaultSpectrum != null)
+                {
+                    Helpers.Destroy(s_DefaultSpectrum);
+                }
             }
         }
 
@@ -350,8 +369,7 @@ namespace Crest
 
             if (_activeSpectrum == null)
             {
-                _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
-                _activeSpectrum.name = "Default Waves (auto)";
+                _activeSpectrum = DefaultSpectrum;
             }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -238,8 +238,17 @@ namespace Crest
 
         void InitData()
         {
+            if (_waveBuffers == null)
             {
                 _waveBuffers = new RenderTexture(_resolution, _resolution, 0, GraphicsFormat.R16G16B16A16_SFloat);
+            }
+            else
+            {
+                _waveBuffers.Release();
+            }
+
+            {
+                _waveBuffers.width = _waveBuffers.height = _resolution;
                 _waveBuffers.wrapMode = TextureWrapMode.Clamp;
                 _waveBuffers.antiAliasing = 1;
                 _waveBuffers.filterMode = FilterMode.Bilinear;
@@ -251,6 +260,9 @@ namespace Crest
                 _waveBuffers.enableRandomWrite = true;
                 _waveBuffers.Create();
             }
+
+            _bufCascadeParams?.Release();
+            _bufWaveData?.Release();
 
             _bufCascadeParams = new ComputeBuffer(CASCADE_COUNT + 1, UnsafeUtility.SizeOf<GerstnerCascadeParams>());
             _bufWaveData = new ComputeBuffer(MAX_WAVE_COMPONENTS / 4, UnsafeUtility.SizeOf<GerstnerWaveComponent4>());

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -90,6 +90,22 @@ namespace Crest
 
         float _windSpeedWhenGenerated = -1f;
 
+        static int s_InstanceCount = 0;
+        static OceanWaveSpectrum s_DefaultSpectrum;
+        protected static OceanWaveSpectrum DefaultSpectrum
+        {
+            get
+            {
+                if (s_DefaultSpectrum == null)
+                {
+                    s_DefaultSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
+                    s_DefaultSpectrum.name = "Default Waves (auto)";
+                }
+
+                return s_DefaultSpectrum;
+            }
+        }
+
         public class GerstnerBatch : ILodDataInput
         {
             ShapeGerstner _gerstner;
@@ -313,8 +329,7 @@ namespace Crest
 
             if (_activeSpectrum == null)
             {
-                _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
-                _activeSpectrum.name = "Default Waves (auto)";
+                _activeSpectrum = DefaultSpectrum;
             }
 
             // Unassign mesh
@@ -670,8 +685,7 @@ namespace Crest
 
             if (_activeSpectrum == null)
             {
-                _activeSpectrum = ScriptableObject.CreateInstance<OceanWaveSpectrum>();
-                _activeSpectrum.name = "Default Waves (auto)";
+                _activeSpectrum = DefaultSpectrum;
             }
 
 #if UNITY_EDITOR
@@ -726,6 +740,22 @@ namespace Crest
                     Destroy(_waveBuffers);
                 }
                 _waveBuffers = null;
+            }
+        }
+
+        void Awake()
+        {
+            s_InstanceCount++;
+        }
+
+        void OnDestroy()
+        {
+            if (--s_InstanceCount <= 0)
+            {
+                if (s_DefaultSpectrum != null)
+                {
+                    Helpers.Destroy(s_DefaultSpectrum);
+                }
             }
         }
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -29,9 +29,7 @@ Fixed
    -  Fix *Underwater Renderer* stereo rendering not working in builds for Unity 2021.2.
    -  Fix *Underwater Renderer* stereo rendering issue where both eyes are same for color and/or depth with certain features enabled.
    -  Fix stereo rendering for *Examples* scene.
-   -  Fix *ShapeFFT* memory leaks.
-   -  Fix several material and mesh memory leaks and reference leaks.
-   -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
+   -  Fix many memory/reference leaks.
    -  Fix excessively long build times when no *Underwater Renderer* is present in scene.
    -  Fix *Underwater Renderer* not working with varying water level.
 


### PR DESCRIPTION
Helps solve #999

Fixes more leaks. I went through to see if I could find more, but found none which were proper leaks where duplicates where made. There are still a few references which are not cleared on scene switch, but they were more involved/risky fixes to make and didn't seem worth it for a patch release since they were minor and non duplicating.