### PR TITLE
Fix jagged shoreline foam when using baked depth cache

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -429,7 +429,7 @@ namespace Crest
                 ti.alphaIsTransparency = false;
                 // Compression will clamp negative values.
                 ti.textureCompression = TextureImporterCompression.Uncompressed;
-                ti.filterMode = FilterMode.Point;
+                ti.filterMode = FilterMode.Bilinear;
                 ti.wrapMode = TextureWrapMode.Clamp;
                 // Values are slightly different with NPOT Scale applied.
                 ti.npotScale = TextureImporterNPOTScale.None;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,7 @@ Fixed
    -  Fix several *Texture2D* and *RenderTexture* memory and reference leaks.
    -  Fix excessively long build times when no *Underwater Renderer* is present in scene.
    -  Fix *Underwater Renderer* not working with varying water level.
+   -  Fix jagged shoreline foam when using baked *Sea Floor Depth* cache.
 
 .. only:: birp
 


### PR DESCRIPTION
I made baked depth cache point filtering which was a huge mistake... Switched to bilinear.