### PR TITLE
Main Scene cross RP support

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Crest.Examples.asmdef
+++ b/crest/Assets/Crest/Crest-Examples/Crest.Examples.asmdef
@@ -1,8 +1,12 @@
 {
     "name": "Crest.Examples",
+    "rootNamespace": "",
     "references": [
         "Crest",
-        "Unity.InputSystem"
+        "Unity.InputSystem",
+        "Unity.RenderPipelines.Core.Runtime",
+        "Unity.RenderPipelines.Universal.Runtime",
+        "Unity.RenderPipelines.HighDefinition.Runtime"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -21,6 +25,21 @@
             "name": "com.unity.modules.xr",
             "expression": "1.0.0",
             "define": "ENABLE_XR_MODULE"
+        },
+        {
+            "name": "com.unity.render-pipelines.core",
+            "expression": "",
+            "define": "CREST_SRP"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "",
+            "define": "CREST_URP"
+        },
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "",
+            "define": "CREST_HDRP"
         }
     ],
     "noEngineReferences": false

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d11d3827648a44374b3bc53cd56cfdab
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/Crest.Examples.Editor.asmdef
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/Crest.Examples.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Crest.Examples.Editor",
+    "rootNamespace": "",
+    "references": [
+        "Crest"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/Crest.Examples.Editor.asmdef.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/Crest.Examples.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: facfe0fe72133481baf13695e4b9625f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/RenderPipeline.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/RenderPipeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 780b2f265d4cd4a65940bf1d5e36cac8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/RenderPipeline/RenderPipelinePrefabDontSave.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/RenderPipeline/RenderPipelinePrefabDontSave.cs
@@ -1,0 +1,42 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest.Examples
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using UnityEditor;
+    using UnityEngine;
+
+    /// <summary>
+    /// Makes prefab files with naming convention saveable only when the desired RP is active.
+    /// </summary>
+    public class RenderPipelinePrefabDontSave : AssetModificationProcessor
+    {
+        static string[] OnWillSaveAssets(string[] paths)
+        {
+            var rp = RenderPipelineHelper.CurrentRenderPipelineShortName;
+            var toSave = new List<string>();
+
+            foreach (var path in paths)
+            {
+                var name = Path.GetFileNameWithoutExtension(path);
+                var extension = Path.GetExtension(path);
+                // Must start with "Crest" for safety. Must end with "RP" otherwise all non RP prefabs will trigger it.
+                var noSave = extension == ".prefab" && name.StartsWith("Crest") && name.EndsWith("RP") && !name.EndsWith(rp);
+
+                if (noSave)
+                {
+                    Debug.Log($"Crest: Cannot save prefab (<i>{path}</i>) as it can only be saved when {rp} is active.");
+                }
+                else
+                {
+                    toSave.Add(path);
+                }
+            }
+
+            return toSave.ToArray();
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/RenderPipeline/RenderPipelinePrefabDontSave.cs.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Editor/RenderPipeline/RenderPipelinePrefabDontSave.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 24550b3f9e0b947f19cc6123f83f9bb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8960d8d13645742849cee8b166537cda
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 79d3d743e890045a9be23278a395028a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineEditLock.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineEditLock.cs
@@ -1,0 +1,75 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+#if UNITY_EDITOR
+
+namespace Crest.Examples
+{
+    using UnityEngine;
+    using UnityEngine.Rendering;
+
+    /// <summary>
+    /// Makes the hierarchy editable only when the desired RP is active.
+    /// </summary>
+    [ExecuteAlways]
+    public class RenderPipelineEditLock : MonoBehaviour
+    {
+        [SerializeField]
+        Crest.RenderPipeline _renderPipeline;
+
+        HideFlags _oldHideFlags;
+
+        void OnEnable()
+        {
+            _oldHideFlags = gameObject.hideFlags;
+            UpdateHideFlags();
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= UpdateHideFlags;
+            RenderPipelineManager.activeRenderPipelineTypeChanged += UpdateHideFlags;
+        }
+
+        void OnDisable()
+        {
+            gameObject.hideFlags = _oldHideFlags;
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= UpdateHideFlags;
+        }
+
+        void OnValidate()
+        {
+            UpdateHideFlags();
+        }
+
+        void UpdateHideFlags()
+        {
+            // This can be null.
+            if (!this)
+            {
+                return;
+            }
+
+            if (_renderPipeline == Crest.RenderPipeline.None)
+            {
+                return;
+            }
+
+            if (RenderPipelineHelper.CurrentRenderPipeline != _renderPipeline)
+            {
+                // Make hierarchy not editable.
+                foreach (var transform in GetComponentsInChildren<Transform>())
+                {
+                    transform.gameObject.hideFlags = HideFlags.NotEditable;
+                }
+            }
+            else
+            {
+                // Make hierarchy editable.
+                foreach (var transform in GetComponentsInChildren<Transform>())
+                {
+                    transform.gameObject.hideFlags = _oldHideFlags;
+                }
+            }
+        }
+    }
+}
+
+#endif // UNITY_EDITOR

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineEditLock.cs.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineEditLock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acfe7271b93004302ba6a75774652d98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineLightingSettingsUpdater.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineLightingSettingsUpdater.cs
@@ -1,0 +1,39 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+// Restores "Lighting > Environment" settings after switching from HDRP. "Lighting > Other Settings" do not need
+// restoring. We only need to restore the skybox as we use the default values for everything else.
+
+namespace Crest.Examples
+{
+    using UnityEngine;
+    using UnityEngine.Rendering;
+
+    [ExecuteAlways]
+    public class RenderPipelineLightingSettingsUpdater : MonoBehaviour
+    {
+        [SerializeField]
+        Material _skybox;
+
+        void OnEnable()
+        {
+            UpdateEnvironmentSettings();
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= UpdateEnvironmentSettings;
+            RenderPipelineManager.activeRenderPipelineTypeChanged += UpdateEnvironmentSettings;
+        }
+
+        void OnDisable()
+        {
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= UpdateEnvironmentSettings;
+        }
+
+        void UpdateEnvironmentSettings()
+        {
+            if (RenderPipelineHelper.IsLegacy || RenderPipelineHelper.IsUniversal)
+            {
+                RenderSettings.skybox = _skybox;
+            }
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineLightingSettingsUpdater.cs.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelineLightingSettingsUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2b12eef64b6d84c24a1d95fd5b3c2ec7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelinePrefabSelector.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelinePrefabSelector.cs
@@ -1,0 +1,93 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+namespace Crest.Examples
+{
+    using UnityEditor;
+    using UnityEngine;
+    using UnityEngine.Rendering;
+
+    [ExecuteAlways]
+    public class RenderPipelinePrefabSelector : MonoBehaviour
+    {
+        [SerializeField]
+        GameObject _prefabLegacy;
+
+        [SerializeField]
+        GameObject _prefabHighDefinition;
+
+        [SerializeField]
+        GameObject _prefabUniversal;
+
+        GameObject _prefab;
+
+        void OnEnable()
+        {
+            if (transform.childCount == 0)
+            {
+                LoadPrefab();
+            }
+            else if (_prefab == null)
+            {
+                _prefab = transform.GetChild(0).gameObject;
+            }
+
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= LoadPrefab;
+            RenderPipelineManager.activeRenderPipelineTypeChanged += LoadPrefab;
+        }
+
+        void OnDisable()
+        {
+            Helpers.Destroy(_prefab);
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= LoadPrefab;
+        }
+
+        void LoadPrefab()
+        {
+            switch (RenderPipelineHelper.CurrentRenderPipeline)
+            {
+                case Crest.RenderPipeline.Legacy:
+                    LoadPrefab(_prefabLegacy);
+                    break;
+                case Crest.RenderPipeline.Universal:
+                    LoadPrefab(_prefabUniversal);
+                    break;
+                case Crest.RenderPipeline.HighDefinition:
+                    LoadPrefab(_prefabHighDefinition);
+                    break;
+                default:
+                    throw new System.Exception("Crest: An unknown render pipeline is active.");
+            }
+        }
+
+        void LoadPrefab(GameObject prefab)
+        {
+            if (_prefab != null)
+            {
+                Helpers.Destroy(_prefab);
+            }
+
+            if (prefab == null)
+            {
+                return;
+            }
+
+#if UNITY_EDITOR
+            _prefab = (GameObject)PrefabUtility.InstantiatePrefab(prefab, transform);
+#else
+            _prefab = (GameObject)Instantiate(prefab, transform);
+#endif
+
+#if UNITY_EDITOR
+            // Disable editing for the prefab and its hierarchy because using "Apply to Prefab" on a property in the
+            // inspector will recreate the prefab and it could be serialised. Prefab editing can be done with context in
+            // in the prefab stage so there is no need to edit in the scene stage.
+            foreach (var transform in _prefab.GetComponentsInChildren<Transform>())
+            {
+                transform.gameObject.hideFlags = HideFlags.DontSave | HideFlags.NotEditable;
+            }
+#endif
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelinePrefabSelector.cs.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Helpers/RenderPipeline/RenderPipelinePrefabSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20cfca36749854523aa12b4ea4f0cba1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Lit.shadergraph
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Lit.shadergraph
@@ -1,0 +1,2335 @@
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.GraphData",
+    "m_ObjectId": "219d0408c72243a8b48a7150191aefad",
+    "m_Properties": [
+        {
+            "m_Id": "32a1b39e2b7f4ff4ac5ac828b0cdfd9c"
+        },
+        {
+            "m_Id": "157f6951fc4f45c38945a3835e500101"
+        },
+        {
+            "m_Id": "7d53f12e89154dffbe022a1cd71ef300"
+        },
+        {
+            "m_Id": "2d0b70f7c70847ec94f2da9edcb9527a"
+        },
+        {
+            "m_Id": "df77e63a10524db7bbfa3ab581dcec34"
+        },
+        {
+            "m_Id": "d4e6fe4110a2411e9377e8a64429bdfc"
+        },
+        {
+            "m_Id": "de9312c2664e41a69db2e1e0f2a2822e"
+        }
+    ],
+    "m_Keywords": [],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "d31516fc9d9c4569bc0c869ebcd4be95"
+        }
+    ],
+    "m_Nodes": [
+        {
+            "m_Id": "6714ab0a231845139bf7ca03689d00be"
+        },
+        {
+            "m_Id": "faf0b3b6aea24c5c98a6aa09d33e005b"
+        },
+        {
+            "m_Id": "4f3c4239d7aa420fa59e1965054a4787"
+        },
+        {
+            "m_Id": "009651a611ed484c9da2132ea3904b32"
+        },
+        {
+            "m_Id": "20f935392d8d4e65a40bda641215485a"
+        },
+        {
+            "m_Id": "8f05c7802c4d4efa8be5f98eef48e89e"
+        },
+        {
+            "m_Id": "62ff9996f202453a92782f16b221157a"
+        },
+        {
+            "m_Id": "b286494cfcd74e9fa691d7fce27cd3f1"
+        },
+        {
+            "m_Id": "bbe46d3150ca40b7b4108d91186a665f"
+        },
+        {
+            "m_Id": "ee6732035c9e4da493a23b3f3b3a59e4"
+        },
+        {
+            "m_Id": "8a59780f552745e1a81e43b4390c6727"
+        },
+        {
+            "m_Id": "abc9230db9154e0f8df78c8bc28cd425"
+        },
+        {
+            "m_Id": "3323b9b818204ef899438468f25fcf46"
+        },
+        {
+            "m_Id": "21950c6c389f44a4b234c92ce97f696d"
+        },
+        {
+            "m_Id": "1eae3a5bdbd74dfa87e140e9a75215c1"
+        },
+        {
+            "m_Id": "3e98f68c72d245dbadb1469fae761c3a"
+        },
+        {
+            "m_Id": "58aea0047d1a4e60a6478792d3c076bd"
+        },
+        {
+            "m_Id": "e3c83cb5ecee43cd924276689d160b59"
+        },
+        {
+            "m_Id": "a03574a13cc04d8f9cd6ed62eca303e9"
+        },
+        {
+            "m_Id": "5410887aeac5437fa5488d2ec46612e1"
+        },
+        {
+            "m_Id": "a82881b3ac7b400a9e9966ae48b03e81"
+        },
+        {
+            "m_Id": "9a3a8549247c4252bc2d26d306a2e7a9"
+        },
+        {
+            "m_Id": "b2e37d24d66f44d39f729f37bdadb3ef"
+        }
+    ],
+    "m_GroupDatas": [
+        {
+            "m_Id": "9ddc359ce9a34edeb1316414c15b72bc"
+        }
+    ],
+    "m_StickyNoteDatas": [],
+    "m_Edges": [
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "1eae3a5bdbd74dfa87e140e9a75215c1"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "bbe46d3150ca40b7b4108d91186a665f"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "21950c6c389f44a4b234c92ce97f696d"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "20f935392d8d4e65a40bda641215485a"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "3e98f68c72d245dbadb1469fae761c3a"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "58aea0047d1a4e60a6478792d3c076bd"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "5410887aeac5437fa5488d2ec46612e1"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "62ff9996f202453a92782f16b221157a"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "58aea0047d1a4e60a6478792d3c076bd"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "009651a611ed484c9da2132ea3904b32"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "58aea0047d1a4e60a6478792d3c076bd"
+                },
+                "m_SlotId": 2
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "a82881b3ac7b400a9e9966ae48b03e81"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "9a3a8549247c4252bc2d26d306a2e7a9"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "b286494cfcd74e9fa691d7fce27cd3f1"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "a03574a13cc04d8f9cd6ed62eca303e9"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "58aea0047d1a4e60a6478792d3c076bd"
+                },
+                "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "a82881b3ac7b400a9e9966ae48b03e81"
+                },
+                "m_SlotId": 4
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ee6732035c9e4da493a23b3f3b3a59e4"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "b2e37d24d66f44d39f729f37bdadb3ef"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "8a59780f552745e1a81e43b4390c6727"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "e3c83cb5ecee43cd924276689d160b59"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "3e98f68c72d245dbadb1469fae761c3a"
+                },
+                "m_SlotId": 1
+            }
+        }
+    ],
+    "m_VertexContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 0.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "6714ab0a231845139bf7ca03689d00be"
+            },
+            {
+                "m_Id": "faf0b3b6aea24c5c98a6aa09d33e005b"
+            },
+            {
+                "m_Id": "4f3c4239d7aa420fa59e1965054a4787"
+            }
+        ]
+    },
+    "m_FragmentContext": {
+        "m_Position": {
+            "x": 0.0,
+            "y": 200.0
+        },
+        "m_Blocks": [
+            {
+                "m_Id": "009651a611ed484c9da2132ea3904b32"
+            },
+            {
+                "m_Id": "20f935392d8d4e65a40bda641215485a"
+            },
+            {
+                "m_Id": "8f05c7802c4d4efa8be5f98eef48e89e"
+            },
+            {
+                "m_Id": "62ff9996f202453a92782f16b221157a"
+            },
+            {
+                "m_Id": "b286494cfcd74e9fa691d7fce27cd3f1"
+            },
+            {
+                "m_Id": "bbe46d3150ca40b7b4108d91186a665f"
+            },
+            {
+                "m_Id": "ee6732035c9e4da493a23b3f3b3a59e4"
+            },
+            {
+                "m_Id": "8a59780f552745e1a81e43b4390c6727"
+            },
+            {
+                "m_Id": "abc9230db9154e0f8df78c8bc28cd425"
+            },
+            {
+                "m_Id": "3323b9b818204ef899438468f25fcf46"
+            }
+        ]
+    },
+    "m_PreviewData": {
+        "serializedMesh": {
+            "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
+            "m_Guid": ""
+        },
+        "preventRotation": false
+    },
+    "m_Path": "Crest/Examples",
+    "m_GraphPrecision": 1,
+    "m_PreviewMode": 2,
+    "m_OutputNode": {
+        "m_Id": ""
+    },
+    "m_ActiveTargets": [
+        {
+            "m_Id": "dea4c38abd8d446da36e8f1015923bad"
+        },
+        {
+            "m_Id": "3e1b4b88b1d44148adb60bae1c11979f"
+        },
+        {
+            "m_Id": "5ee68e8bedaf417ab0eb90e935a62b79"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "009651a611ed484c9da2132ea3904b32",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BaseColor",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "2a38ce4450bf4ac6ac68411cb676751e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BaseColor"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "078d46e2f2884c2fbe80bb7ca3572179",
+    "m_Id": 0,
+    "m_DisplayName": "RGBA",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "RGBA",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "07c2161a029d4368a6903798173caae9",
+    "m_Id": 6,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "08258379cf7f404b9906ab0a7917a7ba",
+    "m_Id": 3,
+    "m_DisplayName": "B",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "0e822873719a4c4dacc5685335b68481",
+    "m_Id": 0,
+    "m_DisplayName": "Specular Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Specular",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.HDLitData",
+    "m_ObjectId": "11fa4628946c4447877535bf40d157aa",
+    "m_RayTracing": false,
+    "m_MaterialType": 0,
+    "m_RefractionModel": 0,
+    "m_SSSTransmission": true,
+    "m_EnergyConservingSpecular": true,
+    "m_ClearCoat": false
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "157f6951fc4f45c38945a3835e500101",
+    "m_Guid": {
+        "m_GuidSerialized": "34f64712-c660-4713-bba8-ee7fe593c21b"
+    },
+    "m_Name": "Smoothness",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Smoothness",
+    "m_DefaultReferenceName": "_Smoothness",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 1,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "17524596ea8f42f0ad47da2845aa606e",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "1eae3a5bdbd74dfa87e140e9a75215c1",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -148.66668701171876,
+            "y": 451.3333740234375,
+            "width": 117.33334350585938,
+            "height": 35.999969482421878
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "458c5ca86e8d4438bca0856e16dacd4f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "7d53f12e89154dffbe022a1cd71ef300"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "202c6239da754bf2871c0449d43703e9",
+    "m_Id": 0,
+    "m_DisplayName": "Smoothness",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "20f935392d8d4e65a40bda641215485a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Smoothness",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a8b0dcdf5a3d4d93ba72edae77f7e1da"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Smoothness"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "21950c6c389f44a4b234c92ce97f696d",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -172.6666259765625,
+            "y": 280.66668701171877,
+            "width": 141.3332977294922,
+            "height": 35.999969482421878
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "202c6239da754bf2871c0449d43703e9"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "157f6951fc4f45c38945a3835e500101"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "22c185d83e85406da404d69fa2c2d219",
+    "m_Id": 2,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DMaterialSlot",
+    "m_ObjectId": "25ee23c971bc4333921af44959a28f99",
+    "m_Id": 0,
+    "m_DisplayName": "Base Map",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "282f355fed794ab5a2f238a16b51e45d",
+    "m_Id": 0,
+    "m_DisplayName": "Bent Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BentNormal",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "2a38ce4450bf4ac6ac68411cb676751e",
+    "m_Id": 0,
+    "m_DisplayName": "Base Color",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "BaseColor",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.5,
+        "y": 0.5,
+        "z": 0.5
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 0,
+    "m_DefaultColor": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Texture2DShaderProperty",
+    "m_ObjectId": "2d0b70f7c70847ec94f2da9edcb9527a",
+    "m_Guid": {
+        "m_GuidSerialized": "fe011aee-b45f-4335-b83c-dd28ee740f2f"
+    },
+    "m_Name": "Base Map",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Base Map",
+    "m_DefaultReferenceName": "_Base_Map",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "isMainTexture": true,
+    "useTilingAndOffset": false,
+    "m_Modifiable": true,
+    "m_DefaultType": 0
+}
+
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "32a1b39e2b7f4ff4ac5ac828b0cdfd9c",
+    "m_Guid": {
+        "m_GuidSerialized": "4d8c95c8-7507-4b24-bef4-88fb71c8c39a"
+    },
+    "m_Name": "Color",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Color",
+    "m_DefaultReferenceName": "_Color",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "r": 0.501960813999176,
+        "g": 0.501960813999176,
+        "b": 0.501960813999176,
+        "a": 1.0
+    },
+    "isMainColor": false,
+    "m_ColorMode": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "3323b9b818204ef899438468f25fcf46",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Specular",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "0e822873719a4c4dacc5685335b68481"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Specular"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "3730397b8a21400694309f0c16abf3c3",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha Clip Threshold",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.HDTarget",
+    "m_ObjectId": "3e1b4b88b1d44148adb60bae1c11979f",
+    "m_ActiveSubTarget": {
+        "m_Id": "d90c25009b1e4d448d1ad79c13cb0cdd"
+    },
+    "m_Datas": [
+        {
+            "m_Id": "11fa4628946c4447877535bf40d157aa"
+        },
+        {
+            "m_Id": "5d9c23378b2648f7b5ffa44762a8aa4a"
+        },
+        {
+            "m_Id": "7f2feb26011940f69ad5deac4a9aa794"
+        },
+        {
+            "m_Id": "8cea61a7ce5447d2b4e3ae7331af53db"
+        }
+    ],
+    "m_CustomEditorGUI": "",
+    "m_SupportVFX": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SampleTexture2DNode",
+    "m_ObjectId": "3e98f68c72d245dbadb1469fae761c3a",
+    "m_Group": {
+        "m_Id": "9ddc359ce9a34edeb1316414c15b72bc"
+    },
+    "m_Name": "Sample Texture 2D",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -749.3333740234375,
+            "y": 194.66665649414063,
+            "width": 181.99993896484376,
+            "height": 158.66668701171876
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "078d46e2f2884c2fbe80bb7ca3572179"
+        },
+        {
+            "m_Id": "4341baff13aa4c2a954de63517530964"
+        },
+        {
+            "m_Id": "f543a5d3a9cf4a2fa11abd44868fa08b"
+        },
+        {
+            "m_Id": "07c2161a029d4368a6903798173caae9"
+        },
+        {
+            "m_Id": "8be2b73a8ef14299a552ace12d0e8cbe"
+        },
+        {
+            "m_Id": "fbd71984f00443a18f131ac84b7bb0f5"
+        },
+        {
+            "m_Id": "6ff70f0a5ab84babaca47a180df75de3"
+        },
+        {
+            "m_Id": "539b36af13834a7a86ba806876f3ee4e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_TextureType": 0,
+    "m_NormalMapSpace": 0,
+    "m_EnableGlobalMipBias": true
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "4341baff13aa4c2a954de63517530964",
+    "m_Id": 4,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "444e8b0420ec42c0a056c424f72a6b92",
+    "m_Id": 2,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "458c5ca86e8d4438bca0856e16dacd4f",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "4f3c4239d7aa420fa59e1965054a4787",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Tangent",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9f88a671b20440528b46520ca3a02e66"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Tangent"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
+    "m_ObjectId": "539b36af13834a7a86ba806876f3ee4e",
+    "m_Id": 3,
+    "m_DisplayName": "Sampler",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Sampler",
+    "m_StageCapability": 3,
+    "m_BareResource": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "5410887aeac5437fa5488d2ec46612e1",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -186.6666717529297,
+            "y": 366.6667175292969,
+            "width": 155.3333282470703,
+            "height": 36.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "9452ae1ac8854f799eaba2aba9a79f75"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "df77e63a10524db7bbfa3ab581dcec34"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInLitSubTarget",
+    "m_ObjectId": "55f6f8be7343490987e823a78d437505",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "58749045e53e457ab77f95320409704c",
+    "m_Id": 0,
+    "m_DisplayName": "Occlusion",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
+    "m_ObjectId": "58aea0047d1a4e60a6478792d3c076bd",
+    "m_Group": {
+        "m_Id": "9ddc359ce9a34edeb1316414c15b72bc"
+    },
+    "m_Name": "Multiply",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -547.3333129882813,
+            "y": 194.66665649414063,
+            "width": 131.333251953125,
+            "height": 120.00003051757813
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "a983875a368e4778aa1749c455d80fbe"
+        },
+        {
+            "m_Id": "75ba5f15dd1d418ea4af201868e736cf"
+        },
+        {
+            "m_Id": "22c185d83e85406da404d69fa2c2d219"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": false,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.BuiltinData",
+    "m_ObjectId": "5d9c23378b2648f7b5ffa44762a8aa4a",
+    "m_Distortion": false,
+    "m_DistortionMode": 0,
+    "m_DistortionDepthTest": true,
+    "m_AddPrecomputedVelocity": false,
+    "m_TransparentWritesMotionVec": false,
+    "m_AlphaToMask": false,
+    "m_DepthOffset": false,
+    "m_ConservativeDepthOffset": false,
+    "m_TransparencyFog": true,
+    "m_AlphaTestShadow": false,
+    "m_BackThenFrontRendering": false,
+    "m_TransparentDepthPrepass": false,
+    "m_TransparentDepthPostpass": false,
+    "m_SupportLodCrossFade": false
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
+    "m_ObjectId": "5ee68e8bedaf417ab0eb90e935a62b79",
+    "m_ActiveSubTarget": {
+        "m_Id": "e504c8d7bdec4af7b7edf8d5866e47f5"
+    },
+    "m_AllowMaterialOverride": true,
+    "m_SurfaceType": 0,
+    "m_ZTestMode": 4,
+    "m_ZWriteControl": 0,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CastShadows": true,
+    "m_ReceiveShadows": true,
+    "m_CustomEditorGUI": "",
+    "m_SupportVFX": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "62ff9996f202453a92782f16b221157a",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Emission",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "ac6c02345a0e4f6c8f2e9ef8d3b17b51"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Emission"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "6714ab0a231845139bf7ca03689d00be",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Position",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d990f95d250d4fc09e48c71a05f2beca"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Position"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.UVMaterialSlot",
+    "m_ObjectId": "6ff70f0a5ab84babaca47a180df75de3",
+    "m_Id": 2,
+    "m_DisplayName": "UV",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "UV",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0
+    },
+    "m_Labels": [],
+    "m_Channel": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "75ba5f15dd1d418ea4af201868e736cf",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 2.0,
+        "e01": 2.0,
+        "e02": 2.0,
+        "e03": 2.0,
+        "e10": 2.0,
+        "e11": 2.0,
+        "e12": 2.0,
+        "e13": 2.0,
+        "e20": 2.0,
+        "e21": 2.0,
+        "e22": 2.0,
+        "e23": 2.0,
+        "e30": 2.0,
+        "e31": 2.0,
+        "e32": 2.0,
+        "e33": 2.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "7d53f12e89154dffbe022a1cd71ef300",
+    "m_Guid": {
+        "m_GuidSerialized": "3b34edef-d391-4fcb-895c-b00adcca3dce"
+    },
+    "m_Name": "Metallic",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Metallic",
+    "m_DefaultReferenceName": "_Metallic",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.0,
+    "m_FloatType": 1,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.LightingData",
+    "m_ObjectId": "7f2feb26011940f69ad5deac4a9aa794",
+    "m_NormalDropOffSpace": 0,
+    "m_BlendPreserveSpecular": true,
+    "m_ReceiveDecals": true,
+    "m_ReceiveSSR": true,
+    "m_ReceiveSSRTransparent": false,
+    "m_SpecularAA": false,
+    "m_SpecularOcclusionMode": 1,
+    "m_OverrideBakedGI": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "880db1d9b8ec4db486056697f4a73c0f",
+    "m_Id": 4,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "8a59780f552745e1a81e43b4390c6727",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.AlphaClipThreshold",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "db859799333b4eac8ba25bd6ef16426b"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.AlphaClipThreshold"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "8be2b73a8ef14299a552ace12d0e8cbe",
+    "m_Id": 7,
+    "m_DisplayName": "A",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.SystemData",
+    "m_ObjectId": "8cea61a7ce5447d2b4e3ae7331af53db",
+    "m_MaterialNeedsUpdateHash": 529,
+    "m_SurfaceType": 0,
+    "m_RenderingPass": 1,
+    "m_BlendMode": 0,
+    "m_ZTest": 4,
+    "m_ZWrite": false,
+    "m_TransparentCullMode": 2,
+    "m_OpaqueCullMode": 2,
+    "m_SortPriority": 0,
+    "m_AlphaTest": false,
+    "m_TransparentDepthPrepass": false,
+    "m_TransparentDepthPostpass": false,
+    "m_SupportLodCrossFade": false,
+    "m_DoubleSidedMode": 0,
+    "m_DOTSInstancing": false,
+    "m_CustomVelocity": false,
+    "m_Tessellation": false,
+    "m_TessellationMode": 0,
+    "m_TessellationFactorMinDistance": 20.0,
+    "m_TessellationFactorMaxDistance": 50.0,
+    "m_TessellationFactorTriangleSize": 100.0,
+    "m_TessellationShapeFactor": 0.75,
+    "m_TessellationBackFaceCullEpsilon": -0.25,
+    "m_TessellationMaxDisplacement": 0.009999999776482582,
+    "m_Version": 1,
+    "inspectorFoldoutMask": 9
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "8f05c7802c4d4efa8be5f98eef48e89e",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.NormalTS",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c68401c7ac5c48b0ae7357229c0a3b31"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.NormalTS"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "9452ae1ac8854f799eaba2aba9a79f75",
+    "m_Id": 0,
+    "m_DisplayName": "Emissive Color",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "954c7aa5fa044a869ed95f6e4af9b71f",
+    "m_Id": 0,
+    "m_DisplayName": "Normal",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Normal",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "9a3a8549247c4252bc2d26d306a2e7a9",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -159.33334350585938,
+            "y": 409.3333435058594,
+            "width": 128.0,
+            "height": 36.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "58749045e53e457ab77f95320409704c"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "d4e6fe4110a2411e9377e8a64429bdfc"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.GroupData",
+    "m_ObjectId": "9ddc359ce9a34edeb1316414c15b72bc",
+    "m_Title": "Albedo",
+    "m_Position": {
+        "x": -924.666748046875,
+        "y": 135.99996948242188
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.TangentMaterialSlot",
+    "m_ObjectId": "9f88a671b20440528b46520ca3a02e66",
+    "m_Id": 0,
+    "m_DisplayName": "Tangent",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Tangent",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "a03574a13cc04d8f9cd6ed62eca303e9",
+    "m_Group": {
+        "m_Id": "9ddc359ce9a34edeb1316414c15b72bc"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -674.0000610351563,
+            "y": 353.3333435058594,
+            "width": 106.6666259765625,
+            "height": 36.000030517578128
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c39dbfe81440446e94d50a6cdf40166f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "32a1b39e2b7f4ff4ac5ac828b0cdfd9c"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.SplitNode",
+    "m_ObjectId": "a82881b3ac7b400a9e9966ae48b03e81",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Split",
+    "m_DrawState": {
+        "m_Expanded": false,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -347.3333435058594,
+            "y": 453.3333740234375,
+            "width": 120.00001525878906,
+            "height": 78.6666259765625
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "17524596ea8f42f0ad47da2845aa606e"
+        },
+        {
+            "m_Id": "ee4bc128d2824b6da401b672a1e26255"
+        },
+        {
+            "m_Id": "444e8b0420ec42c0a056c424f72a6b92"
+        },
+        {
+            "m_Id": "08258379cf7f404b9906ab0a7917a7ba"
+        },
+        {
+            "m_Id": "880db1d9b8ec4db486056697f4a73c0f"
+        }
+    ],
+    "synonyms": [
+        "separate"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "a8b0dcdf5a3d4d93ba72edae77f7e1da",
+    "m_Id": 0,
+    "m_DisplayName": "Smoothness",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Smoothness",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicValueMaterialSlot",
+    "m_ObjectId": "a983875a368e4778aa1749c455d80fbe",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "e00": 0.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 0.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 0.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 0.0
+    },
+    "m_DefaultValue": {
+        "e00": 1.0,
+        "e01": 0.0,
+        "e02": 0.0,
+        "e03": 0.0,
+        "e10": 0.0,
+        "e11": 1.0,
+        "e12": 0.0,
+        "e13": 0.0,
+        "e20": 0.0,
+        "e21": 0.0,
+        "e22": 1.0,
+        "e23": 0.0,
+        "e30": 0.0,
+        "e31": 0.0,
+        "e32": 0.0,
+        "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "abc9230db9154e0f8df78c8bc28cd425",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.BentNormal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "282f355fed794ab5a2f238a16b51e45d"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.BentNormal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ColorRGBMaterialSlot",
+    "m_ObjectId": "ac6c02345a0e4f6c8f2e9ef8d3b17b51",
+    "m_Id": 0,
+    "m_DisplayName": "Emission",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Emission",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_ColorMode": 1,
+    "m_DefaultColor": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "b286494cfcd74e9fa691d7fce27cd3f1",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Occlusion",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "c08b03038f3c48b6a594197c4031593e"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "b2e37d24d66f44d39f729f37bdadb3ef",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -216.00001525878907,
+            "y": 537.3333740234375,
+            "width": 184.6666717529297,
+            "height": 36.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "3730397b8a21400694309f0c16abf3c3"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "de9312c2664e41a69db2e1e0f2a2822e"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "bbe46d3150ca40b7b4108d91186a665f",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Metallic",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e0358b81db65480286e03e8cc1d04737"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Metallic"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "c08b03038f3c48b6a594197c4031593e",
+    "m_Id": 0,
+    "m_DisplayName": "Ambient Occlusion",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Occlusion",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector4MaterialSlot",
+    "m_ObjectId": "c39dbfe81440446e94d50a6cdf40166f",
+    "m_Id": 0,
+    "m_DisplayName": "Color",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.NormalMaterialSlot",
+    "m_ObjectId": "c68401c7ac5c48b0ae7357229c0a3b31",
+    "m_Id": 0,
+    "m_DisplayName": "Normal (Tangent Space)",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "NormalTS",
+    "m_StageCapability": 2,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 3
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "d31516fc9d9c4569bc0c869ebcd4be95",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "2d0b70f7c70847ec94f2da9edcb9527a"
+        },
+        {
+            "m_Id": "32a1b39e2b7f4ff4ac5ac828b0cdfd9c"
+        },
+        {
+            "m_Id": "157f6951fc4f45c38945a3835e500101"
+        },
+        {
+            "m_Id": "7d53f12e89154dffbe022a1cd71ef300"
+        },
+        {
+            "m_Id": "df77e63a10524db7bbfa3ab581dcec34"
+        },
+        {
+            "m_Id": "d4e6fe4110a2411e9377e8a64429bdfc"
+        },
+        {
+            "m_Id": "de9312c2664e41a69db2e1e0f2a2822e"
+        }
+    ]
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "d3c0965262c54f3b8ac5ebe4312b6613",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Alpha",
+    "m_StageCapability": 2,
+    "m_Value": 1.0,
+    "m_DefaultValue": 1.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "d4e6fe4110a2411e9377e8a64429bdfc",
+    "m_Guid": {
+        "m_GuidSerialized": "33c5679b-52a4-4266-a32e-1c1f217561a7"
+    },
+    "m_Name": "Occlusion",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Occlusion",
+    "m_DefaultReferenceName": "_Occlusion",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 1.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.HighDefinition.ShaderGraph.HDLitSubTarget",
+    "m_ObjectId": "d90c25009b1e4d448d1ad79c13cb0cdd"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PositionMaterialSlot",
+    "m_ObjectId": "d990f95d250d4fc09e48c71a05f2beca",
+    "m_Id": 0,
+    "m_DisplayName": "Position",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Position",
+    "m_StageCapability": 1,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+    },
+    "m_Labels": [],
+    "m_Space": 0
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "db859799333b4eac8ba25bd6ef16426b",
+    "m_Id": 0,
+    "m_DisplayName": "Alpha Clip Threshold",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "AlphaClipThreshold",
+    "m_StageCapability": 2,
+    "m_Value": 0.5,
+    "m_DefaultValue": 0.5,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "de9312c2664e41a69db2e1e0f2a2822e",
+    "m_Guid": {
+        "m_GuidSerialized": "9d27ae6e-4be5-4a5e-bfc6-9ff33f743a5b"
+    },
+    "m_Name": "Alpha Clip Threshold",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Alpha Clip Threshold",
+    "m_DefaultReferenceName": "_Alpha_Clip_Threshold",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 0.5,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 2,
+    "m_Type": "UnityEditor.Rendering.BuiltIn.ShaderGraph.BuiltInTarget",
+    "m_ObjectId": "dea4c38abd8d446da36e8f1015923bad",
+    "m_ActiveSubTarget": {
+        "m_Id": "55f6f8be7343490987e823a78d437505"
+    },
+    "m_AllowMaterialOverride": true,
+    "m_SurfaceType": 0,
+    "m_ZWriteControl": 0,
+    "m_ZTestMode": 4,
+    "m_AlphaMode": 0,
+    "m_RenderFace": 2,
+    "m_AlphaClip": false,
+    "m_CustomEditorGUI": ""
+}
+
+{
+    "m_SGVersion": 3,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.ColorShaderProperty",
+    "m_ObjectId": "df77e63a10524db7bbfa3ab581dcec34",
+    "m_Guid": {
+        "m_GuidSerialized": "a43c300e-356f-4a8a-9253-61c577834343"
+    },
+    "m_Name": "Emissive Color",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "Emissive Color",
+    "m_DefaultReferenceName": "_Emissive_Color",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": {
+        "r": 0.0,
+        "g": 0.0,
+        "b": 0.0,
+        "a": 0.0
+    },
+    "isMainColor": false,
+    "m_ColorMode": 1
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "e0358b81db65480286e03e8cc1d04737",
+    "m_Id": 0,
+    "m_DisplayName": "Metallic",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Metallic",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "e3c83cb5ecee43cd924276689d160b59",
+    "m_Group": {
+        "m_Id": "9ddc359ce9a34edeb1316414c15b72bc"
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -899.3333740234375,
+            "y": 234.6666717529297,
+            "width": 122.0,
+            "height": 36.00001525878906
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "25ee23c971bc4333921af44959a28f99"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "2d0b70f7c70847ec94f2da9edcb9527a"
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
+    "m_ObjectId": "e504c8d7bdec4af7b7edf8d5866e47f5",
+    "m_WorkflowMode": 1,
+    "m_NormalDropOffSpace": 0,
+    "m_ClearCoat": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ee4bc128d2824b6da401b672a1e26255",
+    "m_Id": 1,
+    "m_DisplayName": "R",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "R",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "ee6732035c9e4da493a23b3f3b3a59e4",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "SurfaceDescription.Alpha",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "d3c0965262c54f3b8ac5ebe4312b6613"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "SurfaceDescription.Alpha"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "f543a5d3a9cf4a2fa11abd44868fa08b",
+    "m_Id": 5,
+    "m_DisplayName": "G",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "G",
+    "m_StageCapability": 2,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.BlockNode",
+    "m_ObjectId": "faf0b3b6aea24c5c98a6aa09d33e005b",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "VertexDescription.Normal",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 0.0,
+            "height": 0.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "954c7aa5fa044a869ed95f6e4af9b71f"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_SerializedDescriptor": "VertexDescription.Normal"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Texture2DInputMaterialSlot",
+    "m_ObjectId": "fbd71984f00443a18f131ac84b7bb0f5",
+    "m_Id": 1,
+    "m_DisplayName": "Texture",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Texture",
+    "m_StageCapability": 3,
+    "m_BareResource": false,
+    "m_Texture": {
+        "m_SerializedTexture": "{\"texture\":{\"instanceID\":0}}",
+        "m_Guid": ""
+    },
+    "m_DefaultType": 0
+}
+

--- a/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Lit.shadergraph.meta
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Shaders/Lit.shadergraph.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 25b88c715c863184db21f34871397ece
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 625f186215c104763be7675aa2d941aa, type: 3}

--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -2,6 +2,9 @@
     "name": "Crest",
     "rootNamespace": "",
     "references": [
+        "Unity.RenderPipelines.Core.Runtime",
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Unity.RenderPipelines.Universal.Runtime",
         "Unity.Postprocessing.Runtime",
         "Unity.InputSystem",
         "Unity.Mathematics",
@@ -29,6 +32,21 @@
             "name": "com.unity.modules.xr",
             "expression": "1.0.0",
             "define": "ENABLE_XR_MODULE"
+        },
+        {
+            "name": "com.unity.render-pipelines.core",
+            "expression": "",
+            "define": "CREST_SRP"
+        },
+        {
+            "name": "com.unity.render-pipelines.universal",
+            "expression": "",
+            "define": "CREST_URP"
+        },
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "",
+            "define": "CREST_HDRP"
         },
         {
             "name": "com.unity.burst",

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderPipelineHelper.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderPipelineHelper.cs
@@ -1,0 +1,94 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Rendering;
+#if CREST_URP
+using UnityEngine.Rendering.Universal;
+#endif
+#if CREST_HDRP
+using UnityEngine.Rendering.HighDefinition;
+#endif
+
+namespace Crest
+{
+    public enum RenderPipeline
+    {
+        None,
+        Legacy,
+        HighDefinition,
+        Universal,
+    }
+
+    public static class RenderPipelineHelper
+    {
+        public static RenderPipeline CurrentRenderPipeline { get; private set; }
+        public static bool IsLegacy => CurrentRenderPipeline == RenderPipeline.Legacy;
+        public static bool IsHighDefinition => CurrentRenderPipeline == RenderPipeline.HighDefinition;
+        public static bool IsUniversal => CurrentRenderPipeline == RenderPipeline.Universal;
+
+        // This will run once on load for both editor and standalone. If domain reload is enabled, it will also run
+        // when entering play mode.
+#if UNITY_EDITOR
+        [InitializeOnLoadMethod]
+#else
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+#endif
+        static void OnLoad()
+        {
+            UpdateRenderPipeline();
+
+            // Delegates execute in order so the state will be ready for any other objects using the same delegate.
+            RenderPipelineManager.activeRenderPipelineTypeChanged -= UpdateRenderPipeline;
+            RenderPipelineManager.activeRenderPipelineTypeChanged += UpdateRenderPipeline;
+        }
+
+        static void UpdateRenderPipeline()
+        {
+            // GraphicsSettings.currentRenderPipeline handles both graphics setting and current quality level. There is
+            // also RenderPipelineManager.currentPipeline, but:
+            // > Unity updates this property only after rendering at least one frame with the active render pipeline,
+            // > which can take up to four calls to Update. This means that this property is null on startup, and does not immediately reflect changes to the active render pipeline.
+            // https://docs.unity3d.com/Manual/srp-setting-render-pipeline-asset.html
+            // https://docs.unity3d.com/Documentation/ScriptReference/Rendering.RenderPipelineManager-currentPipeline.html
+
+            if (GraphicsSettings.currentRenderPipeline == null)
+            {
+                CurrentRenderPipeline = RenderPipeline.Legacy;
+                return;
+            }
+
+#if CREST_URP
+            if (GraphicsSettings.currentRenderPipeline is UniversalRenderPipelineAsset)
+            {
+                CurrentRenderPipeline = RenderPipeline.Universal;
+                return;
+            }
+#endif
+
+#if CREST_HDRP
+            if (GraphicsSettings.currentRenderPipeline is HDRenderPipelineAsset)
+            {
+                CurrentRenderPipeline = RenderPipeline.HighDefinition;
+                return;
+            }
+#endif
+        }
+
+        public static string CurrentRenderPipelineShortName
+        {
+            get
+            {
+                return CurrentRenderPipeline switch
+                {
+                    RenderPipeline.Legacy => "BIRP",
+                    RenderPipeline.HighDefinition => "HDRP",
+                    RenderPipeline.Universal => "URP",
+                    _ => throw new System.Exception("Crest: An unknown render pipeline is active."),
+                };
+            }
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderPipelineHelper.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderPipelineHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0878ffb0cc3a44439511b6612d79cf0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Packages/manifest.json
+++ b/crest/Packages/manifest.json
@@ -11,6 +11,7 @@
     "com.unity.mathematics": "1.2.6",
     "com.unity.memoryprofiler": "0.4.3-preview.1",
     "com.unity.postprocessing": "3.2.2",
+    "com.unity.shadergraph": "12.1.6",
     "com.unity.test-framework": "1.1.31",
     "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",

--- a/crest/ProjectSettings/ShaderGraphSettings.asset
+++ b/crest/ProjectSettings/ShaderGraphSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 61
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de02f9e1d18f588468e474319d09a723, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  customInterpolatorErrorThreshold: 32
+  customInterpolatorWarningThreshold: 16


### PR DESCRIPTION
Adds cross RP support for main scene.

The following is the prefab selector which changes prefabs depending on the RP:

<img width="2032" alt="1_1" src="https://user-images.githubusercontent.com/5249806/169761298-d143e595-f48a-4f89-b083-09adb2d177d4.png">

It sets the instantiated prefab to _Not Editable_ as editing it in the scene can cause problems. If you need to edit the prefab in the scene, then edit the prefab in _Prefab Mode in Context_:

<img width="2032" alt="1_2" src="https://user-images.githubusercontent.com/5249806/169761322-edfeb63b-7f09-4abb-a225-515c5edcf429.png">

And here is the Lit shader graph:

<img width="2032" alt="1_3" src="https://user-images.githubusercontent.com/5249806/169761329-89fca821-e752-4888-b545-b59d276750fb.png">

There is also a component called _RenderPipelineEditLock_ which sets hierarchy to not editable if the correct RP is not active. In addition, there is an asset processor which prevents prefabs with naming convention (eg _**Crest**\_MainScene_Lighting\_**BIRP**.prefab_) from not saving if correct RP is not active (there might be a smarter way to do this). This prevents a bunch of problems like HDRP automatically changing lights and such being saved.

It works in builds but I have not tested RP switching in builds. I don't think it is necessary to test that case for our examples scenes though.

Downstream the following will need to be done:
- Materials will require changes downstream by going through SRPs and making sure non exposed properties are good and saving them.
- SRP prefabs need to be made and added to prefab selector component

One problem is that I am get the following on load (because light is in prefab):
> Failed creating SceneObjectIdentifier for a light!

I've also cleaned up a few things by removing mines and logo from scene and some materials under _Main_.

Let me know if you want to try this with multiple RPs running and I will add a repository which has a minimal example.