### PR TITLE
Wave quality improvement

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -23,6 +23,13 @@ namespace Crest
 
         public const string k_HelpURL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves-settings";
 
+        [Tooltip("PREVIEW: Set this to 2 to improve wave quality. In some cases like flowing rivers this can make a substantial difference to visual stability."
+            + "\n\nWe recommend doubling the Lod Data Resolution on the OceanRenderer component to preserve detail after making this change, but note that this will "
+            + "consume 4x more video memory until we are able to optimise data usage further, so apply this change with caution.")]
+        [SerializeField, Range(1f, 4f)]
+        float _waveResolutionMultiplier = 1f;
+        public float WaveResolutionMultiplier => _waveResolutionMultiplier;
+
         [Tooltip("How much waves are dampened in shallow water."), SerializeField, Range(0f, 1f)]
         float _attenuationInShallows = 0.95f;
         public float AttenuationInShallows => _attenuationInShallows;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -28,7 +28,7 @@ namespace Crest
             + "consume 4x more video memory until we are able to optimise data usage further, so apply this change with caution.")]
         [SerializeField, Range(1f, 4f)]
         float _waveResolutionMultiplier = 1f;
-        public float WaveResolutionMultiplier => _waveResolutionMultiplier;
+        public float WaveResolutionMultiplier => Mathf.Max(1f, _waveResolutionMultiplier);
 
         [Tooltip("How much waves are dampened in shallow water."), SerializeField, Range(0f, 1f)]
         float _attenuationInShallows = 0.95f;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -142,7 +142,8 @@ namespace Crest
             public FFTBatch(ShapeFFT shapeFFT, float wavelength, int waveBufferSliceIndex, Material material, Mesh mesh)
             {
                 _shapeFFT = shapeFFT;
-                Wavelength = wavelength;
+                // Need sample higher than Nyquist to get good results, especially when waves flowing
+                Wavelength = wavelength / Mathf.Max(1f, OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier);
                 _waveBufferSliceIndex = waveBufferSliceIndex;
                 _mesh = mesh;
                 _material = material;
@@ -161,7 +162,7 @@ namespace Crest
                     buf.SetGlobalInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
                     buf.SetGlobalFloat(RegisterLodDataInputBase.sp_Weight, finalWeight);
                     buf.SetGlobalInt(sp_WaveBufferSliceIndex, _waveBufferSliceIndex);
-                    buf.SetGlobalFloat(sp_AverageWavelength, Wavelength * 1.5f);
+                    buf.SetGlobalFloat(sp_AverageWavelength, Wavelength * 1.5f / OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier);
                     // Either use a full screen quad, or a provided mesh renderer to draw the waves
                     if (_mesh == null)
                     {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -143,7 +143,7 @@ namespace Crest
             {
                 _shapeFFT = shapeFFT;
                 // Need sample higher than Nyquist to get good results, especially when waves flowing
-                Wavelength = wavelength / Mathf.Max(1f, OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier);
+                Wavelength = wavelength / OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier;
                 _waveBufferSliceIndex = waveBufferSliceIndex;
                 _mesh = mesh;
                 _material = material;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -118,7 +118,7 @@ namespace Crest
             public GerstnerBatch(ShapeGerstner gerstner, float wavelength, int waveBufferSliceIndex, Material material, Mesh mesh)
             {
                 _gerstner = gerstner;
-                Wavelength = wavelength / Mathf.Max(1f, OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier);
+                Wavelength = wavelength / OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier;
                 _waveBufferSliceIndex = waveBufferSliceIndex;
                 _mesh = mesh;
                 _material = material;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -118,7 +118,7 @@ namespace Crest
             public GerstnerBatch(ShapeGerstner gerstner, float wavelength, int waveBufferSliceIndex, Material material, Mesh mesh)
             {
                 _gerstner = gerstner;
-                Wavelength = wavelength;
+                Wavelength = wavelength / Mathf.Max(1f, OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier);
                 _waveBufferSliceIndex = waveBufferSliceIndex;
                 _mesh = mesh;
                 _material = material;
@@ -137,7 +137,7 @@ namespace Crest
                     buf.SetGlobalInt(LodDataMgr.sp_LD_SliceIndex, lodIdx);
                     buf.SetGlobalFloat(RegisterLodDataInputBase.sp_Weight, finalWeight);
                     buf.SetGlobalInt(sp_WaveBufferSliceIndex, _waveBufferSliceIndex);
-                    buf.SetGlobalFloat(sp_AverageWavelength, Wavelength * 1.5f);
+                    buf.SetGlobalFloat(sp_AverageWavelength, Wavelength * 1.5f / OceanRenderer.Instance._lodDataAnimWaves.Settings.WaveResolutionMultiplier);
 
                     // Either use a full screen quad, or a provided mesh renderer to draw the waves
                     if (_mesh == null)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -20,6 +20,14 @@ Breaking
    -  Set minimum Unity version to 2021.3.3.
 
 
+Preview
+^^^^^^^
+.. bullet_list::
+
+   -  Added option to the Animated Waves settings to increase wave resolution to fix quality issues that appear especially in flowing water.
+      See tooltip on this new option for instructions and more details.
+
+
 Fixed
 ^^^^^
 .. bullet_list::


### PR DESCRIPTION
Expose option to double sample rate when generating final waves. This unfortunately requires higher res LOD data (1024 works well) because this effectively halves the range of detail and now at res=384 there is very little resolution left in the waves.

As previously, I'm finding higher LOD data resolution is required to get high quality results. To increase the default resolution, we'd likely need to break out LOD resolutions on a per-LOD basis as 1024x1024x8xTexelBytes x LodDataCount is a lot of video memory. For now i've added a tooltip that warns about this memory usage and labels the setting as preview.

Before [video](https://fr2ygz2xuzx8urqegqxn7uysnqr-my.sharepoint.com/:v:/g/personal/huw_bowles_waveharmonic_com/EScsHKPw375Aj1cClLx7ZJQB4vvtR-HGStAyczBSGThzNQ?e=MjWYkm)
After [video](https://fr2ygz2xuzx8urqegqxn7uysnqr-my.sharepoint.com/:v:/g/personal/huw_bowles_waveharmonic_com/Ebdyzv4msD5PmvdlERb5V7wBFB4ZocE6qz7GNMtQMotLrA?e=vaisyw)

The before/after shows some change in apparent wave amplitude, I believe this is a bad result of undersampling the waves rather than something being scaled wrong. I'll think about if this can be proven, but in any case I believe this can be merged.
