### PR TITLE
Don't let flow period below 1s to avoid obvious phasing

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -29,7 +29,7 @@ RWTexture2DArray<half4> _LD_TexArray_AnimatedWaves_Compute;
 
 void Flow(in const CascadeParams cascadeData, out float2 offsets, out float2 weights)
 {
-	const float period = 3.0 * _CrestCascadeData[_LD_SliceIndex]._texelWidth;
+	const float period = max(3.0 * _CrestCascadeData[_LD_SliceIndex]._texelWidth, 1.0);
 	const float half_period = period / 2.0;
 	offsets = fmod(float2(_CrestTime, _CrestTime + half_period), period);
 	weights.x = offsets.x / half_period;

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.shader
@@ -56,7 +56,7 @@ Shader "Hidden/Crest/Simulation/Combine Animated Wave LODs"
 
 			void Flow(out float2 offsets, out float2 weights)
 			{
-				const float period = 3.0 * _CrestCascadeData[_LD_SliceIndex]._texelWidth;
+				const float period = max(3.0 * _CrestCascadeData[_LD_SliceIndex]._texelWidth, 1.0);
 				const float half_period = period / 2.0;
 				offsets = fmod(float2(_CrestTime, _CrestTime + half_period), period);
 				weights.x = offsets.x / half_period;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -20,6 +20,13 @@ Breaking
    -  Set minimum Unity version to 2021.3.3.
 
 
+Fixed
+^^^^^
+.. bullet_list::
+
+   -  Limit minimum phase period of flow technique applied to waves to fix objectionable phasing issues in flowing water like rivers.
+
+
 4.15.2
 ------
 


### PR DESCRIPTION
Broken out from #1021 as this is simple and can be applied separately.
