### PR TITLE
Refactor LodDataMgr to be self contained

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -311,7 +311,7 @@ namespace Crest
             DrawSim(OceanRenderer.Instance._lodDataDynWaves, ref _drawDynWaves, ref column, 0.5f, 2f);
             DrawSim(OceanRenderer.Instance._lodDataFoam, ref _drawFoam, ref column);
             DrawSim(OceanRenderer.Instance._lodDataFlow, ref _drawFlow, ref column, 0.5f, 2f);
-            DrawSim(OceanRenderer.Instance._lodDataShadow, ref _drawShadow, ref column);
+            DrawSim(OceanRenderer.Instance._shadowSimulation._data, ref _drawShadow, ref column);
             DrawSim(OceanRenderer.Instance._lodDataSeaDepths, ref _drawSeaFloorDepth, ref column);
             DrawSim(OceanRenderer.Instance._lodDataClipSurface, ref _drawClipSurface, ref column);
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -101,28 +101,10 @@ namespace Crest
         // shape texture resolution
         int _shapeRes = -1;
 
+        // TODO: Used internally by shadows on failed states. Also for persistent sims.
         public bool enabled { get; protected set; }
 
         protected OceanRenderer _ocean;
-
-        // Implement in any sub-class which supports having an asset file for settings. This is used for polymorphic
-        // operations. A sub-class will also implement an alternative for the specialised type called Settings.
-        public virtual SimSettingsBase SettingsBase => null;
-        SimSettingsBase _defaultSettings;
-
-        /// <summary>
-        /// Returns the default value of the settings asset for the provided type.
-        /// </summary>
-        protected SettingsType GetDefaultSettings<SettingsType>() where SettingsType : SimSettingsBase
-        {
-            if (_defaultSettings == null)
-            {
-                _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
-                _defaultSettings.name = SimName + " Auto-generated Settings";
-            }
-
-            return (SettingsType)_defaultSettings;
-        }
 
         public LodDataMgr(OceanRenderer ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAlbedo.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAlbedo.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
+// TODO !RunningWithoutGPU !RunningHeadless?
+
 namespace Crest
 {
     using SettingsType = SimSettingsAlbedo;
@@ -29,9 +31,6 @@ namespace Crest
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Albedo feature is disabled on the this but is enabled on the ocean material.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Albedo Data</i> option on this component to turn it on, or disable the <i>Albedo</i> feature on the ocean material to save performance.";
         bool _targetsClear = false;
-
-        public override SimSettingsBase SettingsBase => Settings;
-        public SettingsType Settings => _ocean._settingsAlbedo != null ? _ocean._settingsAlbedo : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrAlbedo(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrClipSurface.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
+// TODO: !RunningWithoutGPU !RunningHeadless
+
 namespace Crest
 {
     using SettingsType = SimSettingsClipSurface;
@@ -30,9 +32,6 @@ namespace Crest
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Clip Surface Data</i> option on this component to turn it on, or disable the <i>Clipping</i> feature on the ocean material to save performance.";
 
         bool _targetsClear = false;
-
-        public override SimSettingsBase SettingsBase => Settings;
-        public SettingsType Settings => _ocean._simSettingsClipSurface != null ? _ocean._simSettingsClipSurface : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrClipSurface(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -5,10 +5,10 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 
+// TODO !RunningWithoutGPU
+
 namespace Crest
 {
-    using SettingsType = SimSettingsWave;
-
     /// <summary>
     /// A dynamic shape simulation that moves around with a displacement LOD.
     /// </summary>
@@ -37,9 +37,6 @@ namespace Crest
         readonly int sp_Gravity = Shader.PropertyToID("_Gravity");
         readonly int sp_CourantNumber = Shader.PropertyToID("_CourantNumber");
         readonly int sp_AttenuationInShallows = Shader.PropertyToID("_AttenuationInShallows");
-
-        public override SimSettingsBase SettingsBase => Settings;
-        public SettingsType Settings => _ocean._simSettingsDynamicWaves != null ? _ocean._simSettingsDynamicWaves : GetDefaultSettings<SettingsType>();
 
         public float TimeLeftToSimulate => _timeToSimulate;
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
+// TODO !RunningWithoutGPU
+
 namespace Crest
 {
     using SettingsType = SimSettingsFlow;
@@ -30,9 +32,6 @@ namespace Crest
         bool _targetsClear = false;
 
         public const string FLOW_KEYWORD = "CREST_FLOW_ON_INTERNAL";
-
-        public override SimSettingsBase SettingsBase => Settings;
-        public SettingsType Settings => _ocean._simSettingsFlow != null ? _ocean._simSettingsFlow : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrFlow(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -6,6 +6,8 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
+// TODO !RunningWithoutGPU
+
 namespace Crest
 {
     using SettingsType = SimSettingsSeaFloorDepth;
@@ -33,9 +35,6 @@ namespace Crest
         public const string FEATURE_TOGGLE_LABEL = "Create Sea Floor Depth Data";
 
         public const string ShaderName = "Crest/Inputs/Depth/Cached Depths";
-
-        public override SimSettingsBase SettingsBase => Settings;
-        public SettingsType Settings => _ocean._simSettingsSeaFloorDepth != null ? _ocean._simSettingsSeaFloorDepth : GetDefaultSettings<SettingsType>();
 
         public LodDataMgrSeaFloorDepth(OceanRenderer ocean) : base(ocean)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
@@ -34,15 +34,8 @@ namespace Crest
         protected override bool FollowHorizontalMotion => false;
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "_createAlbedoData";
-        protected override string FeatureToggleLabel => "Create Albedo Data";
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateAlbedoData;
-
-        protected override string RequiredShaderKeywordProperty => LodDataMgrAlbedo.MATERIAL_KEYWORD_PROPERTY;
-        protected override string RequiredShaderKeyword => LodDataMgrAlbedo.MATERIAL_KEYWORD;
-
-        protected override string MaterialFeatureDisabledError => LodDataMgrAlbedo.ERROR_MATERIAL_KEYWORD_MISSING;
-        protected override string MaterialFeatureDisabledFix => LodDataMgrAlbedo.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -76,5 +76,10 @@ namespace Crest
                 OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxDisplacementHorizontal, maxDispVert, 0f);
             }
         }
+
+#if UNITY_EDITOR
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
+#endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -275,13 +275,8 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "_createClipSurfaceData";
-        protected override string FeatureToggleLabel => "Create Clip Surface Data";
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateClipSurfaceData;
-        protected override string RequiredShaderKeywordProperty => LodDataMgrClipSurface.MATERIAL_KEYWORD_PROPERTY;
-        protected override string RequiredShaderKeyword => LodDataMgrClipSurface.MATERIAL_KEYWORD;
-        protected override string MaterialFeatureDisabledError => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING;
-        protected override string MaterialFeatureDisabledFix => LodDataMgrClipSurface.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
 
         protected override bool RendererRequired => _mode == Mode.Geometry;
         protected override bool RendererOptional => _mode != Mode.Geometry;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -32,9 +32,8 @@ namespace Crest
         protected override string ShaderPrefix => "Crest/Inputs/Dynamic Waves";
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => LodDataMgrDynWaves.FEATURE_TOGGLE_NAME;
-        protected override string FeatureToggleLabel => LodDataMgrDynWaves.FEATURE_TOGGLE_LABEL;
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateDynamicWaveSim;
-#endif
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
+#endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -42,15 +42,8 @@ namespace Crest
         bool _followHorizontalMotion = false;
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "_createFlowSim";
-        protected override string FeatureToggleLabel => "Create Flow Sim";
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFlowSim;
-
-        protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;
-        protected override string RequiredShaderKeyword => LodDataMgrFlow.MATERIAL_KEYWORD;
-
-        protected override string MaterialFeatureDisabledError => LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING;
-        protected override string MaterialFeatureDisabledFix => LodDataMgrFlow.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -40,15 +40,8 @@ namespace Crest
         bool _followHorizontalMotion = false;
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "_createFoamSim";
-        protected override string FeatureToggleLabel => "Create Foam Sim";
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFoamSim;
-
-        protected override string RequiredShaderKeywordProperty => LodDataMgrFoam.MATERIAL_KEYWORD_PROPERTY;
-        protected override string RequiredShaderKeyword => LodDataMgrFoam.MATERIAL_KEYWORD;
-
-        protected override string MaterialFeatureDisabledError => LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING;
-        protected override string MaterialFeatureDisabledFix => LodDataMgrFoam.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -74,8 +74,8 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        // Animated waves are always enabled
-        protected override bool FeatureEnabled(OceanRenderer ocean) => true;
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -49,9 +49,8 @@ namespace Crest
         }
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => LodDataMgrSeaFloorDepth.FEATURE_TOGGLE_NAME;
-        protected override string FeatureToggleLabel => LodDataMgrSeaFloorDepth.FEATURE_TOGGLE_LABEL;
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateSeaFloorDepthData;
+        // TODO:
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => null;
 #endif // UNITY_EDITOR
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -34,14 +34,7 @@ namespace Crest
         protected override bool FollowHorizontalMotion => false;
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "_createShadowData";
-        protected override string FeatureToggleLabel => "Create Shadow Data";
-        protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateShadowData;
-
-        protected override string RequiredShaderKeyword => LodDataMgrShadow.MATERIAL_KEYWORD;
-
-        protected override string MaterialFeatureDisabledError => LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING;
-        protected override string MaterialFeatureDisabledFix => LodDataMgrShadow.ERROR_MATERIAL_KEYWORD_MISSING_FIX;
-#endif // UNITY_EDITOR
+        protected override ISimulation<LodDataMgr, SimSettingsBase> GetSimulation(OceanRenderer ocean) => ocean._shadowSimulation;
+#endif
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Simulation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Simulation.cs
@@ -1,0 +1,162 @@
+namespace Crest
+{
+    using UnityEngine;
+
+    // Covariant
+    public interface ISimulation<out DataType, out SettingsType>
+    {
+        SettingsType Settings { get; }
+        DataType Data { get; }
+        bool Enabled { get; }
+        string Name { get; }
+
+        void Update(OceanRenderer ocean);
+        void CleanUpData();
+    }
+
+    public interface ISimulationWithMaterialKeyword
+    {
+        public bool Enabled { get; }
+        string MaterialKeywordProperty { get; }
+        string MaterialKeyword { get; }
+        string ErrorMaterialKeywordMissing { get; }
+        string ErrorMaterialKeywordMissingFix { get; }
+        string ErrorMaterialKeywordOnFeatureOff { get; }
+        string ErrorMaterialKeywordOnFeatureOffFix { get; }
+
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            var oceanMaterial = ocean.OceanMaterial;
+            var isValid = true;
+
+            if (oceanMaterial.HasProperty(MaterialKeywordProperty) && Enabled != oceanMaterial.IsKeywordEnabled(MaterialKeyword))
+            {
+                if (Enabled)
+                {
+                    showMessage(ErrorMaterialKeywordMissing, ErrorMaterialKeywordMissingFix,
+                        ValidatedHelper.MessageType.Error, oceanMaterial,
+                        (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, MaterialKeyword, MaterialKeywordProperty, true));
+                    isValid = false;
+                }
+                else
+                {
+                    showMessage(ErrorMaterialKeywordOnFeatureOff, ErrorMaterialKeywordOnFeatureOffFix,
+                        ValidatedHelper.MessageType.Info, ocean);
+                }
+            }
+
+            return isValid;
+        }
+    }
+
+    [System.Serializable]
+    public abstract class Simulation<DataType, SettingsType> : ISimulation<DataType, SettingsType>
+        where DataType : LodDataMgr
+        where SettingsType : SimSettingsBase
+    {
+        [Tooltip("Whether the simulation is enabled.")]
+        [SerializeField]
+        protected bool _enabled;
+        public bool Enabled => _enabled && _data != null;
+
+        public abstract string Name { get; }
+
+        // The LodDataMgr.
+        [System.NonSerialized]
+        protected DataType _data;
+        public DataType Data
+        {
+            get
+            {
+                if (!_enabled)
+                {
+                    return null;
+                }
+
+                return _data;
+            }
+        }
+
+        [SerializeField, Embedded]
+        internal SettingsType _settings;
+        SettingsType _defaultSettings;
+        public SettingsType Settings
+        {
+            get
+            {
+                if (_settings != null)
+                {
+                    return _settings;
+                }
+
+                if (_defaultSettings == null)
+                {
+                    _defaultSettings = ScriptableObject.CreateInstance<SettingsType>();
+                    _defaultSettings.name = Name + " Auto-generated Settings";
+                }
+
+                return _defaultSettings;
+            }
+        }
+
+        // AKA batch mode.
+        internal virtual bool RunsInHeadless => false;
+
+        // Instantiates the LodDataMgr* class. Cannot use generics.
+        protected abstract void AddData(OceanRenderer ocean);
+
+        internal virtual void SetUpData(OceanRenderer ocean)
+        {
+            if (!_enabled)
+            {
+                return;
+            }
+
+            if (OceanRenderer.RunningWithoutGPU)
+            {
+                return;
+            }
+
+            if (OceanRenderer.RunningHeadless && !RunsInHeadless)
+            {
+                return;
+            }
+
+            Debug.Assert(_data == null, $"Crest: {Name} simulation data should be null when calling Enable.");
+
+            AddData(ocean);
+            _data.OnEnable();
+        }
+
+        public virtual void CleanUpData()
+        {
+            Debug.Assert(_data != null, $"Crest: {Name} simulation data should not be null when calling Disable.");
+            _data.OnDisable();
+            _data = null;
+        }
+
+        internal bool _failed;
+
+        // Update is here to manage enabled/disabled state with data.
+        public void Update(OceanRenderer ocean)
+        {
+            if (_failed)
+            {
+                return;
+            }
+
+            if (!_enabled && _data != null)
+            {
+                CleanUpData();
+                return;
+            }
+
+            if (_enabled && _data == null)
+            {
+                SetUpData(ocean);
+            }
+
+            _data?.UpdateLodData();
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Simulation.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Simulation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87b1f45916c4241d98c7632cbfc0104f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Status: Proposal**

I'm putting this out early to get early feedback. Hopefully it is understandable.

> **Note**
> Currently this does not compile as it is incomplete. But I know approach does compile. Also the shadow simulation has received the most attention so best to pay attention there.

The goal of this refactor is to make the LodDataMgr self contained and utilise new C# features to replace workaround patterns (like virtual properties accessing static properties). The end goal is that these LDMs will abstract management away and easily allow for things such as rebuilding individual sims when needed instead of the entire OR on change and other things.

New C# features used:
- [Default Interface Methods](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods)
- [Covariance](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/covariance-contravariance/creating-variant-generic-interfaces)

With these we can reduce have the LDMs (Simulation or LodDataMgr) in a collection (like in OR) without sacrificing code reuse. It also moves enabled and settings property and management of said properties out of OR and greatly simplifies the class. The LDMs are always available which means we can take advantage of inheritance all the time like with validation.

## Wrapper Approach

Relationship graph (Simulation is serialised):
```mermaid
graph TD;
    LodDataMgr-->|Inherits|LodDataMgrShadow;
    Simulation-->|Inherits|ShadowSimulation;
    Simulation-->|Holds| LodDataMgr;
    LodDataMgrShadow-->|References|ShadowSimulation;
    OceanRenderer-->|Holds|Simulation;
```
## Non Wrapper Approach

An alternative approach which uses no wrapper: [refactor/serialized-loddatamgr-2](https://github.com/wave-harmonic/crest/compare/refactor/serialized-loddatamgr-2). There are two commits there: the first one has no intermediary class to handle the generic to keep us having to add a generic class to const/static calls. The second commit adds that in. Another alternative to the second commit (intermediary class) is to move const/statics into a separate class.

## Separate Ocean Material Validation

This replaces the Ocean Material validation from using statics/consts to using an interface with a default method handling validation. The end result is increase code reuse and reduced line count burden on OR.

Definition:
https://github.com/wave-harmonic/crest/compare/refactor/serialized-loddatamgr?expand=1#diff-98bc0292c27302285bdfc62e9db5145ebbd9f56a760906f6d0d6d9c66be225f8R17-R50
Implementation:
https://github.com/wave-harmonic/crest/compare/refactor/serialized-loddatamgr?expand=1#diff-1099375d850e5fdef0a11b95916bbb8ba7ee35123a193dfc71d32812dcbddafaR14-R30
Usage (bit hard to see this one so pasted code here):
https://github.com/wave-harmonic/crest/compare/refactor/serialized-loddatamgr?expand=1#diff-4a2204eda7d2c86ba91bf28c341605275433597ca0586ff3d9fe2a61bb851198R1682-R1684
```csharp
                foreach (var simulation in _simulations.OfType<ISimulationWithMaterialKeyword>())
                {
                    simulation.Validate(ocean, showMessage);
                }
```

## Early Feedback Thoughts

I'll need feedback on whether the wrapper route or the non wrapper route is preferred. Or if neither is preferred.

An advantage of the current approach is it is a little more optimised as when an LDM is disabled it is removed from play. In both new approaches this is not the case so there will be a little overhead (one method call per disabled sim).

With the new approach the UI will need a custom one to be nicer as right now the settings UI is nested in a dropdown which is too much nesting for me. But I think we were looking at doing something like that at some point anyway.