### PR TITLE
Local wave alpha blending

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -13,6 +13,12 @@ namespace Crest
     /// </summary>
     public static class Helpers
     {
+        public static class ShaderIDs
+        {
+            public static readonly int s_BlendSrcMode = Shader.PropertyToID("_BlendSrcMode");
+            public static readonly int s_BlendDstMode = Shader.PropertyToID("_BlendDstMode");
+        }
+
         public static BindingFlags s_AnyMethod = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
             BindingFlags.Static;
 
@@ -41,6 +47,42 @@ namespace Crest
             CopyDepth,
             ClearDepth,
             ClearStencil,
+        }
+
+        public enum BlendPreset
+        {
+            /// <summary>
+            /// BlendMode SrcAlpha One
+            /// </summary>
+            AdditiveBlend,
+            /// <summary>
+            /// SrcAlpha OneMinusSrcAlpha
+            /// </summary>
+            AlphaBlend,
+        }
+
+        /// <summary>
+        /// Sets the Blend render state using BlendPreset.
+        /// </summary>
+        public static void SetBlendFromPreset(Material material, BlendPreset preset)
+        {
+            var source = 0;
+            var destination = 0;
+
+            switch (preset)
+            {
+                case BlendPreset.AdditiveBlend:
+                    source = (int)BlendMode.SrcAlpha;
+                    destination = (int)BlendMode.One;
+                    break;
+                case BlendPreset.AlphaBlend:
+                    source =  (int)BlendMode.SrcAlpha;
+                    destination = (int)BlendMode.OneMinusSrcAlpha;
+                    break;
+            }
+
+            material.SetInt(ShaderIDs.s_BlendSrcMode, source);
+            material.SetInt(ShaderIDs.s_BlendDstMode, destination);
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -21,8 +21,7 @@ namespace Crest
     ///    pass and subsequent assignment to the ocean material (see OceanScheduler).
     ///
     /// The RGB channels are the XYZ displacement from a rest plane at sea level to the corresponding displaced position on the
-    /// surface. The A channel holds the variance/energy in all the smaller wavelengths that are too small to go into the cascade
-    /// slice. This is used as a statistical measure for the missing waves and is used to ensure foam is generated everywhere.
+    /// surface.
     /// </summary>
     public class LodDataMgrAnimWaves : LodDataMgr
     {

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -176,7 +176,6 @@ namespace Crest
         struct GerstnerCascadeParams
         {
             public int _startIndex;
-            public float _cumulativeVariance;
         }
         ComputeBuffer _bufCascadeParams;
         GerstnerCascadeParams[] _cascadeParams = new GerstnerCascadeParams[CASCADE_COUNT + 1];
@@ -503,24 +502,6 @@ namespace Crest
             }
 
             _lastCascade = CASCADE_COUNT - 1;
-
-            // Compute a measure of variance, cumulative from low cascades to high
-            for (int i = 0; i < CASCADE_COUNT; i++)
-            {
-                // Accumulate from lower cascades
-                _cascadeParams[i]._cumulativeVariance = i > 0 ? _cascadeParams[i - 1]._cumulativeVariance : 0f;
-
-                var wl = MinWavelength(i) * 1.5f;
-                var octaveIndex = OceanWaveSpectrum.GetOctaveIndex(wl);
-                octaveIndex = Mathf.Min(octaveIndex, _activeSpectrum._chopScales.Length - 1);
-
-                // Heuristic - horiz disp is roughly amp*chop, divide by wavelength to normalize
-                var amp = _activeSpectrum.GetAmplitude(wl, 1f, windSpeed, out _);
-                var chop = _activeSpectrum._chopScales[octaveIndex];
-                float amp_over_wl = chop * amp / wl;
-                _cascadeParams[i]._cumulativeVariance += amp_over_wl;
-            }
-            _cascadeParams[CASCADE_COUNT]._cumulativeVariance = _cascadeParams[CASCADE_COUNT - 1]._cumulativeVariance;
 
             _bufCascadeParams.SetData(_cascadeParams);
             _bufWaveData.SetData(_waveData);

--- a/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanHelpers.hlsl
@@ -61,26 +61,15 @@ float2 IDtoUV(in float2 i_id, in float i_width, in float i_height)
 
 // Sampling functions
 
-// Displacements. Variance is a statistical measure of how many waves are in the smaller cascades (below this cascade slice). This gives a measure
-// of how much wave content is missing when we sample a particular LOD, and can be used to compensate. The foam sim uses it to compensate for missing
-// waves when computing surface pinch.
-void SampleDisplacements(in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos, inout half io_variance)
+void SampleDisplacements(in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos)
 {
-	const half4 data = i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0);
+	const half3 data = i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0).xyz;
 	io_worldPos += i_wt * data.xyz;
-	io_variance += i_wt * data.w;
-}
-
-void SampleDisplacements( in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, inout float3 io_worldPos )
-{
-	half unusedVariance = 0.0;
-	SampleDisplacements( i_dispSampler, i_uv_slice, i_wt, io_worldPos, unusedVariance );
 }
 
 void SampleDisplacementsNormals(in Texture2DArray i_dispSampler, in float3 i_uv_slice, in float i_wt, in float i_invRes, in float i_texelSize, inout float3 io_worldPos, inout float2 io_nxz, inout half io_sss)
 {
-	const half4 data = i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0);
-	const half3 disp = data.xyz;
+	const half3 disp = i_dispSampler.SampleLevel(LODData_linear_clamp_sampler, i_uv_slice, 0.0);
 	io_worldPos += i_wt * disp;
 
 	float3 dd = float3(i_invRes, 0.0, i_texelSize);

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGenerate.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGenerate.shader
@@ -8,8 +8,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Generate Waves"
 {
 	SubShader
 	{
-		// Additive blend everywhere
-		Blend One One
+		Blend [_BlendSrcMode] [_BlendDstMode]
 		ZWrite Off
 		ZTest Always
 		Cull Off
@@ -113,8 +112,12 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Generate Waves"
 				if (all(_PaintedDataSize > 0.0))
 				{
 					float2 paintUV = (input.worldPosXZ - _PaintedDataPosition) / _PaintedDataSize + 0.5;
+
+					float featherBoundaries = max(abs(paintUV.x - 0.5), abs(paintUV.y - 0.5));
+					wt *= smoothstep(0.5, 0.4, featherBoundaries);
+
 					// Check if in bounds
-					if (all(saturate(paintUV) == paintUV))
+					if (wt > 0.0)
 					{
 						float2 axis = _PaintedData.Sample(LODData_linear_clamp_sampler, paintUV).xy;
 						float axisLen2 = dot(axis, axis);
@@ -154,7 +157,7 @@ Shader "Hidden/Crest/Inputs/Animated Waves/Generate Waves"
 					disp.xz = disp.x * _AxisX + disp.z * float2(-_AxisX.y, _AxisX.x);
 				}
 
-				return half4(wt * disp, 1.0);
+				return float4(disp, wt);
 			}
 			ENDCG
 		}

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
@@ -138,22 +138,14 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
                 const float2 uv1 = float2(dot( input.worldPosScaled.xz, axisX1 ), dot( input.worldPosScaled.xz, axisZ1 ));
 
                 // Sample displacement, rotate into frame
-                float4 disp_variance0 = _WaveBuffer.SampleLevel( sampler_Crest_linear_repeat, float3(uv0, _WaveBufferSliceIndex), 0 );
-                float4 disp_variance1 = _WaveBuffer.SampleLevel( sampler_Crest_linear_repeat, float3(uv1, _WaveBufferSliceIndex), 0 );
-                disp_variance0.xz = disp_variance0.x * axisX0 + disp_variance0.z * axisZ0;
-                disp_variance1.xz = disp_variance1.x * axisX1 + disp_variance1.z * axisZ1;
+                float3 disp0 = _WaveBuffer.SampleLevel( sampler_Crest_linear_repeat, float3(uv0, _WaveBufferSliceIndex), 0 ).xyz;
+                float3 disp1 = _WaveBuffer.SampleLevel( sampler_Crest_linear_repeat, float3(uv1, _WaveBufferSliceIndex), 0 ).xyz;
+                disp0.xz = disp0.x * axisX0 + disp0.z * axisZ0;
+                disp1.xz = disp1.x * axisX1 + disp1.z * axisZ1;
                 const float alpha = rem / dTheta;
-                float4 disp_variance = lerp( disp_variance0, disp_variance1, alpha );
+                float3 disp = lerp( disp0, disp1, alpha );
 
-                // The large waves are added to the last two lods. Don't write cumulative variances for these - cumulative variance
-                // for the last fitting wave cascade captures everything needed.
-                const float minWavelength = _AverageWavelength / 1.5;
-                if( minWavelength > _CrestCascadeData[_LD_SliceIndex]._maxWavelength )
-                {
-                    disp_variance.w = 0.0;
-                }
-
-                return wt * disp_variance;
+                return float4(wt * disp, 0.0);
             }
             ENDCG
         }

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/AnimWavesGerstnerGeometry.shader
@@ -23,12 +23,15 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
         _FeatherWaveStart( "Feather wave start (0-1)", Range( 0.0, 0.5 ) ) = 0.1
         // Can be set to 0 to make waves ignore shallow water
         _RespectShallowWaterAttenuation( "Respect Shallow Water Attenuation", Range( 0, 1 ) ) = 1
+
+        _BlendSrcMode("Blend Source Mode", Float) = 5
+        _BlendDstMode("Blend Destination Mode", Float) = 1
     }
 
     SubShader
     {
-        // Additive blend everywhere
-        Blend One One
+        // Either additive or alpha blend for geometry waves.
+        Blend [_BlendSrcMode] [_BlendDstMode]
         ZWrite Off
         ZTest Always
         Cull Off
@@ -145,7 +148,7 @@ Shader "Crest/Inputs/Animated Waves/Gerstner Geometry"
                 const float alpha = rem / dTheta;
                 float3 disp = lerp( disp0, disp1, alpha );
 
-                return float4(wt * disp, 0.0);
+                return float4(disp, wt);
             }
             ENDCG
         }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/FFT/FFTCompute.compute
@@ -32,7 +32,8 @@ RWTexture2DArray<float2> _Output1;
 RWTexture2DArray<float2> _Output2;
 RWTexture2DArray<float2> _Output3;
 #else
-RWTexture2DArray<float3> _Output;
+// Write zero to W to clear garbage.
+RWTexture2DArray<float4> _Output;
 #endif
 
 groupshared float2 _IntermediatesH[SIZE];
@@ -167,6 +168,7 @@ void ComputeFFT(uint3 id : SV_DispatchThreadID)
 #else
 	const float sign = ((id.x + id.y) % 2) == 1 ? -1.0 : 1.0;
 	const float3 res = float3(sign * resultX.x, sign * resultH.x, sign * resultZ.x);
-	_Output[id] = float3(sign * resultX.x, sign * resultH.x, sign * resultZ.x);
+	// Write zero to W to clear garbage.
+	_Output[id] = float4(sign * resultX.x, sign * resultH.x, sign * resultZ.x, 0.0);
 #endif
 }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/Gerstner.compute
@@ -18,7 +18,6 @@ uint _FirstCascadeIndex;
 struct GerstnerCascadeParams
 {
 	int _startIndex;
-	float _cumulativeVariance;
 };
 StructuredBuffer<GerstnerCascadeParams> _GerstnerCascadeParams;
 
@@ -112,9 +111,5 @@ void Gerstner(uint3 id : SV_DispatchThreadID)
 		ComputeGerstner( worldPosXZ, worldSize, _GerstnerWaveData[i], result );
 	}
 
-	// Get variance term up until just before this cascade. Gives a statistical measure of wave content
-	// in lower cascades.
-	float _cumulativeVarianceBeforeThisCascade = cascadeIndex > 0 ? _GerstnerCascadeParams[cascadeIndex - 1]._cumulativeVariance : 0.0;
-
-	_WaveBuffer[uint3(id.xy, cascadeIndex)] = float4(result, _cumulativeVarianceBeforeThisCascade);
+	_WaveBuffer[uint3(id.xy, cascadeIndex)] = float4(result, 0.0);
 }

--- a/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/ShapeCombine.compute
@@ -94,7 +94,6 @@ void ShapeCombineBase(uint3 id)
 	float3 uv_thisLod = float3(input_uv, _LD_SliceIndex);
 
 	float3 result = 0.0;
-	half variance = 0.0;
 
 	// Sample in waves for this cascade.
 #if _FLOW_ON
@@ -106,15 +105,14 @@ void ShapeCombineBase(uint3 id)
 
 	const float3 uv_thisLod_flow_0 = WorldToUV(worldPosXZ - offsets[0] * flow, cascadeData0, _LD_SliceIndex);
 	const float3 uv_thisLod_flow_1 = WorldToUV(worldPosXZ - offsets[1] * flow, cascadeData0, _LD_SliceIndex);
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result, variance );
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result, variance );
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_0, weights[0], result);
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod_flow_1, weights[1], result);
 #else
-	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod, 1.0, result, variance);
+	SampleDisplacements(_LD_TexArray_WaveBuffer, uv_thisLod, 1.0, result);
 #endif // _FLOW_ON
 
 #if !_DISABLE_COMBINE
 	// Waves to combine down from the next lod up the chain.
-	// Do not combine variance. Variance is already cumulative - from low cascades up.
 	SampleDisplacementsCompute(_LD_TexArray_AnimatedWaves_Compute, width, height, uv_nextLod, 1.0, result);
 #endif
 
@@ -145,7 +143,7 @@ void ShapeCombineBase(uint3 id)
 	}
 #endif // _DYNAMIC_WAVE_SIM_ON
 
-	_LD_TexArray_AnimatedWaves_Compute[uint3(id.xy, _LD_SliceIndex)] = half4(result, variance);
+	_LD_TexArray_AnimatedWaves_Compute[uint3(id.xy, _LD_SliceIndex)] = half4(result, 0.0);
 }
 
 

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateFoam.compute
@@ -80,9 +80,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 
 	// Sample displacement texture and generate foam from it
 	const float3 dd = float3(cascadeData._oneOverTextureRes, 0.0, cascadeData._texelWidth);
-	half4 data = SampleLod( _LD_TexArray_AnimatedWaves, uv_slice );
-	half3 s = data.xyz;
-	float foamBase = data.w;
+	half3 s = SampleLod( _LD_TexArray_AnimatedWaves, uv_slice ).xyz;
 	half3 sx = SampleLodLevel(_LD_TexArray_AnimatedWaves, uv_slice + float3(dd.xy, 0.0), dd.y).xyz;
 	half3 sz = SampleLodLevel(_LD_TexArray_AnimatedWaves, uv_slice + float3(dd.yx, 0.0), dd.y).xyz;
 	float3 disp = s.xyz;
@@ -95,7 +93,7 @@ void UpdateFoam(uint3 id : SV_DispatchThreadID)
 	const float2x2 jacobian = (float4(disp_x.xz, disp_z.xz) - disp.xzxz) / cascadeData._texelWidth;
 	// Determinant is < 1 for pinched, < 0 for overlap/inversion
 	const float det = determinant( jacobian );
-	foam += 5.0 * simDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det + foamBase * 0.7 );
+	foam += 5.0 * simDeltaTime * _WaveFoamStrength * saturate( _WaveFoamCoverage - det );
 
 	// Prewarm shoreline foam. 1.0 / _FoamFadeRate perfectly matches a paused ocean in edit mode which is fine for
 	// shoreline foam.

--- a/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/Underwater/UnderwaterMaskShared.hlsl
@@ -79,15 +79,13 @@ Varyings Vert(Attributes v)
 	// Data that needs to be sampled at the undisplaced position
 	if (wt_smallerLod > 0.001)
 	{
-		half sss = 0.0;
 		const float3 uv_slice_smallerLod = WorldToUV(positionWS_XZ_before, cascadeData0, _LD_SliceIndex);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, worldPos, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_smallerLod, wt_smallerLod, worldPos);
 	}
 	if (wt_biggerLod > 0.001)
 	{
-		half sss = 0.0;
 		const float3 uv_slice_biggerLod = WorldToUV(positionWS_XZ_before, cascadeData1, _LD_SliceIndex + 1);
-		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, worldPos, sss);
+		SampleDisplacements(_LD_TexArray_AnimatedWaves, uv_slice_biggerLod, wt_biggerLod, worldPos);
 	}
 
 	// Data that needs to be sampled at the displaced position.

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -52,6 +52,7 @@ Fixed
    -  Fixed water plane moving in edit mode with *Always Refresh* disabled. `[HDRP]`
    -  Fixed *Build Processor* deprecated/obsolete warnings.
    -  Fixed some components breaking in edit mode after entering/exiting prefab mode.
+   -  Fixed FFTs incorrectly adding extra foam.
 
 
 Removed

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -43,6 +43,9 @@ Changed
 
    -  Warn users edits in prefab mode will not be reflected in scene view until prefab is saved.
    -  Ocean inputs provided via the *Register* components now sort on sibling index in addition to queue, so multiple inputs with the same queue can be organised in the hierarchy to control sort order.
+   -  Added ability to alpha blend waves (effectively an override) instead of only having additive blend waves.
+      Set *Blend Mode* to *Alpha Blend* on the *ShapeFFT* or *ShapeGerstner* to use.
+      It's useful for preventing rivers and lakes from receiving ocean waves.
 
 
 Fixed

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -24,6 +24,8 @@ Breaking
       This option may need to be configured on existing components.
       A migration tool to fix up existing inputs is available via the *Run 2022 Migration on Ocean Inputs* button in the *OceanRenderer* inspector.
    -  Removed *DeltaTimeDynamics* field from *Time Provider* interface as it was unused by the system and unnecessary.
+   -  Wave variance for ShapeGerstner has been removed which will reduce overall foam strength.
+      This was necessary to support alpha blending of wave inputs.
 
 
 Preview


### PR DESCRIPTION
Adds alpha blending for local waves (geometry or splines). It adds an _Additive_ option which is on by default. It can only be disabled for local waves as no point for global ones.

Also fixes FFTs writing into alpha channel which was adding a bunch of foam:

![1_1](https://user-images.githubusercontent.com/5249806/170814687-962749f0-03f8-4162-a693-e63331329d1f.jpg)
FFT Waves alpha channel rendered to the surface

Lastly, it removes variance from gerstner waves.

We don't use ShapeGerstner anywhere so example scenes shouldn't need tweaking.

I've added a test scene under Assets/Demo folder.

I'll look at reorganising the UI in another PR as it is getting cluttered.