### PR TITLE
Refactor HelpURL to be dynamic

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Constants.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Constants.cs
@@ -6,6 +6,8 @@ namespace Crest.Internal
 {
     public static class Constants
     {
+        public const string k_Version = "2022.0.0";
+
         const string PREFIX = "Crest ";
         public const string MENU_SCRIPTS = "Scripts/Crest/";
         public const string MENU_PREFIX_SCRIPTS = MENU_SCRIPTS + PREFIX;
@@ -13,17 +15,5 @@ namespace Crest.Internal
         public const string MENU_PREFIX_DEBUG = MENU_SCRIPTS + "Debug/" + PREFIX;
         public const string MENU_PREFIX_SPLINE = MENU_SCRIPTS + "Spline/" + PREFIX;
         public const string MENU_PREFIX_EXAMPLE = MENU_SCRIPTS + "Example/" + PREFIX;
-
-        // Usage: HelpURL(HELP_URL_BASE_USER + "page.html" + HELP_URL_RP + "#heading")
-        // HELP_URL_VERSION should be updated AFTER a new tag is made. The 404 page for the documentation will redirect
-        // the user to "latest" since the tag for the new version is not published yet.
-        // For example, if 4.9 was just released, so we change HELP_URL_VERSION from 4.9 to 4.10. If a user is using
-        // master, then they will be redirected from crest.readthedocs.io/en/4.10 to crest.readthedocs.io/en/latest when
-        // they land on the 404 page.
-        public const string HELP_URL_VERSION = "2022.0.0";
-        public const string HELP_URL_RP = "?rp=birp";
-        public const string HELP_URL_BASE = "https://crest.readthedocs.io/en/" + HELP_URL_VERSION + "/";
-        public const string HELP_URL_BASE_USER = HELP_URL_BASE + "user/";
-        public const string HELP_URL_GENERAL = HELP_URL_BASE + HELP_URL_RP;
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/CrestHelpURLAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/CrestHelpURLAttribute.cs
@@ -1,0 +1,33 @@
+// Crest Ocean System
+
+// This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
+
+using System;
+using System.Diagnostics;
+using UnityEngine;
+
+namespace Crest
+{
+    /// <summary>
+    /// Constructs a custom link to Crest's documentation for the help URL button.
+    /// </summary>
+    [Conditional("UNITY_EDITOR")]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum, AllowMultiple = false)]
+    public class CrestHelpURLAttribute : HelpURLAttribute
+    {
+        // 0 = Version, 1 = Path, 2 = Render Pipeline, 3 = Heading
+        const string k_URL = "https://crest.readthedocs.io/en/{0}/{1}.html?rp={2}#{3}";
+
+        public CrestHelpURLAttribute(string path = "", string hash = "") : base(GetPageLink(path, hash))
+        {
+            // Blank.
+        }
+
+        public static string GetPageLink(string path, string hash = "")
+        {
+            var rp = "birp";
+
+            return string.Format(k_URL, Internal.Constants.k_Version, path, rp, hash);
+        }
+    }
+}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/CrestHelpURLAttribute.cs.meta
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/CrestHelpURLAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5bcc2b498bd80460e98111e88acc3264
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/FloatingOrigin.cs
@@ -41,7 +41,7 @@ namespace Crest
     /// script should normally be attached to the viewpoint, typically the main camera.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Floating Origin")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "other-features.html" + Internal.Constants.HELP_URL_RP + "#floating-origin")]
+    [CrestHelpURL("user/other-features", "floating-origin")]
     public class FloatingOrigin : MonoBehaviour
     {
         const string k_Keyword = "CREST_FLOATING_ORIGIN";

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/FloatingObjectBase.cs
@@ -13,6 +13,7 @@ namespace Crest
     /// <summary>
     /// Base class for objects that float on water.
     /// </summary>
+    [CrestHelpURL("user/other-features", "buoyancy")]
     public abstract partial class FloatingObjectBase : MonoBehaviour
     {
         public abstract float ObjectWidth { get; }

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -16,6 +16,7 @@ namespace Crest
     /// spheres can be used to model the interaction of a non-spherical shape.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Sphere Water Interaction")]
+    [CrestHelpURL("user/ocean-simulation", "adding-interaction-forces")]
     public partial class SphereWaterInteraction : MonoBehaviour, ILodDataInput
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -16,7 +16,7 @@ namespace Crest
     /// This should be used for static geometry, dynamic objects should be tagged with the Render Ocean Depth component.
     /// </summary>
     [ExecuteAlways]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "shallows-and-shorelines.html" + Internal.Constants.HELP_URL_RP)]
+    [CrestHelpURL("user/shallows-and-shorelines")]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Depth Cache")]
     public partial class OceanDepthCache : MonoBehaviour
     {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Albedo Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#albedo")]
+    [CrestHelpURL("user/ocean-simulation", "albedo")]
     public class RegisterAlbedoInput : RegisterLodDataInput<LodDataMgrAlbedo>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Animated Waves Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves")]
+    [CrestHelpURL("user/ocean-simulation", "animated-waves")]
     public class RegisterAnimWavesInput : RegisterLodDataInput<LodDataMgrAnimWaves>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -13,7 +13,7 @@ namespace Crest
     /// clip the surface of the ocean.
     /// </summary>
     [AddComponentMenu(MENU_PREFIX + "Clip Surface Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#clip-surface")]
+    [CrestHelpURL("user/ocean-simulation", "clip-surface")]
     public partial class RegisterClipSurfaceInput : RegisterLodDataInput<LodDataMgrClipSurface>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Dynamic Waves Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#dynamic-waves")]
+    [CrestHelpURL("user/ocean-simulation", "dynamic-waves")]
     public class RegisterDynWavesInput : RegisterLodDataInput<LodDataMgrDynWaves>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Flow Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#flow")]
+    [CrestHelpURL("user/ocean-simulation", "flow")]
     public class RegisterFlowInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFlow, SplinePointDataFlow>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Foam Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#foam")]
+    [CrestHelpURL("user/ocean-simulation", "foam")]
     public class RegisterFoamInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFoam, SplinePointDataFoam>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -11,6 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Height Input")]
+    [CrestHelpURL("user/water-bodies")]
     public partial class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrSeaFloorDepth>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Sea Floor Depth Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#sea-floor-depth")]
+    [CrestHelpURL("user/ocean-simulation", "sea-floor-depth")]
     public class RegisterSeaFloorDepthInput : RegisterLodDataInput<LodDataMgrSeaFloorDepth>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAlbedo.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAlbedo.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SettingsAlbedo", menuName = "Crest/Albedo Settings", order = 10000)]
+    [CrestHelpURL("user/ocean-simulation", "albedo")]
     public class SimSettingsAlbedo : SimSettingsBase
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -9,7 +9,7 @@ using UnityEngine.Experimental.Rendering;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsAnimatedWaves", menuName = "Crest/Animated Waves Sim Settings", order = 10000)]
-    [HelpURL(k_HelpURL)]
+    [CrestHelpURL("user/ocean-simulation", "animated-waves-settings")]
     public partial class SimSettingsAnimatedWaves : SimSettingsBase
     {
         /// <summary>
@@ -20,8 +20,6 @@ namespace Crest
 #pragma warning disable 414
         int _version = 0;
 #pragma warning restore 414
-
-        public const string k_HelpURL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves-settings";
 
         [Tooltip("PREVIEW: Set this to 2 to improve wave quality. In some cases like flowing rivers this can make a substantial difference to visual stability."
             + "\n\nWe recommend doubling the Lod Data Resolution on the OceanRenderer component to preserve detail after making this change, but note that this will "
@@ -221,22 +219,6 @@ namespace Crest
             }
         }
 #endif // CREST_UNITY_MATHEMATICS
-    }
-
-    [CustomEditor(typeof(SimSettingsAnimatedWaves), true), CanEditMultipleObjects]
-    class SimSettingsAnimatedWavesEditor : SimSettingsBaseEditor
-    {
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.Space();
-            if (GUILayout.Button("Open Online Help Page"))
-            {
-                Application.OpenURL(SimSettingsAnimatedWaves.k_HelpURL);
-            }
-            EditorGUILayout.Space();
-
-            base.OnInspectorGUI();
-        }
     }
 #endif // UNITY_EDITOR
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsBase.cs
@@ -31,6 +31,22 @@ namespace Crest
     }
 
     [CustomEditor(typeof(SimSettingsBase), true), CanEditMultipleObjects]
-    class SimSettingsBaseEditor : ValidatedEditor { }
+    class SimSettingsBaseEditor : ValidatedEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.Space();
+            if (GUILayout.Button("Open Online Help Page"))
+            {
+                var targetType = target.GetType();
+                var helpAttribute = (CrestHelpURLAttribute)System.Attribute.GetCustomAttribute(targetType, typeof(CrestHelpURLAttribute));
+                Debug.AssertFormat(helpAttribute != null, "Crest: Could not get CrestHelpURL attribute from {0}.", targetType);
+                Application.OpenURL(helpAttribute.URL);
+            }
+            EditorGUILayout.Space();
+
+            base.OnInspectorGUI();
+        }
+    }
 #endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs
@@ -12,7 +12,7 @@ using UnityEditor;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsClipSurface", menuName = "Crest/Clip Surface Sim Settings", order = 10000)]
-    [HelpURL(HELP_URL)]
+    [CrestHelpURL("user/ocean-simulation", "clip-surface-settings")]
     public class SimSettingsClipSurface : SimSettingsBase
     {
         /// <summary>
@@ -24,8 +24,6 @@ namespace Crest
         int _version = 0;
 #pragma warning restore 414
 
-        public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#clip-surface";
-
         // The clip values only really need 8bits (unless using signed distance).
         [Tooltip("The render texture format to use for the clip surface simulation. It should only be changed if you need more precision. See the documentation for information.")]
         public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R8_UNorm;
@@ -36,22 +34,4 @@ namespace Crest
             Hashy.AddInt((int)_renderTextureGraphicsFormat, ref settingsHash);
         }
     }
-
-#if UNITY_EDITOR
-    [CustomEditor(typeof(SimSettingsClipSurface), true), CanEditMultipleObjects]
-    class SimSettingsClipSurfaceEditor : SimSettingsBaseEditor
-    {
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.Space();
-            if (GUILayout.Button("Open Online Help Page"))
-            {
-                Application.OpenURL(SimSettingsClipSurface.HELP_URL);
-            }
-            EditorGUILayout.Space();
-
-            base.OnInspectorGUI();
-        }
-    }
-#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFlow.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsFlow", menuName = "Crest/Flow Sim Settings", order = 10000)]
+    [CrestHelpURL("user/ocean-simulation", "flow")]
     public class SimSettingsFlow : SimSettingsBase
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsFoam.cs
@@ -12,7 +12,7 @@ using UnityEditor;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsFoam", menuName = "Crest/Foam Sim Settings", order = 10000)]
-    [HelpURL(HELP_URL)]
+    [CrestHelpURL("user/ocean-simulation", "foam-settings")]
     public class SimSettingsFoam : SimSettingsBase
     {
         /// <summary>
@@ -23,8 +23,6 @@ namespace Crest
 #pragma warning disable 414
         int _version = 0;
 #pragma warning restore 414
-
-        public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#id5";
 
         [Header("General settings")]
         [Tooltip("Prewarms the simulation on load and teleports. Results are only an approximation but are better than no foam.")]
@@ -56,22 +54,4 @@ namespace Crest
             Hashy.AddInt((int)_renderTextureGraphicsFormat, ref settingsHash);
         }
     }
-
-#if UNITY_EDITOR
-    [CustomEditor(typeof(SimSettingsFoam), true), CanEditMultipleObjects]
-    class SimSettingsFoamEditor : SimSettingsBaseEditor
-    {
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.Space();
-            if (GUILayout.Button("Open Online Help Page"))
-            {
-                Application.OpenURL(SimSettingsFoam.HELP_URL);
-            }
-            EditorGUILayout.Space();
-
-            base.OnInspectorGUI();
-        }
-    }
-#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsSeaFloorDepth.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsSeaFloorDepth", menuName = "Crest/Sea Floor Depth Settings", order = 10000)]
+    [CrestHelpURL("user/ocean-simulation", "sea-floor-depth")]
     public class SimSettingsSeaFloorDepth : SimSettingsBase
     {
         [Tooltip("Allow varying water level, to support water bodies at different heights and rivers to run down slopes. Disabling this will save some memory and may improve performance on some platforms.")]

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsWave.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsWave.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 namespace Crest
 {
     [CreateAssetMenu(fileName = "SimSettingsDynamicWaves", menuName = "Crest/Dynamic Wave Sim Settings", order = 10000)]
-    [HelpURL(HELP_URL)]
+    [CrestHelpURL("user/ocean-simulation", "dynamic-waves-settings")]
     public class SimSettingsWave : SimSettingsBase
     {
         /// <summary>
@@ -19,8 +19,6 @@ namespace Crest
 #pragma warning disable 414
         int _version = 0;
 #pragma warning restore 414
-
-        public const string HELP_URL = Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#simulation-settings";
 
         //[Header("Range")]
         [Range(0f, 32f), Tooltip("NOT CURRENTLY WORKING. The wave sim will not run if the simulation grid is smaller in resolution than this size. Useful to limit sim range for performance."),
@@ -49,22 +47,4 @@ namespace Crest
         [Range(0f, 64f), Tooltip("Multiplier for gravity. More gravity means dynamic waves will travel faster.")]
         public float _gravityMultiplier = 1f;
     }
-
-#if UNITY_EDITOR
-    [CustomEditor(typeof(SimSettingsWave), true), CanEditMultipleObjects]
-    class SimSettingsWaveEditor : SimSettingsBaseEditor
-    {
-        public override void OnInspectorGUI()
-        {
-            EditorGUILayout.Space();
-            if (GUILayout.Button("Open Online Help Page"))
-            {
-                Application.OpenURL(SimSettingsWave.HELP_URL);
-            }
-            EditorGUILayout.Space();
-
-            base.OnInspectorGUI();
-        }
-    }
-#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Shadow Input")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#shadows")]
+    [CrestHelpURL("user/ocean-simulation", "shadows")]
     public class RegisterShadowInput : RegisterLodDataInput<LodDataMgrShadow>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -28,7 +28,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways, SelectionBase]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Renderer")]
-    [HelpURL(Constants.HELP_URL_GENERAL)]
+    [CrestHelpURL()]
     public partial class OceanRenderer : MonoBehaviour
     {
         /// <summary>
@@ -1967,7 +1967,7 @@ namespace Crest
 
             if (GUILayout.Button("Open Material Online Help"))
             {
-                Application.OpenURL(Internal.Constants.HELP_URL_BASE_USER + "configuration.html" + Internal.Constants.HELP_URL_RP + "#material-parameters");
+                Application.OpenURL(CrestHelpURLAttribute.GetPageLink("user/configuration", "material-parameters"));
             }
 
             DrawMaterialEditor();

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -17,7 +17,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape FFT")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP)]
+    [CrestHelpURL("user/wave-conditions")]
     public partial class ShapeFFT : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
         , ISplinePointCustomDataSetup
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/OceanWaveSpectrum.cs
@@ -14,6 +14,7 @@ namespace Crest
     /// Ocean shape representation - power values for each octave of wave components.
     /// </summary>
     [CreateAssetMenu(fileName = "OceanWaves", menuName = "Crest/Ocean Wave Spectrum", order = 10000)]
+    [CrestHelpURL("user/wave-conditions")]
     public class OceanWaveSpectrum : ScriptableObject
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -19,7 +19,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP)]
+    [CrestHelpURL("user/wave-conditions")]
     public partial class ShapeGerstner : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
         , ISplinePointCustomDataSetup
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -17,7 +17,7 @@ namespace Crest.Spline
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SPLINE + "Spline")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#wave-splines")]
+    [CrestHelpURL("user/wave-conditions", "wave-splines")]
     public partial class Spline : MonoBehaviour, ISplinePointCustomDataSetup
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderBase.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderBase.cs
@@ -19,7 +19,7 @@ namespace Crest
         float DeltaTimeDynamics { get; }
     }
 
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "time-providers.html" + Internal.Constants.HELP_URL_RP)]
+    [CrestHelpURL("user/time-providers")]
     public abstract class TimeProviderBase : MonoBehaviour, ITimeProvider
     {
         public abstract float CurrentTime { get; }

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCustom.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCustom.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// This time provider fixes the ocean time at a custom value which is usable for testing/debugging.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Custom Time Provider")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "time-providers.html" + Internal.Constants.HELP_URL_RP + "#supporting-pause")]
+    [CrestHelpURL("user/time-providers", "supporting-pause")]
     public class TimeProviderCustom : TimeProviderBase
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
@@ -13,7 +13,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Cutscene Time Provider")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "time-providers.html" + Internal.Constants.HELP_URL_RP + "#timelines-and-cutscenes")]
+    [CrestHelpURL("user/time-providers", "timelines-and-cutscenes")]
     public class TimeProviderCutscene : TimeProviderBase
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderNetworked.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderNetworked.cs
@@ -13,7 +13,7 @@ namespace Crest
     /// delta from this client's time to the shared server time.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Networked Time Provider")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "time-providers.html" + Internal.Constants.HELP_URL_RP + "#network-synchronisation")]
+    [CrestHelpURL("user/time-providers", "network-synchronisation")]
     public class TimeProviderNetworked : TimeProviderBase
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -19,7 +19,7 @@ namespace Crest
     [ExecuteAlways]
     [RequireComponent(typeof(Camera))]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Underwater Renderer")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "underwater.html" + Internal.Constants.HELP_URL_RP)]
+    [CrestHelpURL("user/underwater")]
     public partial class UnderwaterRenderer : MonoBehaviour
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -17,7 +17,7 @@ namespace Crest
     /// </summary>
     [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Water Body")]
-    [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "water-bodies.html")]
+    [CrestHelpURL("user/water-bodies")]
     public partial class WaterBody : MonoBehaviour
     {
         /// <summary>

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -33,6 +33,7 @@ Fixed
 .. bullet_list::
 
    -  Limit minimum phase period of flow technique applied to waves to fix objectionable phasing issues in flowing water like rivers.
+   -  Fixed broken/missing documentation links.
 
 
 Removed

--- a/docs/user/ocean-simulation.rst
+++ b/docs/user/ocean-simulation.rst
@@ -242,6 +242,8 @@ The following input shaders are provided under *Crest/Inputs/Foam*:
    Useful for removing foam from unwanted areas.
 
 
+.. _foam-settings:
+
 Simulation Settings
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
In 2021 Unity removed the sealed modifier to the HelpURL class which allows us to extend it. This is what Unity does for UPM documentation links.

Downstream I can added SRP support, but I might not need to if removing RP branching from documentation.

I also fixed some links and added missing ones.