### PR TITLE
Factor out feature validation so it can be used from SWS

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrFlow.cs
@@ -27,6 +27,9 @@ namespace Crest
         internal const string ERROR_MATERIAL_KEYWORD_MISSING_FIX = "Tick the <i>Enable</i> option in the <i>Flow</i> parameter section on the material currently assigned to the <i>OceanRenderer</i> component.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF = "The Flow feature is disabled on the this but is enabled on the ocean material.";
         internal const string ERROR_MATERIAL_KEYWORD_ON_FEATURE_OFF_FIX = "If this is not intentional, either enable the <i>Create Flow Data</i> option on this component to turn it on, or disable the <i>Flow</i> feature on the ocean material to save performance.";
+        internal const string FEATURE_TOGGLE_LABEL = "Create Flow Sim";
+        internal const string FEATURE_TOGGLE_NAME = "_createFlowSim";
+
         bool _targetsClear = false;
 
         public const string FLOW_KEYWORD = "CREST_FLOW_ON_INTERNAL";

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -42,8 +42,8 @@ namespace Crest
         bool _followHorizontalMotion = false;
 
 #if UNITY_EDITOR
-        protected override string FeatureToggleName => "_createFlowSim";
-        protected override string FeatureToggleLabel => "Create Flow Sim";
+        protected override string FeatureToggleName => LodDataMgrFlow.FEATURE_TOGGLE_NAME;
+        protected override string FeatureToggleLabel => LodDataMgrFlow.FEATURE_TOGGLE_LABEL;
         protected override bool FeatureEnabled(OceanRenderer ocean) => ocean.CreateFlowSim;
 
         protected override string RequiredShaderKeywordProperty => LodDataMgrFlow.MATERIAL_KEYWORD_PROPERTY;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -478,22 +478,14 @@ namespace Crest
                 }
             }
 
-            if (ocean != null && !FeatureEnabled(ocean))
+            if (ocean != null)
             {
-                showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the <i>OceanRenderer</i> component.",
-                    $"Enable the <i>{FeatureToggleLabel}</i> option on the <i>OceanRenderer</i> component.",
-                    ValidatedHelper.MessageType.Error, ocean,
-                    (so) => OceanRenderer.FixSetFeatureEnabled(so, FeatureToggleName, true)
-                    );
-                isValid = false;
-            }
-
-            if (ocean != null && !string.IsNullOrEmpty(RequiredShaderKeyword) && ocean.OceanMaterial.HasProperty(RequiredShaderKeywordProperty) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
-            {
-                showMessage(MaterialFeatureDisabledError, MaterialFeatureDisabledFix,
-                    ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
-                    (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, RequiredShaderKeyword, RequiredShaderKeywordProperty, true));
-                isValid = false;
+                if (!OceanRenderer.ValidateFeatureEnabled(ocean, showMessage, FeatureEnabled,
+                    FeatureToggleLabel, FeatureToggleName, RequiredShaderKeyword, RequiredShaderKeywordProperty,
+                    MaterialFeatureDisabledError, MaterialFeatureDisabledFix))
+                {
+                    isValid = false;
+                }
             }
 
             return isValid;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1910,6 +1910,36 @@ namespace Crest
             return isValid;
         }
 #pragma warning restore 0618
+
+        /// <summary>
+        /// Does validation for a feature on the water component and on the material
+        /// </summary>
+        public static bool ValidateFeatureEnabled(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage, System.Func<OceanRenderer, bool> featureEnabled,
+            string FeatureToggleLabel, string FeatureToggleName, string RequiredShaderKeyword, string RequiredShaderKeywordProperty,
+            string MaterialFeatureDisabledError, string MaterialFeatureDisabledFix)
+        {
+            var isValid = true;
+
+            if (!featureEnabled(ocean))
+            {
+                showMessage($"<i>{FeatureToggleLabel}</i> must be enabled on the <i>OceanRenderer</i> component.",
+                    $"Enable the <i>{FeatureToggleLabel}</i> option on the <i>OceanRenderer</i> component.",
+                    ValidatedHelper.MessageType.Error, ocean,
+                    (so) => FixSetFeatureEnabled(so, FeatureToggleName, true)
+                    );
+                isValid = false;
+            }
+
+            if (!string.IsNullOrEmpty(RequiredShaderKeyword) && ocean.OceanMaterial.HasProperty(RequiredShaderKeywordProperty) && !ocean.OceanMaterial.IsKeywordEnabled(RequiredShaderKeyword))
+            {
+                showMessage(MaterialFeatureDisabledError, MaterialFeatureDisabledFix,
+                    ValidatedHelper.MessageType.Error, ocean.OceanMaterial,
+                    (material) => ValidatedHelper.FixSetMaterialOptionEnabled(material, RequiredShaderKeyword, RequiredShaderKeywordProperty, true));
+                isValid = false;
+            }
+
+            return isValid;
+        }
     }
 
     [CustomEditor(typeof(OceanRenderer))]


### PR DESCRIPTION
I accidentally had flow disabled when messing around with shoreline waves, so I added validation to the SWS for ocean Flow feature enabled on OR and on material.

Rather than duplicate that stuff, I factored out the validation code to a central location, which is in this PR.

This means I can call `OceanRenderer.ValidateFeatureEnabled` from the SWS validated editor.

I only did this for Flow as its the only one SWS. However i could roll out the minor change to `LodDataMgrFlow` to the other lod datas if you think it makes sense.