### PR TITLE
Add enum filter attribute

### DIFF
--- a/crest/Assets/Development/Editor/AttributeValidator.cs
+++ b/crest/Assets/Development/Editor/AttributeValidator.cs
@@ -24,12 +24,40 @@ namespace Crest
             {
                 foreach (var type in assembly.GetTypes())
                 {
-                    foreach (var property in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+                    ValidateFilterEnumAttribute(type);
+
+                    foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
                     {
-                        if (property.GetCustomAttributes<DecoratorAttribute>().ToList().Count == 0) continue;
-                        if (property.GetCustomAttributes<DecoratedPropertyAttribute>().ToList().Count > 0) continue;
-                        Debug.LogError($"Crest: A decorator attribute on {type}.{property.Name} has no attribute which inherits from DecoratedPropertyAttribute. The decorator will be ignored.");
+                        ValidateDecoratorAttribute(type, field);
                     }
+                }
+            }
+        }
+
+        static void ValidateDecoratorAttribute(Type type, FieldInfo field)
+        {
+            if (field.GetCustomAttributes<DecoratorAttribute>().ToList().Count == 0) return;
+            if (field.GetCustomAttributes<DecoratedPropertyAttribute>().ToList().Count > 0) return;
+            Debug.LogError($"Crest: A decorator attribute on {type}.{field.Name} has no attribute which inherits from DecoratedPropertyAttribute. The decorator will be ignored.");
+        }
+
+        static void ValidateFilterEnumAttribute(Type type)
+        {
+            foreach (var attribute in type.GetCustomAttributes<FilterEnumAttribute>())
+            {
+                var field = type.GetField(attribute._property, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+                if (field == null)
+                {
+                    Debug.LogError($"Crest: A FilterEnumAttribute on {type} has no property named <i>{attribute._property}</i>. It will be ignored.");
+                }
+                else if (field.FieldType.BaseType != typeof(Enum))
+                {
+                    Debug.LogError($"Crest: A FilterEnumAttribute on {type} references <i>{attribute._property}</i> ({field.FieldType}) which is not an enum. It will be ignored.");
+                }
+                else if (field.GetCustomAttribute<FilteredAttribute>() == null)
+                {
+                    Debug.LogError($"Crest: A FilterEnumAttribute on {type} references <i>{attribute._property}</i> which has no FilteredAttribute. It will be ignored.");
                 }
             }
         }


### PR DESCRIPTION
Allows for subclasses to filter enum options.

```c#
class BaseInput
{
  [Filtered]
  Mode _mode;
}

[FilterEnum("_mode", FilteredAttribute.Mode.Include, (int)Mode.Primitive, (int)Mode.Geometry)]
class Input {}
```

There is a demo commit with implementation on the inputs for testing if you wish.

It will have to be implemented in painted branch to avoid a merge conflict.