### PR TITLE
Use full-screen triangle for shadow simulation

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -191,7 +191,8 @@ namespace Crest
         }
 
         /// <summary>
-        /// Blit using full screen triangle.
+        /// Blit using full screen triangle. Supports more features than CommandBuffer.Blit like the RenderPipeline tag
+        /// in sub-shaders.
         /// </summary>
         public static void Blit(CommandBuffer buffer, RenderTargetIdentifier target, Material material, int pass, MaterialPropertyBlock properties = null)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -75,8 +75,7 @@ namespace Crest
 
             {
                 _renderMaterial = new PropertyWrapperMaterial[OceanRenderer.Instance.CurrentLodCount];
-                var shaderPath = "Hidden/Crest/Simulation/Update Shadow";
-                var shader = Shader.Find(shaderPath);
+                var shader = Shader.Find("Hidden/Crest/Simulation/Update Shadow");
                 for (int i = 0; i < _renderMaterial.Length; i++)
                 {
                     _renderMaterial[i] = new PropertyWrapperMaterial(shader);
@@ -382,7 +381,7 @@ namespace Crest
 
                     LodDataMgrSeaFloorDepth.Bind(_renderMaterial[lodIdx]);
 
-                    BufCopyShadowMap.Blit(Texture2D.blackTexture, _targets.Current, _renderMaterial[lodIdx].material, -1, lodIdx);
+                    Helpers.Blit(BufCopyShadowMap, new RenderTargetIdentifier(_targets.Current, 0, CubemapFace.Unknown, lodIdx), _renderMaterial[lodIdx].material, -1);
                 }
 
 #if ENABLE_VR && ENABLE_VR_MODULE

--- a/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.shader
+++ b/crest/Assets/Crest/Crest/Shaders/Resources/UpdateShadow.shader
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+// Soft shadow term is red, hard shadow term is green.
+
 Shader "Hidden/Crest/Simulation/Update Shadow"
 {
 	SubShader
@@ -20,6 +22,7 @@ Shader "Hidden/Crest/Simulation/Update Shadow"
 
 			#include "UnityCG.cginc"
 
+			#include "../FullScreenTriangle.hlsl"
 			#include "../Helpers/BIRP/ScreenSpaceShadows.hlsl"
 			#include "../ShaderLibrary/UpdateShadow.hlsl"
 
@@ -41,20 +44,6 @@ Shader "Hidden/Crest/Simulation/Update Shadow"
 				float fade = UnityComputeShadowFade(fadeDistance);
 				return fade;
 			}
-
-			Varyings Vert(Attributes input)
-			{
-				Varyings output;
-
-				output.positionCS = UnityObjectToClipPos(input.positionOS);
-
-				// World position from [0,1] quad.
-				output.positionWS.xyz = float3(input.positionOS.x - 0.5, 0.0, input.positionOS.y - 0.5) * _Scale * 4.0 + _CenterPos;
-				output.positionWS.y = _OceanCenterPosWorld.y;
-
-				return output;
-			}
-
 			ENDHLSL
 		}
 	}

--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/UpdateShadow.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/UpdateShadow.hlsl
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+// Soft shadow term is red, hard shadow term is green.
+
 #include "../OceanConstants.hlsl"
 #include "../OceanGlobals.hlsl"
 #include "../OceanInputsDriven.hlsl"
@@ -21,14 +23,33 @@ CBUFFER_END
 
 struct Attributes
 {
-	float3 positionOS : POSITION;
+	uint id : SV_VertexID;
+	UNITY_VERTEX_INPUT_INSTANCE_ID
 };
 
 struct Varyings
 {
 	float4 positionCS : SV_POSITION;
 	float3 positionWS : TEXCOORD0;
+	UNITY_VERTEX_OUTPUT_STEREO
 };
+
+Varyings Vert(Attributes input)
+{
+	// This will work for all pipelines.
+	Varyings output = (Varyings)0;
+	UNITY_SETUP_INSTANCE_ID(input);
+	UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+	output.positionCS = GetFullScreenTriangleVertexPosition(input.id);
+	float2 uv = GetFullScreenTriangleTexCoord(input.id);
+
+	// World position from UV.
+	output.positionWS.xyz = float3(uv.x - 0.5, 0.0, uv.y - 0.5) * _Scale * 4.0 + _CenterPos;
+	output.positionWS.y = _OceanCenterPosWorld.y;
+
+	return output;
+}
 
 half CrestSampleShadows(const float4 i_positionWS);
 half CrestComputeShadowFade(const float4 i_positionWS);


### PR DESCRIPTION
Unity's Blit has a lot of limitations like not supporting the RP tag. I have moved to using our own helper method which uses FST. This change will allow us to combine all RP subshaders into one file using the RP tag.