### PR TITLE
Move "default clipping state" to settings

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsClipSurface.cs
@@ -28,6 +28,15 @@ namespace Crest
         [Tooltip("The render texture format to use for the clip surface simulation. It should only be changed if you need more precision. See the documentation for information.")]
         public GraphicsFormat _renderTextureGraphicsFormat = GraphicsFormat.R8_UNorm;
 
+        public enum DefaultClippingState
+        {
+            NothingClipped,
+            EverythingClipped,
+        }
+
+        [Tooltip("Whether to clip nothing by default (and clip inputs remove patches of surface), or to clip everything by default (and clip inputs add patches of surface).")]
+        public DefaultClippingState _defaultClippingState = DefaultClippingState.NothingClipped;
+
         public override void AddToSettingsHash(ref int settingsHash)
         {
             base.AddToSettingsHash(ref settingsHash);

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -255,15 +255,6 @@ namespace Crest
         [Predicated("_createClipSurfaceData"), Embedded]
         public SimSettingsClipSurface _simSettingsClipSurface;
 
-        public enum DefaultClippingState
-        {
-            NothingClipped,
-            EverythingClipped,
-        }
-        [Tooltip("Whether to clip nothing by default (and clip inputs remove patches of surface), or to clip everything by default (and clip inputs add patches of surface).")]
-        [Predicated("_createClipSurfaceData"), DecoratedField]
-        public DefaultClippingState _defaultClippingState = DefaultClippingState.NothingClipped;
-
         [Tooltip("Albedo - a colour layer composited onto the water surface."), SerializeField]
         bool _createAlbedoData = false;
         public bool CreateAlbedoData => _createAlbedoData;
@@ -429,7 +420,6 @@ namespace Crest
         public static readonly int sp_CrestLodChange = Shader.PropertyToID("_CrestLodChange");
         readonly static int sp_meshScaleLerp = Shader.PropertyToID("_MeshScaleLerp");
         readonly static int sp_sliceCount = Shader.PropertyToID("_SliceCount");
-        readonly static int sp_clipByDefault = Shader.PropertyToID("_CrestClipByDefault");
         readonly static int sp_lodAlphaBlackPointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointFade");
         readonly static int sp_lodAlphaBlackPointWhitePointFade = Shader.PropertyToID("_CrestLodAlphaBlackPointWhitePointFade");
         readonly static int sp_CrestDepthTextureOffset = Shader.PropertyToID("_CrestDepthTextureOffset");
@@ -969,7 +959,6 @@ namespace Crest
             // Set global shader params
             Shader.SetGlobalFloat(sp_crestTime, CurrentTime);
             Shader.SetGlobalFloat(sp_sliceCount, CurrentLodCount);
-            Shader.SetGlobalFloat(sp_clipByDefault, _defaultClippingState == DefaultClippingState.EverythingClipped ? 1f : 0f);
             Shader.SetGlobalFloat(sp_lodAlphaBlackPointFade, _lodAlphaBlackPointFade);
             Shader.SetGlobalFloat(sp_lodAlphaBlackPointWhitePointFade, _lodAlphaBlackPointWhitePointFade);
             Shader.SetGlobalInt(sp_CrestDepthTextureOffset, ViewCamera != null && Helpers.IsMSAAEnabled(ViewCamera) ? 1 : 0);

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -113,8 +113,8 @@ namespace Crest
         void HandleClipInputRegistration()
         {
             var registered = _clipInput != null;
-            var shouldBeRegistered = _registerWithClipSurfaceData && OceanRenderer.Instance && OceanRenderer.Instance.CreateClipSurfaceData
-                && OceanRenderer.Instance._defaultClippingState == OceanRenderer.DefaultClippingState.EverythingClipped;
+            var shouldBeRegistered = _registerWithClipSurfaceData && OceanRenderer.Instance && OceanRenderer.Instance._lodDataClipSurface != null
+                && OceanRenderer.Instance._lodDataClipSurface.Settings._defaultClippingState == SimSettingsClipSurface.DefaultClippingState.EverythingClipped;
 
             if (registered != shouldBeRegistered)
             {

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -18,6 +18,8 @@ Breaking
 .. bullet_list::
 
    -  Set minimum Unity version to 2021.3.3.
+   -  Moved *Default Clipping State* from *Ocean Renderer* into *Sim Settings Clip Surface* asset.
+      There is no migration available for this setting so if *Everything Clipped* is needed then this will need to be configured in the *Sim Settings Clip Surface* asset.
 
 
 Preview


### PR DESCRIPTION
Moved _Default Clipping State_ from _Ocean Renderer_ into _Sim Settings Clip Surface_ asset. I don't think a migration is worth the effort as we'd have to create a settings file if they don't have one which probably won't play nice in the migration pattern we favour.