### PR TITLE
Experiment with new approach

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
@@ -109,32 +109,32 @@ namespace Crest.EditorHelpers
                 EditorUtility.SetDirty(input);
             };
 
-            foreach (var input in GameObject.FindObjectsOfType<RegisterLodDataInputBase>(true))
-            {
-                if (input._inputMode == RegisterLodDataInputBase.InputMode.Unset)
-                {
-                    var newMode = input.DefaultMode;
-                    input.AutoDetectMode(out newMode);
+            //foreach (var input in GameObject.FindObjectsOfType<RegisterLodDataInputBase>(true))
+            //{
+            //    if (input._inputMode == RegisterLodDataInputBase.InputMode.Unset)
+            //    {
+            //        var newMode = input.DefaultMode;
+            //        input.AutoDetectMode(out newMode);
 
-                    if (newMode != input._inputMode)
-                    {
-                        setInputMode(input, newMode);
-                    }
+            //        if (newMode != input._inputMode)
+            //        {
+            //            setInputMode(input, newMode);
+            //        }
 
-                    continue;
-                }
+            //        continue;
+            //    }
 
-                if (input._inputMode != input.DefaultMode)
-                {
-                    // Don't touch if already set to a non-default mode
-                    continue;
-                }
+            //    if (input._inputMode != input.DefaultMode)
+            //    {
+            //        // Don't touch if already set to a non-default mode
+            //        continue;
+            //    }
 
-                if (input.AutoDetectMode(out var autoMode) && autoMode != input._inputMode)
-                {
-                    setInputMode(input, autoMode);
-                }
-            }
+            //    if (input.AutoDetectMode(out var autoMode) && autoMode != input._inputMode)
+            //    {
+            //        setInputMode(input, autoMode);
+            //    }
+            //}
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/EditorHelpers.cs
@@ -105,36 +105,38 @@ namespace Crest.EditorHelpers
             System.Action<RegisterLodDataInputBase, RegisterLodDataInputBase.InputMode> setInputMode = (input, newMode) =>
             {
                 Debug.Log($"Crest: Changing Input Mode of {input.GetType().Name} component on GameObject {input.gameObject.name} from {input._inputMode.ToString()} to {newMode}. Click this message to highlight this GameObject.", input);
-                input._inputMode = newMode;
-                EditorUtility.SetDirty(input);
+                input.InputModeUserFacing = newMode;
             };
 
-            //foreach (var input in GameObject.FindObjectsOfType<RegisterLodDataInputBase>(true))
-            //{
-            //    if (input._inputMode == RegisterLodDataInputBase.InputMode.Unset)
-            //    {
-            //        var newMode = input.DefaultMode;
-            //        input.AutoDetectMode(out newMode);
+            foreach (var input in GameObject.FindObjectsOfType<RegisterLodDataInputBase>(true))
+            {
+                if (input.InputModeUserFacing == RegisterLodDataInputBase.InputMode.Autodetect)
+                {
+                    input.AutoDetectMode(out var newMode);
 
-            //        if (newMode != input._inputMode)
-            //        {
-            //            setInputMode(input, newMode);
-            //        }
+                    // Avoid dirtying unnecessarily
+                    if (newMode != input.InputModeUserFacing)
+                    {
+                        setInputMode(input, newMode);
+                    }
 
-            //        continue;
-            //    }
+                    continue;
+                }
 
-            //    if (input._inputMode != input.DefaultMode)
-            //    {
-            //        // Don't touch if already set to a non-default mode
-            //        continue;
-            //    }
+                if (input.InputModeUserFacing != input.DefaultMode)
+                {
+                    // Don't touch if already set to a non-default mode (to avoid dirtying unnecessarily)
+                    continue;
+                }
 
-            //    if (input.AutoDetectMode(out var autoMode) && autoMode != input._inputMode)
-            //    {
-            //        setInputMode(input, autoMode);
-            //    }
-            //}
+                input.AutoDetectMode(out var autoMode);
+
+                // Avoid dirtying unnecessarily
+                if (autoMode != input._inputMode)
+                {
+                    setInputMode(input, autoMode);
+                }
+            }
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Albedo Input")]
     [CrestHelpURL("user/ocean-simulation", "albedo")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted, (int)InputMode.Primitive, (int)InputMode.Spline)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted, (int)InputMode.Primitive, (int)InputMode.Spline)]
     public class RegisterAlbedoInput : RegisterLodDataInput<LodDataMgrAlbedo>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Animated Waves Input")]
     [CrestHelpURL("user/ocean-simulation", "animated-waves")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted, (int)InputMode.Primitive, (int)InputMode.Spline)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted, (int)InputMode.Primitive, (int)InputMode.Spline)]
     public class RegisterAnimWavesInput : RegisterLodDataInput<LodDataMgrAnimWaves>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -17,7 +17,7 @@ namespace Crest
     /// </summary>
     [AddComponentMenu(MENU_PREFIX + "Clip Surface Input")]
     [CrestHelpURL("user/ocean-simulation", "clip-surface")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Spline)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Spline)]
     public partial class RegisterClipSurfaceInput : RegisterLodDataInput<LodDataMgrClipSurface>, IPaintable
     {
         /// <summary>
@@ -200,8 +200,9 @@ namespace Crest
                 return;
             }
 
-            if (_inputMode == InputMode.Unset)
+            if (_inputMode == InputMode.Autodetect)
             {
+                // TODO update message. This is invalid state.
                 Debug.LogError($"Crest: {GetType().Name} has component does not have an Input Mode set, please set this to a supported option such as {DefaultMode}. Click this message to highlight the relevant GameObject.", this);
                 return;
             }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Dynamic Waves Input")]
     [CrestHelpURL("user/ocean-simulation", "dynamic-waves")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted, (int)InputMode.Primitive, (int)InputMode.Spline)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted, (int)InputMode.Primitive, (int)InputMode.Spline)]
     public class RegisterDynWavesInput : RegisterLodDataInput<LodDataMgrDynWaves>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -16,7 +16,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Flow Input")]
     [CrestHelpURL("user/ocean-simulation", "flow")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Primitive)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Primitive)]
     public class RegisterFlowInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFlow, SplinePointDataFlow>, IPaintable
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -16,7 +16,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Foam Input")]
     [CrestHelpURL("user/ocean-simulation", "foam")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Primitive)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Primitive)]
     public class RegisterFoamInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFoam, SplinePointDataFoam>, IPaintable
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -13,7 +13,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Height Input")]
     [CrestHelpURL("user/water-bodies")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Primitive)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Primitive)]
     public partial class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrSeaFloorDepth>, IPaintable
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -58,7 +58,7 @@ namespace Crest
     {
         public enum InputMode
         {
-            Unset = 0,
+            Autodetect = 0,
             Painted,
             Spline,
             CustomGeometryAndShader,
@@ -67,7 +67,9 @@ namespace Crest
 
         [Header("Mode")]
         [Filtered]
-        public InputMode _inputMode = InputMode.Unset;
+        public InputMode _inputModeUserFacing = InputMode.Autodetect;
+        [HideInInspector]
+        public InputMode _inputMode = InputMode.Autodetect;
 
         public virtual InputMode DefaultMode => InputMode.Painted;
 
@@ -130,21 +132,25 @@ namespace Crest
         {
         }
 
-        public virtual bool AutoDetectMode(out InputMode mode)
+        public virtual void AutoDetectMode(out InputMode mode)
         {
             if (TryGetComponent<Renderer>(out _))
             {
                 mode = InputMode.CustomGeometryAndShader;
-                return true;
             }
-
-            mode = DefaultMode;
-            return false;
+            else
+            {
+                mode = DefaultMode;
+            }
         }
 
         protected virtual void Awake()
         {
-            if (_inputMode == InputMode.Unset)
+            if (_inputModeUserFacing != InputMode.Autodetect)
+            {
+                _inputMode = _inputModeUserFacing;
+            }
+            else
             {
                 AutoDetectMode(out _inputMode);
             }
@@ -153,10 +159,7 @@ namespace Crest
         // Called when component attached in edit mode, or when Reset clicked by user.
         protected void Reset()
         {
-            if (_inputMode == InputMode.Unset)
-            {
-                AutoDetectMode(out _inputMode);
-            }
+            AutoDetectMode(out _inputModeUserFacing);
         }
 
         protected virtual void OnDrawGizmosSelected()
@@ -292,9 +295,10 @@ namespace Crest
                     }
                 }
             }
-            else if (_inputMode == InputMode.Unset)
+            else if (_inputMode == InputMode.Autodetect)
             {
-                Debug.LogError($"Crest: {GetType().Name} has component does not have an Input Mode set, please set this to a supported option such as {DefaultMode}. Click this message to highlight the relevant GameObject.", this);
+                // TODO update message
+                //Debug.LogError($"Crest: {GetType().Name} has component does not have an Input Mode set, please set this to a supported option such as {DefaultMode}. Click this message to highlight the relevant GameObject.", this);
             }
         }
 
@@ -464,15 +468,16 @@ namespace Crest
             }
         }
 
-        public override bool AutoDetectMode(out InputMode mode)
+        public override void AutoDetectMode(out InputMode mode)
         {
             if (TryGetComponent<Spline.Spline>(out _))
             {
                 mode = InputMode.Spline;
-                return true;
             }
-
-            return base.AutoDetectMode(out mode);
+            else
+            {
+                base.AutoDetectMode(out mode);
+            }
         }
 
         protected virtual void CreateSplineMaterial()
@@ -597,16 +602,16 @@ namespace Crest
         {
             var isValid = true;
 
-            if (_inputMode == InputMode.Unset)
-            {
-                showMessage
-                (
-                    "Invalid or unset <i>Input Mode</i> setting.",
-                    $"Select a valid <i>Input Mode</i> such as {DefaultMode.ToString()} to use this input.",
-                    ValidatedHelper.MessageType.Error, this, so => FixSetMode(so, DefaultMode)
-                );
-                isValid = false;
-            }
+            //if (_inputMode == InputMode.Unset)
+            //{
+            //    showMessage
+            //    (
+            //        "Invalid or unset <i>Input Mode</i> setting.",
+            //        $"Select a valid <i>Input Mode</i> such as {DefaultMode.ToString()} to use this input.",
+            //        ValidatedHelper.MessageType.Error, this, so => FixSetMode(so, DefaultMode)
+            //    );
+            //    isValid = false;
+            //}
 
             if (_inputMode == InputMode.CustomGeometryAndShader)
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -13,7 +13,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Sea Floor Depth Input")]
     [CrestHelpURL("user/ocean-simulation", "sea-floor-depth")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted)]
     public class RegisterSeaFloorDepthInput : RegisterLodDataInput<LodDataMgrSeaFloorDepth>
     {
         /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -12,7 +12,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Shadow Input")]
     [CrestHelpURL("user/ocean-simulation", "shadows")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Spline, (int)InputMode.Painted, (int)InputMode.Primitive)]
+    [FilterEnum("_inputModeUserFacing", FilteredAttribute.Mode.Exclude, (int)InputMode.Spline, (int)InputMode.Painted, (int)InputMode.Primitive)]
     public class RegisterShadowInput : RegisterLodDataInput<LodDataMgrShadow>
     {
         /// <summary>


### PR DESCRIPTION
I figured a lot of the complication was coming from fighting with serialisation, and decided to untangle things by separating out serialised/user facing state with internal actual state. I replaced 'Unset' with 'Autodetect' which is a valid default for all components. Then internally, if the user setting is Autodetect, the component detects which state to go into.

This creates a valid default for the serialised data - a deserialised component with default data should work happily and we should not have to worry about migration for old data. I feel this is a compelling idea and with just a few changes i could remove the code that fights with serialisation.

However it throws up a whole new set of problems with keeping the user facing state and internal state synchronised. I did some changes and it might be working in many cases.. but i dont think all.. and there's too many cases for me to reason about all at once, so im not sure its worth pursuing further. Or maybe i just need to find the right pattern.

Another problem is its not clear what state the component as has picked, although if we could display the dropdown option with the current selected mode that could sort it, like `Autodetect (Spline)`.

I think we should stick with what we have but posting here for posterity.