### PR TITLE
Fix Build Processor obsolete warnings

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/BuildProcessor.cs
@@ -145,10 +145,10 @@ namespace Crest
                 // way to get a list of keywords without trying to extract them from shader property names. Lastly,
                 // shader_feature will be returned only if they are enabled.
                 var skipped = data[i].shaderKeywordSet.GetShaderKeywords()
-                    // Ignore Unity keywords.
-                    .Where(x => ShaderKeyword.GetKeywordType(shader, x) == ShaderKeywordType.UserDefined)
+                    // Ignore Unity keywords (I do not think this actually does anything but I feel better with it here).
+                    .Where(x => ShaderKeyword.IsKeywordLocal(x) || ShaderKeyword.GetGlobalKeywordType(x) == ShaderKeywordType.UserDefined)
                     // Ignore keywords from our list above.
-                    .Where(x => !s_ShaderKeywordsToIgnoreStripping.Contains(ShaderKeyword.GetKeywordName(shader, x)));
+                    .Where(x => !s_ShaderKeywordsToIgnoreStripping.Contains(x.name));
                 shaderKeywords.UnionWith(skipped);
             }
 
@@ -157,7 +157,7 @@ namespace Crest
             foreach (var shaderKeyword in shaderKeywords)
             {
                 // GetKeywordName will work for both global and local keywords.
-                var shaderKeywordName = ShaderKeyword.GetKeywordName(shader, shaderKeyword);
+                var shaderKeywordName = shaderKeyword.name;
 
                 // Mensicus is set on the UnderwaterRenderer component.
                 if (shaderKeywordName.Contains("CREST_MENISCUS"))
@@ -189,7 +189,7 @@ namespace Crest
             var unusedShaderKeyowrds = new HashSet<ShaderKeyword>();
             foreach (var shaderKeyword in shaderKeywords)
             {
-                var shaderKeywordName = ShaderKeyword.GetKeywordName(shader, shaderKeyword);
+                var shaderKeywordName = shaderKeyword.name;
 
                 // Mensicus is set on the UnderwaterRenderer component.
                 if (shaderKeywordName.Contains("CREST_MENISCUS"))

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -37,6 +37,7 @@ Fixed
    -  Limit minimum phase period of flow technique applied to waves to fix objectionable phasing issues in flowing water like rivers.
    -  Fixed broken/missing documentation links.
    -  Fixed water plane moving in edit mode with *Always Refresh* disabled. `[HDRP]`
+   -  Fixed *Build Processor* deprecated/obsolete warnings.
 
 
 Removed


### PR DESCRIPTION
Fixes obsolete warnings seen on load / script recompile for using obsolete shader keyword API.