### PR TITLE
Fix prefab mode breaking things

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Constants.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Constants.cs
@@ -15,5 +15,7 @@ namespace Crest.Internal
         public const string MENU_PREFIX_DEBUG = MENU_SCRIPTS + "Debug/" + PREFIX;
         public const string MENU_PREFIX_SPLINE = MENU_SCRIPTS + "Spline/" + PREFIX;
         public const string MENU_PREFIX_EXAMPLE = MENU_SCRIPTS + "Example/" + PREFIX;
+
+        public const string k_NoPrefabModeSupportWarning = "Crest does not support prefab mode. Changes made in prefab mode will not be reflected in the scene view. Save this prefab to see changes.";
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -9,11 +9,6 @@ using Crest.Internal;
 #if UNITY_EDITOR
 using UnityEngine.Rendering;
 using UnityEditor;
-#if UNITY_2021_2_OR_NEWER
-using UnityEditor.SceneManagement;
-#else
-using UnityEditor.Experimental.SceneManagement;
-#endif
 #endif
 
 #if !UNITY_2021_3_OR_NEWER
@@ -484,20 +479,28 @@ namespace Crest
         BufferedData<PerCascadeInstanceData[]> _perCascadeInstanceData;
         public int BufferSize { get; private set; }
 
-        // When leaving the last prefab stage, OnDisabled will be called but GetCurrentPrefabStage will return nothing
-        // which will fail the prefab check and disable the OceanRenderer in the scene. We need to track it ourselves.
-#pragma warning disable 414
-        static bool s_IsPrefabStage = false;
-#pragma warning restore 414
+#if UNITY_EDITOR
+        // The OceanRenderer system (due to Singleton pattern) does not work well with prefab stages as they create
+        // duplicates (one for scene one for prefab stage).
+        // When leaving the last prefab stage, OnDisabled/OnDestroyed will be called but GetCurrentPrefabStage will
+        // return nothing which will fail the prefab check and disable the OceanRenderer in the scene. We need to track
+        // it ourselves.
+        internal bool _isPrefabStageInstance = false;
+
+        void Awake()
+        {
+            // Store whether this instance was created in a prefab stage.
+            var stage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+            _isPrefabStageInstance = stage != null && gameObject.scene == stage.scene;
+        }
+#endif
 
         // Drive state from OnEnable and OnDisable? OnEnable on RegisterLodDataInput seems to get called on script reload
         void OnEnable()
         {
-            // We don't run in "prefab scenes", i.e. when editing a prefab. Bail out if prefab scene is detected.
 #if UNITY_EDITOR
-            if (PrefabStageUtility.GetCurrentPrefabStage() != null)
+            if (_isPrefabStageInstance)
             {
-                s_IsPrefabStage = true;
                 return;
             }
 #endif
@@ -618,17 +621,8 @@ namespace Crest
         private void OnDisable()
         {
 #if UNITY_EDITOR
-            // We don't run in "prefab scenes", i.e. when editing a prefab. Bail out if prefab scene is detected.
-            if (PrefabStageUtility.GetCurrentPrefabStage() != null)
+            if (_isPrefabStageInstance)
             {
-                // We have just left a prefab scene on the stack and are now in another prefab scene.
-                return;
-            }
-            else if (s_IsPrefabStage)
-            {
-                // We have left the last prefab scene and are now back to a normal scene. We do not want to disable the
-                // OceanRenderer.
-                s_IsPrefabStage = false;
                 return;
             }
 #endif
@@ -908,6 +902,11 @@ namespace Crest
 #if UNITY_EDITOR
             // Don't run immediately if in edit mode - need to count editor frames so this is run through EditorUpdate()
             if (!EditorApplication.isPlaying)
+            {
+                return;
+            }
+
+            if (_isPrefabStageInstance)
             {
                 return;
             }
@@ -1959,11 +1958,19 @@ namespace Crest
 
         public override void OnInspectorGUI()
         {
+            var target = this.target as OceanRenderer;
+
+            if (target._isPrefabStageInstance)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.HelpBox(Internal.Constants.k_NoPrefabModeSupportWarning, MessageType.Warning);
+                EditorGUILayout.Space();
+            }
+
             var currentAssignedTP = serializedObject.FindProperty("_timeProvider").objectReferenceValue;
 
             base.OnInspectorGUI();
 
-            var target = this.target as OceanRenderer;
 
             // Detect if user changed TP, if so update stack
             var newlyAssignedTP = serializedObject.FindProperty("_timeProvider").objectReferenceValue;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -106,6 +106,10 @@ namespace Crest
             }
         }
 
+#if UNITY_EDITOR
+        internal bool _isPrefabStageInstance = false;
+#endif
+
         public class GerstnerBatch : ILodDataInput
         {
             ShapeGerstner _gerstner;
@@ -685,6 +689,13 @@ namespace Crest
 
         private void OnEnable()
         {
+#if UNITY_EDITOR
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             Instances.Add(transform.GetSiblingIndex(), this);
 
             _firstUpdate = true;
@@ -713,6 +724,13 @@ namespace Crest
 
         void OnDisable()
         {
+#if UNITY_EDITOR
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             Instances.Remove(this);
 
             LodDataMgrAnimWaves.DeregisterUpdatable(this);
@@ -757,11 +775,24 @@ namespace Crest
 
         void Awake()
         {
+#if UNITY_EDITOR
+            // Store whether this instance was created in a prefab stage.
+            var stage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+            _isPrefabStageInstance = stage != null && gameObject.scene == stage.scene;
+#endif
+
             s_InstanceCount++;
         }
 
         void OnDestroy()
         {
+#if UNITY_EDITOR
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             if (--s_InstanceCount <= 0)
             {
                 if (s_DefaultSpectrum != null)
@@ -836,6 +867,21 @@ namespace Crest
 
     // Here for the help boxes
     [CustomEditor(typeof(ShapeGerstner))]
-    public class ShapeGerstnerEditor : ValidatedEditor { }
+    public class ShapeGerstnerEditor : ValidatedEditor
+    {
+        public override void OnInspectorGUI()
+        {
+            var target = this.target as ShapeGerstner;
+
+            if (target._isPrefabStageInstance)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.HelpBox(Internal.Constants.k_NoPrefabModeSupportWarning, MessageType.Warning);
+                EditorGUILayout.Space();
+            }
+
+            base.OnInspectorGUI();
+        }
+    }
 #endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -182,8 +182,28 @@ namespace Crest
             }
         }
 
+#if UNITY_EDITOR
+        internal bool _isPrefabStageInstance = false;
+
+        void Awake()
+        {
+            // Store whether this instance was created in a prefab stage.
+            var stage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
+            _isPrefabStageInstance = stage != null && gameObject.scene == stage.scene;
+        }
+#endif
+
         void OnEnable()
         {
+#if UNITY_EDITOR
+            _isPrefabStageInstance = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage() != null;
+
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             if (_camera == null)
             {
                 _camera = GetComponent<Camera>();
@@ -210,6 +230,13 @@ namespace Crest
 
         void OnDisable()
         {
+#if UNITY_EDITOR
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             Disable();
             Instance = null;
         }
@@ -256,6 +283,13 @@ namespace Crest
 
         void LateUpdate()
         {
+#if UNITY_EDITOR
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             Helpers.SetGlobalKeyword("CREST_UNDERWATER_BEFORE_TRANSPARENT", _enableShaderAPI);
 
             if (_enableShaderAPI != _currentEnableShaderAPI && _underwaterEffectCommandBuffer != null)
@@ -273,6 +307,13 @@ namespace Crest
 
         void OnPreRender()
         {
+#if UNITY_EDITOR
+            if (_isPrefabStageInstance)
+            {
+                return;
+            }
+#endif
+
             if (!IsActive)
             {
                 if (Instance != null)
@@ -512,6 +553,15 @@ namespace Crest
     {
         public override void OnInspectorGUI()
         {
+            var target = this.target as UnderwaterRenderer;
+
+            if (target._isPrefabStageInstance)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.HelpBox(Internal.Constants.k_NoPrefabModeSupportWarning, MessageType.Warning);
+                EditorGUILayout.Space();
+            }
+
             EditorGUILayout.Space();
             EditorGUILayout.HelpBox("Scene view rendering can be enabled/disabled with the scene view fog toggle in the scene view command bar.", MessageType.Info);
             EditorGUILayout.Space();

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -30,6 +30,13 @@ Preview
       See tooltip on this new option for instructions and more details.
 
 
+Changed
+^^^^^^^
+.. bullet_list::
+
+   -  Warn users edits in prefab mode will not be reflected in scene view until prefab is saved.
+
+
 Fixed
 ^^^^^
 .. bullet_list::
@@ -38,6 +45,7 @@ Fixed
    -  Fixed broken/missing documentation links.
    -  Fixed water plane moving in edit mode with *Always Refresh* disabled. `[HDRP]`
    -  Fixed *Build Processor* deprecated/obsolete warnings.
+   -  Fixed some components breaking in edit mode after entering/exiting prefab mode.
 
 
 Removed

--- a/docs/about/known-issues.rst
+++ b/docs/about/known-issues.rst
@@ -43,3 +43,10 @@ There are upcoming features being developed by Unity which will greatly help `Cr
 If you could vote on these features, that would be greatly appreciated:
 
 -  :link:`Post Processing Custom Effects <https://portal.productboard.com/8ufdwj59ehtmsvxenjumxo82/c/37-post-processing-custom-effects>` `[[URP]]`
+
+
+Prefab Mode Not Supported
+-------------------------
+
+Crest does not support running in prefab mode which means dirty state in prefab mode will not be reflected in the scene view.
+Save the prefab to see the changes.

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -19,6 +19,11 @@ Why does the ocean not update smoothly in edit mode?
 ----------------------------------------------------
 .. include:: /user/includes/_animated-materials.rst
 
+Why aren't my prefab mode edits not reflected in the scene view?
+----------------------------------------------------------------
+Crest does not support running in prefab mode which means dirty state in prefab mode will not be reflected in the scene view.
+Save the prefab to see the changes.
+
 Is *Crest* well suited for medium-to-low powered mobile devices?
 ----------------------------------------------------------------
 *Crest* is built to be performant by design and has numerous quality/performance levers.

--- a/docs/user/getting-started.rst
+++ b/docs/user/getting-started.rst
@@ -245,3 +245,10 @@ Ocean framerate low in edit mode
    If reflections appear wrong, it can be useful to make a simple test shadergraph with our water normal map applied to it, to compare results.
    We provide a simple test shadergraph for debugging purposes - enable the *Apply test material* debug option on the *OceanRenderer* component to apply it.
    If you find you are getting good results with a test shadergraph but not with our ocean shader, please report this to us.
+
+
+Changes made in prefab mode are not reflected in the scene view
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Crest does not support running in prefab mode which means dirty state in prefab mode will not be reflected in the scene view.
+Save the prefab to see the changes.


### PR DESCRIPTION
Crest doesn't support prefab mode but some components still run which causes problems. This makes disabling prefab mode more robust and expands the roster of components to all problematic components.

The prefab mode experience is that the OR from the scene will continue to run and be visible in prefab mode, but prefab mode changes will not be reflected in the scene view until it is saved. This is due to the OR in the scene view not knowing about the changes made in prefab mode as they are separate instances. This is the same for the other problematic components: UR, ShapeFFT and ShapeGerstner.