### PR TITLE
Tweaks to painting input

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -58,8 +58,8 @@ namespace Crest
         bool _spectrumFixedAtRuntime = true;
 
         [Tooltip("Primary wave direction heading (deg). This is the angle from x axis in degrees that the waves are oriented towards. If a spline is being used to place the waves, this angle is relative ot the spline."), Range(-180, 180)]
+        [Predicated("_inputMode", inverted: false, Mode.Painted), DecoratedField]
         public float _waveDirectionHeadingAngle = 0f;
-        public float WindDirRadForFFT => _inputMode == Mode.Spline ? 0f : _waveDirectionHeadingAngle * Mathf.Deg2Rad;
         public Vector2 PrimaryWaveDirection => new Vector2(Mathf.Cos(Mathf.PI * _waveDirectionHeadingAngle / 180f), Mathf.Sin(Mathf.PI * _waveDirectionHeadingAngle / 180f));
 
         [Tooltip("When true, uses the wind speed on this component rather than the wind speed from the Ocean Renderer component.")]
@@ -338,7 +338,7 @@ namespace Crest
 
             // If using geo, the primary wave dir is used by the input shader to rotate the waves relative
             // to the geo rotation. If not, the wind direction is already used in the FFT gen.
-            var waveDir = _inputMode == Mode.Spline ? PrimaryWaveDirection : Vector2.right;
+            var waveDir = (_inputMode == Mode.Spline || _inputMode == Mode.Painted) ? PrimaryWaveDirection : Vector2.right;
             mat.SetVector(sp_AxisX, waveDir);
 
             // If geometry is being used, the ocean input shader will rotate the waves to align to geo
@@ -535,6 +535,20 @@ namespace Crest
                 }
 
                 _batches = null;
+            }
+        }
+
+        public float WindDirRadForFFT
+        {
+            get
+            {
+                // These input types use a wave direction provided by geometry or the painted user direction
+                if (_inputMode == Mode.Spline || _inputMode == Mode.Painted)
+                {
+                    return 0f;
+                }
+
+                return _waveDirectionHeadingAngle * Mathf.Deg2Rad;
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -116,7 +116,7 @@ namespace Crest
         {
             _paintData.CenterPosition3 = transform.position;
 
-            return _paintData.PaintSmoothstep(this, paintPosition3, 0.0125f * paintWeight, paintDir, _paintData.BrushRadius, _paintData._brushStrength, CPUTexturePaintHelpers.PaintFnAdditivePlusRemoveBlendSaturateVector2, remove);
+            return _paintData.PaintSmoothstep(this, paintPosition3, 0.025f * paintWeight, paintDir, _paintData.BrushRadius, _paintData._brushStrength, CPUTexturePaintHelpers.PaintFnAdditivePlusRemoveBlendSaturateVector2, remove);
         }
         #endregion
 

--- a/crest/Assets/Crest/Crest/Scripts/UserPainted/InputPainting.cs
+++ b/crest/Assets/Crest/Crest/Scripts/UserPainted/InputPainting.cs
@@ -133,7 +133,7 @@ namespace Crest
         // These two params have been around the houses. It doesn't really make sense to put them here, but it was awful having them shared across all
         // input types, and having them as statics so they'd get lost after code changes. Perhaps they belong in a dictionary based on data type,
         // with recovery after recompiles.
-        [Range(0f, 50f)]
+        [Range(0f, 100f)]
         public float _brushRadius = 2f;
         public float BrushRadius => _brushRadius;
 


### PR DESCRIPTION
Few minor tweaks after authoring Island waves.

Most significant is the wave direction change. When painting waves, take the direction the user is painting for the waves, don't incorporate the global wind heading offset. Adding the offset makes the behaviour very confusing and I don't envision a use case for this in practice.