### PR TITLE
Helpers for register/deregister with input for subqueue index

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -238,14 +238,12 @@ namespace Crest
 
         void OnEnable()
         {
-            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrDynWaves));
-            registered.Remove(this);
-            registered.Add(0, this);
+            RegisterLodDataInput<LodDataMgrDynWaves>.RegisterInput(this, 0, transform.GetSiblingIndex());
         }
 
         void OnDisable()
         {
-            RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrDynWaves)).Remove(this);
+            RegisterLodDataInput<LodDataMgrDynWaves>.DeregisterInput(this);
         }
 
         private void OnDrawGizmosSelected()

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -386,13 +386,11 @@ namespace Crest
 
         void InitBatches()
         {
-            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
-
             if (_batches != null)
             {
                 foreach (var batch in _batches)
                 {
-                    registered.Remove(batch);
+                    RegisterLodDataInput<LodDataMgrAnimWaves>.DeregisterInput(batch);
                 }
             }
 
@@ -438,6 +436,11 @@ namespace Crest
             var usingGeometryToGenerate = _inputMode == Mode.Spline;
             if (!usingGeometryToGenerate || MeshForGeneration)
             {
+                // Queue determines draw order of this input. Global waves should be rendered first. They are additive
+                // so not order dependent.
+                var queue = 0;
+                var subQueue = transform.GetSiblingIndex();
+
                 // Submit draws to create the FFT waves
                 _batches = new FFTBatch[CASCADE_COUNT];
                 var generationMaterial = MaterialForGeneration;
@@ -445,7 +448,7 @@ namespace Crest
                 {
                     if (i == -1) break;
                     _batches[i] = new FFTBatch(this, MinWavelength(i), i, generationMaterial, MeshForGeneration);
-                    registered.Add(0, _batches[i]);
+                    RegisterLodDataInput<LodDataMgrAnimWaves>.RegisterInput(_batches[i], queue, subQueue);
                 }
             }
         }
@@ -528,10 +531,9 @@ namespace Crest
 
             if (_batches != null)
             {
-                var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
                 foreach (var batch in _batches)
                 {
-                    registered.Remove(batch);
+                    RegisterLodDataInput<LodDataMgrAnimWaves>.DeregisterInput(batch);
                 }
 
                 _batches = null;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -636,13 +636,11 @@ namespace Crest
 
         void InitBatches()
         {
-            var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
-
             if (_batches != null)
             {
                 foreach (var batch in _batches)
                 {
-                    registered.Remove(batch);
+                    RegisterLodDataInput<LodDataMgrAnimWaves>.DeregisterInput(batch);
                 }
             }
 
@@ -677,13 +675,16 @@ namespace Crest
                 _matGenerateWaves = _matGenerateWavesGeometry;
             }
 
+            var queue = 0;
+            var subQueue = transform.GetSiblingIndex();
+            
             // Submit draws to create the Gerstner waves
             _batches = new GerstnerBatch[CASCADE_COUNT];
             for (int i = _firstCascade; i <= _lastCascade; i++)
             {
                 if (i == -1) break;
                 _batches[i] = new GerstnerBatch(this, MinWavelength(i), i, _matGenerateWaves, _meshForDrawingWaves);
-                registered.Add(0, _batches[i]);
+                RegisterLodDataInput<LodDataMgrAnimWaves>.RegisterInput(_batches[i], queue, subQueue);
             }
         }
 
@@ -737,10 +738,9 @@ namespace Crest
 
             if (_batches != null)
             {
-                var registered = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrAnimWaves));
                 foreach (var batch in _batches)
                 {
-                    registered.Remove(batch);
+                    RegisterLodDataInput<LodDataMgrAnimWaves>.DeregisterInput(batch);
                 }
 
                 _batches = null;

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -92,7 +92,7 @@ namespace Crest
 
             if (_clipInput != null)
             {
-                RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrClipSurface)).Remove(_clipInput);
+                RegisterLodDataInput<LodDataMgrClipSurface>.DeregisterInput(_clipInput);
 
                 _clipInput = null;
             }
@@ -122,12 +122,11 @@ namespace Crest
                 {
                     _clipInput = new ClipInput(this);
 
-                    var registrar = RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrClipSurface));
-                    registrar.Add(0, _clipInput);
+                    RegisterLodDataInput<LodDataMgrClipSurface>.RegisterInput(_clipInput, 0, transform.GetSiblingIndex());
                 }
                 else
                 {
-                    RegisterLodDataInputBase.GetRegistrar(typeof(LodDataMgrClipSurface)).Remove(_clipInput);
+                    RegisterLodDataInput<LodDataMgrClipSurface>.DeregisterInput(_clipInput);
 
                     _clipInput = null;
                 }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -40,6 +40,7 @@ Changed
 .. bullet_list::
 
    -  Warn users edits in prefab mode will not be reflected in scene view until prefab is saved.
+   -  Ocean inputs provided via the *Register* components now sort on sibling index in addition to queue, so multiple inputs with the same queue can be organised in the hierarchy to control sort order.
 
 
 Fixed


### PR DESCRIPTION
After identifying potential issues with sorting, we decided picking sibling index as a sub-queue-index might work well.

So sorting of inputs effectively happens on two keys - primarily on queue index, and then secondarily on subqueue index, for which the sibling index can be used. So relative order of siblings will dictate order they apply, similar to Unity's UI system.

This took a bit of untangling to bring over from #1032. The queue value is not initialised for FFT/Gerstner, leaving that for #1032.

This simplifies/cleans up the code as a bonus.
