### PR TITLE
Add hide option to Predicated and clean up UI

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Attributes/MultiPropertyAttribute.cs
@@ -263,4 +263,24 @@ namespace Crest
             _property = property;
         }
     }
+
+    /// <summary>
+    /// Drop-in replacement for Header. Use when hiding property with Predicated.
+    /// </summary>
+    public class HeadingAttribute : DecoratorAttribute
+    {
+        readonly string _heading;
+
+        public HeadingAttribute(string heading)
+        {
+            _heading = heading;
+        }
+
+        internal override void Decorate(Rect position, SerializedProperty property, GUIContent label, DecoratedDrawer drawer)
+        {
+            // Register margin with IMGUI so subsequent spacing is correct.
+            EditorGUILayout.GetControlRect(false, EditorGUIUtility.singleLineHeight * 0.5f);
+            GUI.Label(EditorGUILayout.GetControlRect(true), _heading, EditorStyles.boldLabel);
+        }
+    }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Editor/MultiPropertyDrawer.cs
@@ -39,8 +39,10 @@ namespace Crest.EditorHelpers
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            // Make original control rectangle be invisible because we always create our own.
-            return 0;
+            // Make original control rectangle be invisible because we always create our own. Zero still adds a little
+            // height which becomes noticeable once multiple properties are hidden. This could be some GUI style
+            // property but could not find which one.
+            return -2f;
         }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
@@ -49,14 +51,24 @@ namespace Crest.EditorHelpers
             var originalColor = GUI.color;
             var originalEnabled = GUI.enabled;
 
+            // Execute all non visual attributes like Predicated.
             for (var index = 0; index < Decorators.Count; index++)
             {
                 var attribute = (DecoratorAttribute)Decorators[index];
+                if (attribute is not PredicatedAttribute) continue;
                 attribute.Decorate(position, property, attribute.BuildLabel(label), this);
             }
 
             if (!s_HideInInspector)
             {
+                // Execute all visual attributes.
+                for (var index = 0; index < Decorators.Count; index++)
+                {
+                    var attribute = (DecoratorAttribute)Decorators[index];
+                    if (attribute is PredicatedAttribute) continue;
+                    attribute.Decorate(position, property, attribute.BuildLabel(label), this);
+                }
+
                 var a = (DecoratedPropertyAttribute) attribute;
                 try
                 {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -44,29 +44,31 @@ namespace Crest
         // Primitive is the best default for clipping, so override the default defined in the base class.
         public override InputMode DefaultMode => InputMode.Primitive;
 
-        [Header("Primitive Mode Settings")]
+        [Heading("Primitive Mode Settings")]
 
         [Tooltip("The primitive to render (signed distance) into the simulation.")]
-        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Primitive), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Primitive, hide: true), DecoratedField]
         Primitive _primitive = Primitive.Cube;
 
         // Only needed for Primitive as non-primitive uses queue from shader.
         [Tooltip("Order (ascending) that this input will be rendered into the clip surface data.")]
-        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Primitive), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Primitive, hide: true), DecoratedField]
         int _order = 0;
 
         // Only Mode.Primitive SDF supports inverted.
         [Tooltip("Removes clip surface data instead of adding it.")]
-        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Primitive), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Primitive, hide: true), DecoratedField]
         bool _inverted = false;
 
-        [Header("3D Clipping Options")]
+        [Heading("3D Clipping Options")]
 
         [Tooltip("Prevents inputs from cancelling each other out when aligned vertically. It is imperfect so custom logic might be needed for your use case.")]
-        [SerializeField] bool _disableClipSurfaceWhenTooFarFromSurface = false;
+        [SerializeField, Predicated("_inputMode", inverted: false, InputMode.Painted, hide: true), Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader), DecoratedField]
+        bool _disableClipSurfaceWhenTooFarFromSurface = false;
 
         [Tooltip("Large, choppy waves require higher iterations to have accurate holes.")]
-        [SerializeField] uint _animatedWavesDisplacementSamplingIterations = 4;
+        [SerializeField, Predicated("_inputMode", inverted: false, InputMode.Painted, hide: true), DecoratedField]
+        uint _animatedWavesDisplacementSamplingIterations = 4;
 
         public override float Wavelength => 0f;
 
@@ -78,8 +80,8 @@ namespace Crest
         protected override bool FollowHorizontalMotion => true;
 
         #region Painting
-        [Header("Paint Mode Settings")]
-        [Predicated("_inputMode", inverted: true, InputMode.Painted), DecoratedField]
+        [Heading("Paint Mode Settings")]
+        [Predicated("_inputMode", inverted: true, InputMode.Painted, hide: true), DecoratedField]
         public CPUTexture2DPaintable_R16_AddBlend _paintData;
         public IPaintedData PaintedData => _paintData;
         public Shader PaintedInputShader => Shader.Find("Hidden/Crest/Inputs/Clip Surface/Painted");
@@ -267,7 +269,7 @@ namespace Crest
             }
 
             // Prevents possible conflicts since overlapping doesn't work for every case for convex null.
-            if (_disableClipSurfaceWhenTooFarFromSurface)
+            if (_inputMode == InputMode.CustomGeometryAndShader && _disableClipSurfaceWhenTooFarFromSurface)
             {
                 var position = transform.position;
                 _sampleHeightHelper.Init(position, 0f);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -42,8 +42,8 @@ namespace Crest
         protected override Vector2 DefaultCustomData => new Vector2(SplinePointDataFlow.k_defaultSpeed, 0f);
 
         #region Painting
-        [Header("Paint Mode Settings")]
-        [Predicated("_inputMode", inverted: true, InputMode.Painted), DecoratedField]
+        [Heading("Paint Mode Settings")]
+        [Predicated("_inputMode", inverted: true, InputMode.Painted, hide: true), DecoratedField]
         public CPUTexture2DPaintable_RG16_AddBlend _paintData;
         public IPaintedData PaintedData => _paintData;
         public Shader PaintedInputShader => Shader.Find("Hidden/Crest/Inputs/Flow/Painted");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -42,8 +42,8 @@ namespace Crest
         protected override Vector2 DefaultCustomData => Vector2.right;
 
         #region Painting
-        [Header("Paint Mode Settings")]
-        [Predicated("_inputMode", inverted: true, InputMode.Painted), DecoratedField]
+        [Heading("Paint Mode Settings")]
+        [Predicated("_inputMode", inverted: true, InputMode.Painted, hide: true), DecoratedField]
         public CPUTexture2DPaintable_R16_AddBlend _paintData;
         public IPaintedData PaintedData => _paintData;
         public Shader PaintedInputShader => Shader.Find("Hidden/Crest/Inputs/Foam/Painted Foam");
@@ -76,6 +76,8 @@ namespace Crest
             return _paintData.PaintSmoothstep(this, paintPosition3, paintWeight, 0.03f, _paintData.BrushRadius, _paintData._brushStrength, CPUTexturePaintHelpers.PaintFnAdditiveBlendSaturateFloat, remove);
         }
         #endregion
+
+        [Header("Other Settings")]
 
         [SerializeField, Tooltip(k_displacementCorrectionTooltip)]
         bool _followHorizontalMotion = false;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -40,8 +40,8 @@ namespace Crest
         protected override bool FollowHorizontalMotion => true;
 
         #region Painting
-        [Header("Paint Mode Settings")]
-        [Predicated("_inputMode", inverted: true, InputMode.Painted), DecoratedField]
+        [Heading("Paint Mode Settings")]
+        [Predicated("_inputMode", inverted: true, InputMode.Painted, hide: true), DecoratedField]
         public CPUTexture2DPaintable_R16_AddBlend _paintData;
         public IPaintedData PaintedData => _paintData;
         public Shader PaintedInputShader => Shader.Find("Hidden/Crest/Inputs/Sea Floor Depth/Base Water Height Painted");

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -89,13 +89,13 @@ namespace Crest
         public bool ShowPaintingUI => _inputMode == InputMode.Painted;
 
 #if UNITY_EDITOR
-        [Header("Custom Geometry And Shader Mode Settings")]
+        [Heading("Custom Geometry And Shader Mode Settings")]
         [SerializeField, Tooltip("Check that the shader applied to this object matches the input type (so e.g. an Animated Waves input object has an Animated Waves input shader.")]
-        [Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader), DecoratedField]
+        [Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader, hide: true), DecoratedField]
         bool _checkShaderName = true;
 
         [SerializeField, Tooltip("Check that the shader applied to this object has only a single pass as only the first pass is executed for most inputs.")]
-        [Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader), DecoratedField]
+        [Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader, hide: true), DecoratedField]
         bool _checkShaderPasses = true;
 #endif
 
@@ -350,7 +350,7 @@ namespace Crest
     {
         protected const string k_displacementCorrectionTooltip = "Whether this input data should displace horizontally with waves. If false, data will not move from side to side with the waves. Adds a small performance overhead when disabled.";
 
-        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.CustomGeometryAndShader, hide: true), DecoratedField]
         bool _disableRenderer = true;
 
         int _registeredQueueValue = int.MinValue;
@@ -446,12 +446,12 @@ namespace Crest
         where LodDataType : LodDataMgr
         where SplinePointCustomData : MonoBehaviour, ISplinePointCustomData
     {
-        [Header("Spline Mode Settings")]
-        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Spline), DecoratedField]
+        [Heading("Spline Mode Settings")]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Spline, hide: true), DecoratedField]
         bool _overrideSplineSettings = false;
-        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Spline, hide: true), Predicated("_overrideSplineSettings"), DecoratedField]
         float _radius = 20f;
-        [SerializeField, Predicated("_overrideSplineSettings"), Delayed]
+        [SerializeField, Predicated("_inputMode", inverted: true, InputMode.Spline, hide: true), Predicated("_overrideSplineSettings"), Delayed]
         int _subdivisions = 1;
 
         protected Material _splineMaterial;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -13,7 +13,7 @@ namespace Crest
     [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Sea Floor Depth Input")]
     [CrestHelpURL("user/ocean-simulation", "sea-floor-depth")]
-    [FilterEnum("_inputMode", FilteredAttribute.Mode.Exclude, (int)InputMode.Painted)]
+    [FilterEnum("_inputMode", FilteredAttribute.Mode.Include, (int)InputMode.CustomGeometryAndShader)]
     public class RegisterSeaFloorDepthInput : RegisterLodDataInput<LodDataMgrSeaFloorDepth>
     {
         /// <summary>
@@ -28,6 +28,8 @@ namespace Crest
         public override bool Enabled => true;
 
         public override InputMode DefaultMode => InputMode.CustomGeometryAndShader;
+
+        [Header("Other Settings")]
 
         public bool _assignOceanDepthMaterial = true;
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -91,9 +91,15 @@ namespace Crest
         bool _debugDrawSlicesInEditor = false;
 #pragma warning restore 414
 
+        [Header("Culling")]
+        [Tooltip("Maximum amount surface will be displaced vertically from sea level. Increase this if gaps appear at bottom of screen."), SerializeField]
+        float _maxVerticalDisplacement = 10f;
+        [Tooltip("Maximum amount a point on the surface will be displaced horizontally by waves from its rest position. Increase this if gaps appear at sides of screen."), SerializeField]
+        float _maxHorizontalDisplacement = 15f;
+
         #region Painting
-        [Header("Paint Mode Settings")]
-        [Predicated("_inputMode", inverted: true, Mode.Painted), DecoratedField]
+        [Heading("Paint Mode Settings")]
+        [Predicated("_inputMode", inverted: true, Mode.Painted, hide: true), DecoratedField]
         public CPUTexture2DPaintable_RG16_AddBlend _paintData;
         void PreparePaintInputMaterial(Material mat)
         {
@@ -120,31 +126,28 @@ namespace Crest
         }
         #endregion
 
-        [Header("Spline Mode Settings")]
-        [SerializeField, Predicated("_inputMode", inverted: true, Mode.Spline), DecoratedField]
+        [Heading("Spline Mode Settings")]
+        [SerializeField, Predicated("_inputMode", inverted: true, Mode.Spline, hide: true), DecoratedField]
         float _featherWaveStart = 0.1f;
-        [SerializeField, Predicated("_inputMode", inverted: true, Mode.Spline), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, Mode.Spline, hide: true), DecoratedField]
         bool _overrideSplineSettings = false;
-        [SerializeField, Predicated("_overrideSplineSettings"), DecoratedField]
+        [SerializeField, Predicated("_inputMode", inverted: true, Mode.Spline, hide: true), Predicated("_overrideSplineSettings"), DecoratedField]
         float _radius = 50f;
-        [SerializeField, Predicated("_overrideSplineSettings"), Delayed]
+        [SerializeField, Predicated("_inputMode", inverted: true, Mode.Spline, hide: true), Predicated("_overrideSplineSettings"), Delayed]
         int _subdivisions = 1;
 
-
-        [Header("Culling")]
-        [Tooltip("Maximum amount surface will be displaced vertically from sea level. Increase this if gaps appear at bottom of screen."), SerializeField]
-        float _maxVerticalDisplacement = 10f;
-        [Tooltip("Maximum amount a point on the surface will be displaced horizontally by waves from its rest position. Increase this if gaps appear at sides of screen."), SerializeField]
-        float _maxHorizontalDisplacement = 15f;
-
-        [Header("Collision Data Baking")]
+        [Heading("Collision Data Baking")]
+        [Predicated("_inputMode", inverted: true, Mode.Global, hide: true), DecoratedField]
         [Tooltip("Enable running this FFT with baked data. This makes the FFT periodic (repeating in time).")]
         public bool _enableBakedCollision = false;
-        [Tooltip("Frames per second of baked data. Larger values may help the collision track the surface closely at the cost of more frames and increase baked data size."), DecoratedField, Predicated("_enableBakedCollision")]
+        [Predicated("_inputMode", inverted: true, Mode.Global, hide: true), Predicated("_enableBakedCollision"), DecoratedField]
+        [Tooltip("Frames per second of baked data. Larger values may help the collision track the surface closely at the cost of more frames and increase baked data size.")]
         public int _timeResolution = 4;
-        [Tooltip("Smallest wavelength required in collision. To preview the effect of this, disable power sliders in spectrum for smaller values than this number. Smaller values require more resolution and increase baked data size."), DecoratedField, Predicated("_enableBakedCollision")]
+        [Predicated("_inputMode", inverted: true, Mode.Global, hide: true), Predicated("_enableBakedCollision"), DecoratedField]
+        [Tooltip("Smallest wavelength required in collision. To preview the effect of this, disable power sliders in spectrum for smaller values than this number. Smaller values require more resolution and increase baked data size.")]
         public float _smallestWavelengthRequired = 2f;
-        [Tooltip("FFT waves will loop with a period of this many seconds. Smaller values decrease data size but can make waves visibly repetitive."), Predicated("_enableBakedCollision"), Range(4f, 128f)]
+        [Predicated("_inputMode", inverted: true, Mode.Global, hide: true), Predicated("_enableBakedCollision"), Range(4f, 128f)]
+        [Tooltip("FFT waves will loop with a period of this many seconds. Smaller values decrease data size but can make waves visibly repetitive.")]
         public float _timeLoopLength = 32f;
 
         internal float LoopPeriod => _enableBakedCollision ? _timeLoopLength : -1f;
@@ -724,6 +727,12 @@ namespace Crest
             }
 
             base.OnInspectorGUI();
+
+            // Only global supports baking.
+            if (target._inputMode != ShapeFFT.Mode.Global)
+            {
+                return;
+            }
 
             bool bakingEnabled = target._enableBakedCollision;
 

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -93,13 +93,13 @@ namespace Crest
         }
 
 
-        [Header("Geometry")]
+        [Heading("Geometry")]
 
-        [SerializeField, Predicated("_mode", inverted: false, Mode.FullScreen), DecoratedField]
+        [SerializeField, Predicated("_mode", inverted: false, Mode.FullScreen, hide: true), DecoratedField]
         [Tooltip("Mesh to use to render the underwater effect.")]
         internal MeshFilter _volumeGeometry;
 
-        [SerializeField, Predicated("_mode", inverted: true, Mode.Portal), DecoratedField]
+        [SerializeField, Predicated("_mode", inverted: false, Mode.FullScreen, hide: true), Predicated("_mode", inverted: true, Mode.Portal), DecoratedField]
         [Tooltip("If enabled, the back faces of the mesh will be used instead of the front faces.")]
         bool _invertCulling = false;
 


### PR DESCRIPTION
Essentially cleans up UI for several components by hiding irrelevant sections per mode. Also includes a few fixes.

- Add hide option to Predicated
- Apply hide option to several components
- Add some extra headings
- Fix SFD input mode filter

I added the optional hide option as the last parameter which saved fixing up a bunch of stuff. Also _Predicated_ now keeps the disabled state so we can have multiple _Predicated_ attributes playing nicely together. Cannot do anything too fancy though.