### PR TITLE
Hide filtered enum unset value

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -81,7 +81,7 @@ namespace Crest
         }
 
         [Header("Mode")]
-        [Filtered]
+        [Filtered((int)InputMode.Unset)]
         public InputMode _inputMode = InputMode.Unset;
 
         public virtual InputMode DefaultMode => InputMode.Painted;


### PR DESCRIPTION
Hides the "unset" value when not needed for filtered enums.