### PR TITLE
Make ocean tiles non-pickable by default

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 namespace Crest
@@ -458,6 +459,13 @@ namespace Crest
                 patch.transform.localPosition = horizScale * new Vector3(pos.x, 0f, pos.y);
                 // scale only horizontally, otherwise culling bounding box will be scaled up in y
                 patch.transform.localScale = new Vector3(horizScale, 1f, horizScale);
+
+#if UNITY_EDITOR
+                if (!ocean._debug._makeOceanTileGameObjectsPickable)
+                {
+                    SceneVisibilityManager.instance.DisablePicking(patch, true);
+                }
+#endif
 
                 {
                     var oceanChunkRenderer = patch.AddComponent<OceanChunkRenderer>();

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -312,6 +312,8 @@ namespace Crest
             public bool _attachDebugGUI = false;
             [Tooltip("Move ocean with viewpoint.")]
             public bool _disableFollowViewpoint = false;
+            [Tooltip("Whether ocean surface tiles are pickable in editor.")]
+            public bool _makeOceanTileGameObjectsPickable = false;
             [Tooltip("Set the ocean surface tiles hidden by default to clean up the hierarchy.")]
             public bool _showOceanTileGameObjects = false;
             [HideInInspector, Tooltip("Whether to generate ocean geometry tiles uniformly (with overlaps).")]
@@ -931,6 +933,7 @@ namespace Crest
             Hashy.AddBool(_debug._forceBatchMode, ref settingsHash);
             Hashy.AddBool(_debug._forceNoGPU, ref settingsHash);
             Hashy.AddBool(_debug._showOceanTileGameObjects, ref settingsHash);
+            Hashy.AddBool(_debug._makeOceanTileGameObjectsPickable, ref settingsHash);
 
 #pragma warning disable 0618
             Hashy.AddObject(_layerName, ref settingsHash);


### PR DESCRIPTION
Issue #1056

Makes ocean tiles non-pickable by default, adds debug option for it.

This will stomp the users preference for pickability. However pickability is almost never desired I guess. And there's a debug option to disable it if need be. LMK what you think.

I initially just intended to respect the pickability state of the ocean gameobject and propagate it to the tiles but it was a non-starter it seems - simply querying pickability of the ocean using `SceneVisibilityManager.instance.IsPickingDisabled(ocean.gameObject)` seems to clear the pickability flag on the ocean when exiting playmode. It's as if the pickability state is left hanging after exiting play mode, and then querying it refreshes it to default (pickable).