### PR TITLE
burst queries and calculating velocities

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
+++ b/crest/Assets/Crest/Crest-Examples/Shared/Scripts/Collision/OceanSampleDisplacementDemo.cs
@@ -2,7 +2,9 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using System;
 using Crest;
+using Unity.Collections;
 using UnityEngine;
 
 /// <summary>
@@ -26,12 +28,21 @@ public class OceanSampleDisplacementDemo : MonoBehaviour
     public float _minGridSize = 0f;
 
     GameObject[] _markerObjects = new GameObject[3];
-    Vector3[] _markerPos = new Vector3[3];
-    Vector3[] _resultDisps = new Vector3[3];
-    Vector3[] _resultNorms = new Vector3[3];
-    Vector3[] _resultVels = new Vector3[3];
+    NativeArray<Vector3> _markerPos;
+    NativeArray<Vector3> _resultDisps;
+    NativeArray<Vector3> _resultNorms;
+    NativeArray<Vector3> _resultVels;
 
     float _samplesRadius = 5f;
+
+    private void Start()
+    {
+        _markerPos = new NativeArray<Vector3>(3, Allocator.Persistent);
+        _resultDisps = new NativeArray<Vector3>(3, Allocator.Persistent);
+        _resultNorms = new NativeArray<Vector3>(3, Allocator.Persistent);
+        _resultVels = new NativeArray<Vector3>(3, Allocator.Persistent);
+
+    }
 
     void Update()
     {
@@ -52,7 +63,7 @@ public class OceanSampleDisplacementDemo : MonoBehaviour
 
         var collProvider = OceanRenderer.Instance.CollisionProvider;
 
-        var status = collProvider.Query(GetHashCode(), _minGridSize, _markerPos, _resultDisps, _resultNorms, _resultVels);
+        var status = collProvider.Query(GetHashCode(), _minGridSize, ref _markerPos, ref _resultDisps, ref _resultNorms, ref _resultVels, true);
 
         if (collProvider.RetrieveSucceeded(status))
         {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProvider.cs
@@ -4,6 +4,7 @@
 
 // NOTE: DWP2 depends on this file. Any API changes need to be communicated to the DWP2 authors in advance.
 
+using Unity.Collections;
 using UnityEngine;
 
 namespace Crest
@@ -22,7 +23,12 @@ namespace Crest
         /// <param name="o_resultHeights">Float array of water heights at the query positions. Pass null if this information is not required.</param>
         /// <param name="o_resultNorms">Water normals at the query positions. Pass null if this information is not required.</param>
         /// <param name="o_resultVels">Water surface velocities at the query positions. Pass null if this information is not required.</param>
-        int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, float[] o_resultHeights, Vector3[] o_resultNorms, Vector3[] o_resultVels);
+        int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<float> o_resultHeights,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels);
 
         /// <summary>
         /// Query water physical data at a set of points. Pass in null to any out parameters that are not required.
@@ -33,7 +39,14 @@ namespace Crest
         /// <param name="o_resultDisps">Displacement vectors for water surface points that will displace to the XZ coordinates of the query points. Water heights are given by sea level plus the y component of the displacement.</param>
         /// <param name="o_resultNorms">Water normals at the query positions. Pass null if this information is not required.</param>
         /// <param name="o_resultVels">Water surface velocities at the query positions. Pass null if this information is not required.</param>
-        int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultDisps, Vector3[] o_resultNorms, Vector3[] o_resultVels);
+        /// <param name="useNormals"></param>
+        int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<Vector3> o_resultDisps,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels,
+            bool useNormals);
 
         /// <summary>
         /// Check if query results could be retrieved successfully using return code from Query() function

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderBakedFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderBakedFFT.cs
@@ -72,7 +72,9 @@ namespace Crest
             /// position data will be created. This will force any running jobs to complete. The jobs will be kicked off in LateUpdate,
             /// so this should be called before the kick-off, such as from Update.
             /// </summary>
-            public int RegisterQueryPoints(int ownerHash, Vector3[] queryPoints, int dataToWriteThisFrame)
+            public int RegisterQueryPoints(int ownerHash,
+                ref NativeArray<Vector3> queryPoints,
+                int dataToWriteThisFrame)
             {
                 var numQuads = (queryPoints.Length + 3) / 4;
 
@@ -222,7 +224,7 @@ namespace Crest
             }
         }
 
-        bool RetrieveHeights(int i_ownerHash, float[] o_resultHeights)
+        bool RetrieveHeights(int i_ownerHash, NativeArray<float> o_resultHeights)
         {
             // Return data - get segment from finished jobs
             if (o_resultHeights != null && _queryDataHeights._segmentRegistryQueriesResults.TryGetValue(i_ownerHash, out var computedQuerySegment))
@@ -238,7 +240,7 @@ namespace Crest
             return false;
         }
 
-        bool RetrieveDisps(int i_ownerHash, Vector3[] o_resultDisps)
+        bool RetrieveDisps(int i_ownerHash, NativeArray<Vector3> o_resultDisps)
         {
             // Return data - get segment from finished jobs
             if (o_resultDisps != null && _queryDataDisps._segmentRegistryQueriesResults.TryGetValue(i_ownerHash, out var computedQuerySegment))
@@ -258,7 +260,7 @@ namespace Crest
             return false;
         }
 
-        bool RetrieveNorms(int i_ownerHash, Vector3[] o_resultNorms)
+        bool RetrieveNorms(int i_ownerHash, NativeArray<Vector3> o_resultNorms)
         {
             if (o_resultNorms != null && _queryDataNorms._segmentRegistryQueriesResults.TryGetValue(i_ownerHash, out var computedQuerySegment))
             {
@@ -277,7 +279,7 @@ namespace Crest
             return false;
         }
 
-        bool RetrieveVels(int i_ownerHash, Vector3[] o_resultVels)
+        bool RetrieveVels(int i_ownerHash, NativeArray<Vector3> o_resultVels)
         {
             if (o_resultVels != null && _queryDataVels._segmentRegistryQueriesResults.TryGetValue(i_ownerHash, out var computedQuerySegment))
             {
@@ -294,14 +296,12 @@ namespace Crest
             return false;
         }
 
-        public int Query(
-            int i_ownerHash,
+        public int Query(int i_ownerHash,
             float i_minSpatialLength,
-            Vector3[] i_queryPoints,
-            float[] o_resultHeights,
-            Vector3[] o_resultNorms,
-            Vector3[] o_resultVels
-            )
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<float> o_resultHeights,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels)
         {
             var dataCopiedOutHeights = RetrieveHeights(i_ownerHash, o_resultHeights);
             var dataCopiedOutNorms = RetrieveNorms(i_ownerHash, o_resultNorms);
@@ -309,15 +309,15 @@ namespace Crest
 
             if (o_resultHeights != null)
             {
-                _queryDataHeights.RegisterQueryPoints(i_ownerHash, i_queryPoints, 1 - _dataBeingUsedByJobs);
+                _queryDataHeights.RegisterQueryPoints(i_ownerHash, ref i_queryPoints, 1 - _dataBeingUsedByJobs);
             }
             if (o_resultNorms != null)
             {
-                _queryDataNorms.RegisterQueryPoints(i_ownerHash, i_queryPoints, 1 - _dataBeingUsedByJobs);
+                _queryDataNorms.RegisterQueryPoints(i_ownerHash, ref i_queryPoints, 1 - _dataBeingUsedByJobs);
             }
             if (o_resultVels != null)
             {
-                _queryDataVels.RegisterQueryPoints(i_ownerHash, i_queryPoints, 1 - _dataBeingUsedByJobs);
+                _queryDataVels.RegisterQueryPoints(i_ownerHash, ref i_queryPoints, 1 - _dataBeingUsedByJobs);
             }
 
             var allCopied = (dataCopiedOutHeights || o_resultHeights == null)
@@ -327,14 +327,13 @@ namespace Crest
             return allCopied ? (int)QueryStatus.Success : (int)QueryStatus.ResultsNotReadyYet;
         }
 
-        public int Query(
-            int i_ownerHash,
+        public int Query(int i_ownerHash,
             float i_minSpatialLength,
-            Vector3[] i_queryPoints,
-            Vector3[] o_resultDisps,
-            Vector3[] o_resultNorms,
-            Vector3[] o_resultVels
-            )
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<Vector3> o_resultDisps,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels,
+            bool useNormals)
         {
             var dataCopiedOutDisps = RetrieveDisps(i_ownerHash, o_resultDisps);
             var dataCopiedOutNorms = RetrieveNorms(i_ownerHash, o_resultNorms);
@@ -342,15 +341,15 @@ namespace Crest
 
             if (o_resultDisps != null)
             {
-                _queryDataDisps.RegisterQueryPoints(i_ownerHash, i_queryPoints, 1 - _dataBeingUsedByJobs);
+                _queryDataDisps.RegisterQueryPoints(i_ownerHash, ref i_queryPoints, 1 - _dataBeingUsedByJobs);
             }
             if (o_resultNorms != null)
             {
-                _queryDataNorms.RegisterQueryPoints(i_ownerHash, i_queryPoints, 1 - _dataBeingUsedByJobs);
+                _queryDataNorms.RegisterQueryPoints(i_ownerHash, ref i_queryPoints, 1 - _dataBeingUsedByJobs);
             }
             if (o_resultVels != null)
             {
-                _queryDataVels.RegisterQueryPoints(i_ownerHash, i_queryPoints, 1 - _dataBeingUsedByJobs);
+                _queryDataVels.RegisterQueryPoints(i_ownerHash, ref i_queryPoints, 1 - _dataBeingUsedByJobs);
             }
 
             var allCopied = (dataCopiedOutDisps || o_resultDisps == null)

--- a/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/CollProviderNull.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Unity.Collections;
 using UnityEngine;
 
 namespace Crest
@@ -11,7 +12,13 @@ namespace Crest
     /// </summary>
     public class CollProviderNull : ICollProvider
     {
-        public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultDisps, Vector3[] o_resultNorms, Vector3[] o_resultVels)
+        public int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<Vector3> o_resultDisps,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels,
+            bool useNormals)
         {
             if (o_resultDisps != null)
             {
@@ -40,7 +47,12 @@ namespace Crest
             return 0;
         }
 
-        public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, float[] o_resultHeights, Vector3[] o_resultNorms, Vector3[] o_resultVels)
+        public int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<float> o_resultHeights,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels)
         {
             if (o_resultHeights != null)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/FlowProvider.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/FlowProvider.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Unity.Collections;
 using UnityEngine;
 
 namespace Crest
@@ -17,8 +18,12 @@ namespace Crest
         /// <param name="i_ownerHash">Unique ID for calling code. Typically acquired by calling GetHashCode().</param>
         /// <param name="i_minSpatialLength">The min spatial length of the object, such as the width of a boat. Useful for filtering out detail when not needed. Set to 0 to get full available detail.</param>
         /// <param name="i_queryPoints">The world space points that will be queried.</param>
+        /// <param name="o_resultFlows"></param>
         /// <param name="o_resultVels">Water surface flow velocities at the query positions.</param>
-        int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows);
+        int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<Vector3> o_resultFlows);
 
         /// <summary>
         /// Check if query results could be retrieved successfully using return code from Query() function

--- a/crest/Assets/Crest/Crest/Scripts/Collision/FlowProviderNull.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/FlowProviderNull.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Unity.Collections;
 using UnityEngine;
 
 namespace Crest
@@ -11,7 +12,10 @@ namespace Crest
     /// </summary>
     public class FlowProviderNull : IFlowProvider
     {
-        public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows)
+        public int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<Vector3> o_resultFlows)
         {
             if (o_resultFlows != null)
             {

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryDisplacements.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Unity.Collections;
 using UnityEngine;
 
 namespace Crest
@@ -28,21 +29,27 @@ namespace Crest
             ShaderProcessQueries.SetBuffer(_kernelHandle, OceanRenderer.sp_cascadeData, OceanRenderer.Instance._bufCascadeDataTgt);
         }
 
-        public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, float[] o_resultHeights, Vector3[] o_resultNorms, Vector3[] o_resultVels)
+        public int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<float> o_resultHeights,
+            ref NativeArray<Vector3> o_resultNorms,
+            ref NativeArray<Vector3> o_resultVels)
         {
             var result = (int)QueryStatus.OK;
+            var useNormals = o_resultNorms.Length > 0;
 
-            if (!UpdateQueryPoints(i_ownerHash, i_minSpatialLength, i_queryPoints, o_resultNorms != null ? i_queryPoints : null))
+            if (!UpdateQueryPoints(i_ownerHash, i_minSpatialLength, i_queryPoints, useNormals ? i_queryPoints : default, useNormals))
             {
                 result |= (int)QueryStatus.PostFailed;
             }
 
-            if (!RetrieveResults(i_ownerHash, null, o_resultHeights, o_resultNorms))
+            if (!RetrieveResults(i_ownerHash, default, o_resultHeights, o_resultNorms))
             {
                 result |= (int)QueryStatus.RetrieveFailed;
             }
 
-            if (o_resultVels != null)
+            if (o_resultVels.Length > 0)
             {
                 result |= CalculateVelocities(i_ownerHash, o_resultVels);
             }

--- a/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/QueryFlow.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Unity.Collections;
 using UnityEngine;
 
 namespace Crest
@@ -23,9 +24,15 @@ namespace Crest
             ShaderProcessQueries.SetBuffer(_kernelHandle, sp_ResultFlows, resultsBuffer);
         }
 
-        public int Query(int i_ownerHash, float i_minSpatialLength, Vector3[] i_queryPoints, Vector3[] o_resultFlows)
+        public int Query(int i_ownerHash,
+            float i_minSpatialLength,
+            ref NativeArray<Vector3> i_queryPoints,
+            ref NativeArray<Vector3> o_resultFlows)
         {
-            return Query(i_ownerHash, i_minSpatialLength, i_queryPoints, o_resultFlows, null, null);
+            var norms = default(NativeArray<Vector3>);
+            var vels = default(NativeArray<Vector3>);
+
+            return Query(i_ownerHash, i_minSpatialLength, ref i_queryPoints, ref o_resultFlows, ref norms, ref vels, false);
         }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Crest.asmdef
@@ -5,11 +5,12 @@
         "Unity.Postprocessing.Runtime",
         "Unity.InputSystem",
         "Unity.Mathematics",
-        "Unity.Burst"
+        "Unity.Burst",
+        "Unity.Collections"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false,
+    "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,

--- a/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/BoatProbes.cs
@@ -5,6 +5,7 @@
 // Shout out to @holdingjason who posted a first version of this script here: https://github.com/huwb/crest-oceanrender/pull/100
 
 using System;
+using Unity.Collections;
 using UnityEngine;
 #if ENABLE_INPUT_SYSTEM
 using UnityEngine.InputSystem;
@@ -83,9 +84,9 @@ namespace Crest
 
         float _totalWeight;
 
-        Vector3[] _queryPoints;
-        Vector3[] _queryResultDisps;
-        Vector3[] _queryResultVels;
+        NativeArray<Vector3> _queryPoints;
+        NativeArray<Vector3> _queryResultDisps;
+        NativeArray<Vector3> _queryResultVels;
 
         SampleFlowHelper _sampleFlowHelper = new SampleFlowHelper();
 
@@ -102,9 +103,9 @@ namespace Crest
 
             CalcTotalWeight();
 
-            _queryPoints = new Vector3[_forcePoints.Length + 1];
-            _queryResultDisps = new Vector3[_forcePoints.Length + 1];
-            _queryResultVels = new Vector3[_forcePoints.Length + 1];
+            _queryPoints = new NativeArray<Vector3>(_forcePoints.Length + 1, Allocator.Persistent);
+            _queryResultDisps = new NativeArray<Vector3>(_forcePoints.Length + 1, Allocator.Persistent);
+            _queryResultVels = new NativeArray<Vector3>(_forcePoints.Length + 1, Allocator.Persistent);
         }
 
         void CalcTotalWeight()
@@ -165,7 +166,8 @@ namespace Crest
             }
             _queryPoints[_forcePoints.Length] = transform.position;
 
-            collProvider.Query(GetHashCode(), ObjectWidth, _queryPoints, _queryResultDisps, null, _queryResultVels);
+            var oResultNorms = new NativeArray<Vector3>();
+            collProvider.Query(GetHashCode(), ObjectWidth, ref _queryPoints, ref _queryResultDisps, ref oResultNorms, ref _queryResultVels, false);
 
             if (_debug._drawQueries)
             {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -223,12 +223,13 @@ namespace Crest
             var drawList = RegisterLodDataInputBase.GetRegistrar(GetType());
             foreach (var draw in drawList)
             {
-                if (!draw.Value.Enabled)
+                var value = draw.Value;
+                if (!value.Enabled)
                 {
                     continue;
                 }
 
-                draw.Value.Draw(this, buf, 1f, 0, lodIdx);
+                value.Draw(this, buf, 1f, 0, lodIdx);
             }
         }
 

--- a/crest/Packages/manifest.json
+++ b/crest/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
     "com.unity.burst": "1.6.5",
+	"com.unity.collections": "1.3.1",
     "com.unity.ide.rider": "3.0.14",
     "com.unity.ide.visualstudio": "2.0.15",
     "com.unity.ide.vscode": "1.2.5",


### PR DESCRIPTION
And, move many things to NativeCollections for that purpose. 

In our game, in areas with several water objects, this change made Query() calls disappear from the profiler, where before they had taken 2-5ms/frame. 

This only bursts the things that showed up for our particular usage, but the changes here likely enable bursting many more things for other use cases. 