### PR TITLE
Fix spurious error during build process

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -91,7 +91,14 @@ namespace Crest
                     }
                     else
                     {
-                        Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
+#if UNITY_EDITOR
+                        // If running a build, do not assert any requirements at all. Requirements are for the runtime,
+                        // not for making builds.
+                        if (!BuildPipeline.isBuildingPlayer)
+#endif
+                        {
+                            Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
+                        }
                     }
                     break;
 #if CREST_UNITY_MATHEMATICS

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,7 @@ Fixed
    -  Limit minimum phase period of flow technique applied to waves to fix objectionable phasing issues in flowing water like rivers.
    -  Fixed some components breaking in edit mode after entering/exiting prefab mode.
    -  Fixed *Build Processor* deprecated/obsolete warnings.
+   -  Fixed spurious "headless/batch mode" error during builds.
 
 
 4.15.2


### PR DESCRIPTION
We were checking platform requirements during a build which we should not do.