### PR TITLE
Improve spline editor performance

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
@@ -47,7 +47,13 @@ namespace Crest.Spline
 
         void OnDrawGizmosSelected()
         {
-            if (transform.parent.TryGetComponent(out IReceiveSplinePointOnDrawGizmosSelectedMessages receiver))
+            // Reduces spam. May have edge cases where spline will not update but that is fine for now.
+            if (gameObject != Selection.activeGameObject)
+            {
+                return;
+            }
+
+            foreach (var receiver in transform.parent.GetComponents<IReceiveSplinePointOnDrawGizmosSelectedMessages>())
             {
                 receiver.OnSplinePointDrawGizmosSelected(this);
             }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -35,6 +35,7 @@ Fixed
    -  Fixed some components breaking in edit mode after entering/exiting prefab mode.
    -  Fixed *Build Processor* deprecated/obsolete warnings.
    -  Fixed spurious "headless/batch mode" error during builds.
+   -  Greatly improve spline performance in the editor.
 
 
 4.15.2


### PR DESCRIPTION
It was reported that splines had serious scalability issues in the editor.

No longer generate the spline mesh for each frame when it is not selected. And reduce spline mesh generation and draw spline gizmo calls significantly.