### PR TITLE
Fix PSSL compiler errors

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Texture.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/ShaderLibrary/Texture.hlsl
@@ -2,6 +2,13 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+// The const keyword for PSSL solves the following:
+// > Shader error in '<Shader>': Program '<Program>', member function '<FunctionName>' not viable: 'this' argument has
+// > type '<Type> const', but function is not marked const
+// This appears to be PSSL only feature as the fix throws a compiler error elsewhere (comprehensive test not done). I
+// tried putting const at the beginning of the function signature which compiles but did not solve the problem on PSSL
+// so must be different.
+
 #ifndef CREST_TEXTURE_INCLUDED
 #define CREST_TEXTURE_INCLUDED
 
@@ -39,23 +46,35 @@ namespace WaveHarmonic
 			}
 
 			half4 Sample(float2 uv)
+#ifdef SHADER_API_PSSL
+	const
+#endif
 			{
 				return _texture.Sample(_sampler, uv);
 			}
 
 			half4 SampleLevel(float2 uv, float lod)
+#ifdef SHADER_API_PSSL
+	const
+#endif
 			{
 				return _texture.SampleLevel(_sampler, uv, lod);
 			}
 
 #if CREST_FLOATING_ORIGIN
 			float2 FloatingOriginOffset()
+#ifdef SHADER_API_PSSL
+	const
+#endif
 			{
 				// Safely assumes a square texture.
 				return _CrestFloatingOriginOffset.xz % (_scale * _size * _texel);
 			}
 
 			float2 FloatingOriginOffset(const CascadeParams i_cascadeData)
+#ifdef SHADER_API_PSSL
+	const
+#endif
 			{
 				// Safely assumes a square texture.
 				return _CrestFloatingOriginOffset.xz % (_scale * _size * i_cascadeData._texelWidth);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,7 @@ Fixed
    -  Fixed *Build Processor* deprecated/obsolete warnings.
    -  Fixed spurious "headless/batch mode" error during builds.
    -  Greatly improve spline performance in the editor.
+   -  Fixed PSSL compiler errors.
 
 
 4.15.2


### PR DESCRIPTION
PSSL has const correctness for functions. Fixes the following:

> Shader error in 'Crest/Ocean': Program 'Frag', member function 'Sample' not viable: 'this' argument has type 'WaveHarmonic::Crest::TiledTexture const', but function is not marked const at Crest/Crest/Shaders/OceanEmission.hlsl(129) (on ps5_cggc)

This appears to be PSSL only feature as the fix throws a compiler error elsewhere (comprehensive test not done). I tried putting const at the beginning of the function signature instead of the end which compiles but did not solve the problem on PSSL so must be different purpose.