### PR TITLE
Make ocean not pickable

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -452,6 +452,8 @@ namespace Crest
             {
                 // instantiate and place patch
                 var patch = new GameObject($"Tile_L{lodIndex}_{patchTypes[i]}");
+                // Also applying the hide flags to the chunk will prevent it from being pickable in the editor.
+                patch.hideFlags = ocean._hideOceanTileGameObjects ? HideFlags.HideAndDontSave : HideFlags.DontSave;
                 patch.layer = oceanLayer;
                 patch.transform.parent = parent;
                 Vector2 pos = offsets[i];

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -35,6 +35,7 @@ Fixed
    -  Fixed spurious "headless/batch mode" error during builds.
    -  Greatly improve spline performance in the editor.
    -  Fixed PSSL compiler errors.
+   -  Fixed ocean tiles being pickable in the editor.
 
 
 4.15.2


### PR DESCRIPTION
Fixes: #1056
Replaces: #1058 and #735

Makes the ocean tiles not pickable in the scene view. Rarely do developers need to pick the ocean from the scene view so there is no specific override, but will be disabled when ocean tiles are made visible through the appropriate debug option.

Unlike previous attempts, this uses the *HideAndDontSave* flag rather than the pickability API which has no downsides.