### PR TITLE
Remove viewpoint validation

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -606,8 +606,6 @@ namespace Crest
 
             _commandbufferBuilder = new BuildCommandBuffer();
 
-            ValidateViewpoint();
-
             if (_attachDebugGUI && GetComponent<OceanDebugGUI>() == null)
             {
                 gameObject.AddComponent<OceanDebugGUI>().hideFlags = HideFlags.DontSave;
@@ -897,14 +895,6 @@ namespace Crest
             return true;
         }
 
-        void ValidateViewpoint()
-        {
-            if (Viewpoint == null)
-            {
-                Debug.LogError("Crest: Crest needs to know where to focus the ocean detail. Please set the <i>ViewCamera</i> or the <i>Viewpoint</i> property that will render the ocean, or tag the primary camera as <i>MainCamera</i>.", this);
-            }
-        }
-
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void InitStatics()
         {
@@ -983,8 +973,6 @@ namespace Crest
             var needToBlendOutShape = ScaleCouldIncrease;
             var meshScaleLerp = needToBlendOutShape ? ViewerAltitudeLevelAlpha : 0f;
             Shader.SetGlobalFloat(sp_meshScaleLerp, meshScaleLerp);
-
-            ValidateViewpoint();
 
             if (_followViewpoint && Viewpoint != null)
             {

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -23,6 +23,7 @@ Changed
       It's useful for preventing rivers and lakes from receiving ocean waves.
    -  Warn users that edits in prefab mode will not be reflected in scene view until prefab is saved.
    -  Validate that no scale can be applied to the *OceanRenderer*.
+   -  Viewpoint validation has been removed as it was unnecessary and spammed the logs.
 
 
 Fixed


### PR DESCRIPTION
It is unnecessary as not having a viewpoint is harmless and valid in cases where the camera is created with a script. In those cases it would spam the logs which was a nuisance. We always use the main fallback so user intervention is not required.