### PR TITLE
Fix executing when building

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Examples/Scripts/CustomPassForCamera.cs
+++ b/crest/Assets/Crest/Crest-Examples/Examples/Scripts/CustomPassForCamera.cs
@@ -9,7 +9,6 @@ namespace Crest.Examples
     using UnityEngine.Events;
     using UnityEngine.Rendering;
 
-    [ExecuteAlways]
     public abstract class CustomPassForCameraBase : MonoBehaviour
     {
         // Use int to support other RPs. We could use a custom enum to map to each RP in the future.
@@ -92,6 +91,13 @@ namespace Crest.Examples
 
         protected abstract void Execute(CommandBuffer buffer, Camera camera, RenderTextureDescriptor descriptor);
         protected abstract void Clear(CommandBuffer buffer, Camera camera);
+
+#if UNITY_EDITOR
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+#endif
     }
 
     public class CustomPassForCamera : CustomPassForCameraBase

--- a/crest/Assets/Crest/Crest-Examples/Examples/Scripts/MaskFill.cs
+++ b/crest/Assets/Crest/Crest-Examples/Examples/Scripts/MaskFill.cs
@@ -10,7 +10,6 @@ namespace Crest.Examples
     using UnityEngine;
     using UnityEngine.Rendering;
 
-    [ExecuteAlways]
     public class MaskFill : MonoBehaviour
     {
         [SerializeField]
@@ -97,6 +96,13 @@ namespace Crest.Examples
 
             buffer.DisableShaderKeyword("_SHADOW_PASS");
         }
+
+#if UNITY_EDITOR
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+#endif
     }
 }
 

--- a/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Collision/VisualiseCollisionArea.cs
@@ -10,7 +10,6 @@ namespace Crest
     /// Debug draw crosses in an area around the GameObject on the water surface.
     /// </summary>
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_DEBUG + "Visualise Collision Area")]
-    [ExecuteAlways]
     public class VisualiseCollisionArea : MonoBehaviour
     {
         /// <summary>
@@ -42,6 +41,14 @@ namespace Crest
         Vector3[] _resultNorms;
 
         Vector3[] _samplePositions;
+
+#if UNITY_EDITOR
+        void OnValidate()
+        {
+            // Using this instead of ExecuteAlways prevents execution during builds.
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+#endif
 
         void Update()
         {

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/OceanDebugGUI.cs
@@ -11,7 +11,6 @@ using UnityEngine.SceneManagement;
 
 namespace Crest
 {
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_DEBUG + "Ocean Debug GUI")]
     public class OceanDebugGUI : MonoBehaviour
     {
@@ -462,5 +461,12 @@ namespace Crest
             // Init here from 2019.3 onwards
             s_simNames.Clear();
         }
+
+#if UNITY_EDTIOR
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+#endif
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/OceanDepthCache.cs
@@ -15,7 +15,6 @@ namespace Crest
     /// Renders terrain height / ocean depth once into a render target to cache this off and avoid rendering it every frame.
     /// This should be used for static geometry, dynamic objects should be tagged with the Render Ocean Depth component.
     /// </summary>
-    [ExecuteAlways]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "shallows-and-shorelines.html" + Internal.Constants.HELP_URL_RP)]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Depth Cache")]
     public partial class OceanDepthCache : MonoBehaviour
@@ -444,6 +443,11 @@ namespace Crest
 
     public partial class OceanDepthCache : IValidated
     {
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         bool IsCacheOutdated()
         {
             return _camDepthCache.orthographicSize != CalculateCacheCameraOrthographicSize() ||

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAlbedoInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input to the albedo data. Attach this GameObjects that you want to influence the surface colour.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Albedo Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#albedo")]
     public class RegisterAlbedoInput : RegisterLodDataInput<LodDataMgrAlbedo>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input to the wave shape. Attach this GameObjects that you want to render into the displacmeent textures to affect ocean shape.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Animated Waves Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves")]
     public class RegisterAnimWavesInput : RegisterLodDataInputWithSplineSupport<LodDataMgrAnimWaves>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterDynWavesInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input to the dynamic wave simulation. Attach this GameObjects that you want to influence the sim to add ripples etc.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Dynamic Waves Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#dynamic-waves")]
     public class RegisterDynWavesInput : RegisterLodDataInput<LodDataMgrDynWaves>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input to the flow data. Attach this GameObjects that you want to influence the horizontal flow of the water volume.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Flow Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#flow")]
     public class RegisterFlowInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFlow, SplinePointDataFlow>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input to the foam simulation. Attach this GameObjects that you want to influence the foam simulation, such as depositing foam on the surface.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Foam Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#foam")]
     public class RegisterFoamInput : RegisterLodDataInputWithSplineSupport<LodDataMgrFoam, SplinePointDataFoam>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input to affect the water height.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Height Input")]
     public partial class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrSeaFloorDepth>
     {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -53,7 +53,6 @@ namespace Crest
     /// <summary>
     /// Base class for scripts that register input to the various LOD data types.
     /// </summary>
-    [ExecuteAlways]
     public abstract partial class RegisterLodDataInputBase : MonoBehaviour, ILodDataInput
     {
 #if UNITY_EDITOR
@@ -197,7 +196,6 @@ namespace Crest
     /// <summary>
     /// Registers input to a particular LOD data.
     /// </summary>
-    [ExecuteAlways]
     public abstract class RegisterLodDataInput<LodDataType> : RegisterLodDataInputBase
         where LodDataType : LodDataMgr
     {
@@ -307,7 +305,6 @@ namespace Crest
     {
     }
 
-    [ExecuteAlways]
     public abstract partial class RegisterLodDataInputWithSplineSupport<LodDataType, SplinePointCustomData>
         : RegisterLodDataInput<LodDataType>
         , ISplinePointCustomDataSetup
@@ -438,6 +435,11 @@ namespace Crest
 
         protected virtual string MaterialFeatureDisabledError => null;
         protected virtual string MaterialFeatureDisabledFix => null;
+
+        protected virtual void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
 
         public virtual bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -10,7 +10,6 @@ namespace Crest
     /// Tags this object as an ocean depth provider. Renders depth every frame and should only be used for dynamic objects.
     /// For static objects, use an Ocean Depth Cache.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Sea Floor Depth Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#sea-floor-depth")]
     public class RegisterSeaFloorDepthInput : RegisterLodDataInput<LodDataMgrSeaFloorDepth>

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Settings/SimSettingsAnimatedWaves.cs
@@ -91,14 +91,7 @@ namespace Crest
                     }
                     else
                     {
-#if UNITY_EDITOR
-                        // If running a build, do not assert any requirements at all. Requirements are for the runtime,
-                        // not for making builds.
-                        if (!BuildPipeline.isBuildingPlayer)
-#endif
-                        {
-                            Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
-                        }
+                        Debug.LogError("Crest: Compute shader queries not supported in headless/batch mode. To resolve, assign an Animated Wave Settings asset to the OceanRenderer component and set the Collision Source to be a CPU option.");
                     }
                     break;
 #if CREST_UNITY_MATHEMATICS

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/RegisterShadowInput.cs
@@ -9,7 +9,6 @@ namespace Crest
     /// <summary>
     /// Registers a custom input for shadow data. Attach this to GameObjects that you want use to override shadows.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(MENU_PREFIX + "Shadow Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#shadows")]
     public class RegisterShadowInput : RegisterLodDataInput<LodDataMgrShadow>

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -14,7 +14,6 @@ namespace Crest
     /// <summary>
     /// Sets shader parameters for each geometry tile/chunk.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_INTERNAL + "Ocean Chunk Renderer")]
     public class OceanChunkRenderer : MonoBehaviour
     {
@@ -200,6 +199,12 @@ namespace Crest
             RenderPipelineManager.beginCameraRendering += BeginCameraRendering;
         }
 
+#if UNITY_EDITOR
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         private void OnDrawGizmos()
         {
             if (_drawRenderBounds)
@@ -207,6 +212,7 @@ namespace Crest
                 Rend.bounds.GizmosDraw();
             }
         }
+#endif
     }
 
     public static class BoundsHelper

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -26,7 +26,7 @@ namespace Crest
     /// The main script for the ocean system. Attach this to a GameObject to create an ocean. This script initializes the various data types and systems
     /// and moves/scales the ocean based on the viewpoint. It also hosts a number of global settings that can be tweaked here.
     /// </summary>
-    [ExecuteAlways, SelectionBase]
+    [SelectionBase]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Ocean Renderer")]
     [HelpURL(Constants.HELP_URL_GENERAL)]
     public partial class OceanRenderer : MonoBehaviour
@@ -850,15 +850,6 @@ namespace Crest
 
         bool VerifyRequirements()
         {
-#if UNITY_EDITOR
-            // If running a build, don't assert any requirements at all. Requirements are for
-            // the runtime, not for making builds.
-            if (BuildPipeline.isBuildingPlayer)
-            {
-                return true;
-            }
-#endif
-
             if (!RunningWithoutGPU)
             {
                 if (Application.platform == RuntimePlatform.WebGLPlayer)
@@ -1841,6 +1832,9 @@ namespace Crest
 
         void OnValidate()
         {
+            // Using this instead of ExecuteAlways prevents execution during builds.
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+
             // Must be at least 0.25, and must be on a power of 2
             _minScale = Mathf.Pow(2f, Mathf.Round(Mathf.Log(Mathf.Max(_minScale, 0.25f), 2f)));
 

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -20,7 +20,6 @@ namespace Crest
     /// <summary>
     /// FFT ocean wave shape
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape FFT")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP)]
     public partial class ShapeFFT : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
@@ -509,6 +508,8 @@ namespace Crest
 #if UNITY_EDITOR
         private void OnValidate()
         {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+
             _resolution = Mathf.ClosestPowerOfTwo(_resolution);
             _resolution = Mathf.Max(_resolution, 16);
         }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -22,7 +22,6 @@ namespace Crest
     /// <summary>
     /// Gerstner ocean waves.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP)]
     public partial class ShapeGerstner : MonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
@@ -915,6 +914,11 @@ namespace Crest
 #if UNITY_EDITOR
     public partial class ShapeGerstner : IValidated
     {
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             var isValid = true;

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -16,7 +16,6 @@ namespace Crest
     /// Support script for Gerstner wave ocean shapes.
     /// Generates a number of batches of Gerstner waves.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Shape Gerstner Batched")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP)]
     public partial class ShapeGerstnerBatched : MonoBehaviour, ICollProvider, IFloatingOrigin
@@ -873,6 +872,11 @@ namespace Crest
 
     public partial class ShapeGerstnerBatched : IValidated
     {
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             var isValid = true;

--- a/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/Spline.cs
@@ -15,7 +15,6 @@ namespace Crest.Spline
     /// <summary>
     /// Simple spline object. Spline points are child GameObjects.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SPLINE + "Spline")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "wave-conditions.html" + Internal.Constants.HELP_URL_RP + "#wave-splines")]
     public partial class Spline : MonoBehaviour, ISplinePointCustomDataSetup
@@ -87,6 +86,11 @@ namespace Crest.Spline
 #if UNITY_EDITOR
     public partial class Spline : IValidated
     {
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         public void OnDrawGizmos()
         {
             var points = GetComponentsInChildren<SplinePoint>();

--- a/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Spline/SplinePoint.cs
@@ -15,7 +15,6 @@ namespace Crest.Spline
     /// <summary>
     /// Spline point, intended to be child of Spline object
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SPLINE + "Spline Point")]
     public class SplinePoint : MonoBehaviour
     {
@@ -29,6 +28,11 @@ namespace Crest.Spline
 #pragma warning restore 414
 
 #if UNITY_EDITOR
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         void OnDrawGizmos()
         {
             // We could not get gizmos or handles to work well when 3D Icons is enabled. problems included

--- a/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Time/TimeProviderCutscene.cs
@@ -11,7 +11,6 @@ namespace Crest
     /// <summary>
     /// This time provider feeds a Timeline time to the ocean system, using a Playable Director
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Cutscene Time Provider")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "time-providers.html" + Internal.Constants.HELP_URL_RP + "#timelines-and-cutscenes")]
     public class TimeProviderCutscene : TimeProviderBase
@@ -100,6 +99,11 @@ namespace Crest
             {
                 Initialise(false);
             }
+        }
+
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
         }
 #endif
 

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -24,7 +24,6 @@ namespace Crest
     ///
     /// For convenience, all shader material settings are copied from the main ocean shader.
     /// </summary>
-    [ExecuteAlways]
     [RequireComponent(typeof(Camera))]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Underwater Renderer")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "underwater.html" + Internal.Constants.HELP_URL_RP)]
@@ -391,6 +390,11 @@ namespace Crest
     // Edit Mode.
     public partial class UnderwaterRenderer
     {
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         void EnableEditMode()
         {
             Camera.onPreRender -= OnBeforeRender;

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -15,7 +15,6 @@ namespace Crest
     /// Demarcates an AABB area where water is present in the world. If present, ocean tiles will be
     /// culled if they don't overlap any WaterBody.
     /// </summary>
-    [ExecuteAlways]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Water Body")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "water-bodies.html")]
     public partial class WaterBody : MonoBehaviour
@@ -196,6 +195,11 @@ namespace Crest
 #if UNITY_EDITOR
     public partial class WaterBody : IValidated
     {
+        void OnValidate()
+        {
+            runInEditMode = !UnityEditor.BuildPipeline.isBuildingPlayer;
+        }
+
         public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
         {
             var isValid = true;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -41,6 +41,7 @@ Fixed
    -  Fixed ocean tiles being pickable in the editor.
    -  Fixed several memory leaks.
    -  Fixed *Sea Floor Depth Data* disabled state as it was still attenuating waves when disabled.
+   -  No longer execute when building which caused several issues.
 
 
 4.15.2


### PR DESCRIPTION
ExecuteAlways will also have scripts execute when building. This causes many issues. Executing when building is a side effect and there is no need for us to do so.