### PR TITLE
Add Water Tile Prefab field to Ocean Renderer

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -48,6 +48,18 @@ namespace Crest
             ClearStencil,
         }
 
+        /// <summary>
+        /// Uses PrefabUtility.InstantiatePrefab in editor and GameObject.Instantiate in standalone.
+        /// </summary>
+        public static GameObject InstantiatePrefab(GameObject prefab)
+        {
+#if UNITY_EDITOR
+            return (GameObject)UnityEditor.PrefabUtility.InstantiatePrefab(prefab);
+#else
+            return GameObject.Instantiate(prefab);
+#endif
+        }
+
 #if UNITY_EDITOR
         public static bool IsPreviewOfGameCamera(Camera camera)
         {

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -168,6 +168,9 @@ namespace Crest
         internal Material _material = null;
         public Material OceanMaterial { get => _material; set => _material = value; }
 
+        [Tooltip("Use prefab for water tiles. The only requirements are that the prefab must contain a MeshRenderer at the root and not a MeshFilter or OceanChunkRenderer. MR values will be overwritten where necessary and the prefabs are linked in edit mode.")]
+        public GameObject _waterTilePrefab;
+
         [System.Obsolete("Use the _layer field instead."), HideInInspector, SerializeField]
         string _layerName = "";
         [System.Obsolete("Use the Layer property instead.")]
@@ -885,6 +888,7 @@ namespace Crest
             Hashy.AddBool(_forceBatchMode, ref settingsHash);
             Hashy.AddBool(_forceNoGPU, ref settingsHash);
             Hashy.AddBool(_hideOceanTileGameObjects, ref settingsHash);
+            Hashy.AddObject(_waterTilePrefab, ref settingsHash);
 
 #pragma warning disable 0618
             Hashy.AddObject(_layerName, ref settingsHash);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -21,6 +21,7 @@ Changed
    -  Added ability to alpha blend waves (effectively an override) instead of only having additive blend waves.
       Set *Blend Mode* to *Alpha Blend* on the *ShapeFFT* or *ShapeGerstner* to use.
       It's useful for preventing rivers and lakes from receiving ocean waves.
+   -  Added *Water Tile Prefab* field to *Ocean Renderer* to provide more control over water tile mesh renderers like reflection probes settings.
    -  Warn users that edits in prefab mode will not be reflected in scene view until prefab is saved.
    -  Validate that no scale can be applied to the *OceanRenderer*.
    -  Viewpoint validation has been removed as it was unnecessary and spammed the logs.


### PR DESCRIPTION
Gives control over various Mesh Renderer properties. We could add more fields to the Ocean Renderer for each property but other RPs (like HDRP) have a growing number of properties across versions.