### PR TITLE
Validate Renderer Layer to prevent potential build failures

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Main/Scenes/Internal/MainSceneCore.prefab
+++ b/crest/Assets/Crest/Crest-Examples/Main/Scenes/Internal/MainSceneCore.prefab
@@ -278,7 +278,7 @@ GameObject:
   - component: {fileID: 1367125207235463481}
   - component: {fileID: 1132221723987805653}
   - component: {fileID: 1976205943932006336}
-  m_Layer: 0
+  m_Layer: 4
   m_Name: CrestLogo
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/RenderAlphaOnSurface.cs
@@ -14,7 +14,7 @@ namespace Crest
     [RequireComponent(typeof(Renderer))]
     [RequireComponent(typeof(MeshFilter))]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_SCRIPTS + "Render Alpha On Surface")]
-    public class RenderAlphaOnSurface : CustomMonoBehaviour
+    public partial class RenderAlphaOnSurface : CustomMonoBehaviour
     {
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
@@ -91,4 +91,15 @@ namespace Crest
             }
         }
     }
+
+#if UNITY_EDITOR
+    public partial class RenderAlphaOnSurface : IValidated
+    {
+        public bool Validate(OceanRenderer ocean, ValidatedHelper.ShowMessage showMessage)
+        {
+            ValidatedHelper.ValidateRendererLayer(gameObject, showMessage, ocean);
+            return true;
+        }
+    }
+#endif
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/UnderwaterEffect.cs
@@ -304,6 +304,8 @@ namespace Crest
                 isValid = false;
             }
 
+            ValidatedHelper.ValidateRendererLayer(gameObject, showMessage, ocean);
+
             // Check that underwater effect has correct material assigned.
             var shaderPrefix = "Crest/Underwater";
             var renderer = GetComponent<Renderer>();

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -155,6 +155,27 @@ namespace Crest
             return true;
         }
 
+        public static bool ValidateRendererLayer(GameObject gameObject, ShowMessage showMessage, OceanRenderer ocean)
+        {
+            if (ocean != null && gameObject.layer != ocean.Layer)
+            {
+                var layerName = LayerMask.LayerToName(ocean.Layer);
+                showMessage
+                (
+                    $"The layer is not the same as the <i>OceanRenderer.Layer ({layerName})</i> which can cause problems if the <i>{layerName}</i> layer is excluded from any culling masks.",
+                    $"Set layer to <i>{layerName}</i>.",
+                    MessageType.Warning, gameObject, x =>
+                    {
+                        Undo.RecordObject(gameObject, $"Change Layer to {layerName}");
+                        gameObject.layer = ocean.Layer;
+                    }
+                );
+            }
+
+            // Is valid as not outright invalid but could be.
+            return true;
+        }
+
         public static bool ValidateRenderer<T>(GameObject gameObject, ShowMessage showMessage, string shaderPrefix) where T : Renderer
         {
             return ValidateRenderer<T>(gameObject, showMessage, isRendererRequired: true, isRendererOptional: false, shaderPrefix);

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -892,6 +892,11 @@ namespace Crest
                 );
             }
 
+            if (_mode == GerstnerMode.Geometry)
+            {
+                ValidatedHelper.ValidateRendererLayer(gameObject, showMessage, ocean);
+            }
+
             if (_mode == GerstnerMode.Global && GetComponent<MeshRenderer>() != null)
             {
                 showMessage

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -30,6 +30,7 @@ Changed
    -  *Render Alpha On Surface* now executes in edit mode.
    -  Only report no Shape component validation as help boxes (ie no more console logs).
    -  Remove outdated lighting validation.
+   -  Validate layers to warn users of potential build failures if *Crest* related renderers are not on the same layer as the *OceanRenderer.Layer*.
 
 
 Fixed

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -51,6 +51,7 @@ Fixed
    -  No longer execute when building which caused several issues.
    -  Fixed self-intersecting polygon (and warning) on Ferry model.
    -  Fixed *Examples* scene UI not scaling and thus looking incorrect for non 4K resolution.
+   -  Fixed build failure for *main* scene if reflection probe is added that excluded the *Water* layer.
 
 
 4.15.2


### PR DESCRIPTION
Validate the layer if a renderer is present because if the _Water_ layer is excluded from any culling masks, then these may still execute without the _Ocean Renderer_ and thus without buffers being bound. This will cause a build failure and the error message is not helpful.

There is probably a proper fix other than validation but these renderers should really be on the same layer anyway.