### PR TITLE
Search Resources and Addressables when stripping underwater shader keywords

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Editor/Crest.Editor.asmdef
+++ b/crest/Assets/Crest/Crest/Scripts/Editor/Crest.Editor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "",
     "references": [
         "GUID:5b35af79ebbe89647a157055d52c59d3",
-        "GUID:d8b63aba1907145bea998dd612889d6b"
+        "GUID:d8b63aba1907145bea998dd612889d6b",
+        "GUID:69448af7b92c7f342b298e06a37122aa"
     ],
     "includePlatforms": [
         "Editor"
@@ -19,6 +20,11 @@
             "name": "com.unity.mathematics",
             "expression": "1.0.0",
             "define": "CREST_UNITY_MATHEMATICS"
+        },
+        {
+            "name": "com.unity.addressables",
+            "expression": "1.0.0",
+            "define": "CREST_UNITY_ADDRESSABLES"
         }
     ],
     "noEngineReferences": false

--- a/crest/Packages/manifest.json
+++ b/crest/Packages/manifest.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.2d.tilemap": "1.0.0",
+    "com.unity.addressables": "1.18.19",
     "com.unity.burst": "1.6.6",
     "com.unity.ide.rider": "3.0.16",
     "com.unity.ide.visualstudio": "2.0.16",

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -34,6 +34,7 @@ Changed
    -  No longer log info level validation to the console.
    -  Add info validation for tips on using reflection probes when found in a scene.
    -  Set *Ocean Renderer* *Wind Speed* default value to the maxmimum to reduce UX friction for new users.
+   -  Also search *Addressables* and *Resources* for ocean materials when stripping keywords from underwater shader.
 
 
 Fixed


### PR DESCRIPTION
If a user had ocean materials in either _Resources_ or _Addressables_, they would not be evaluated when stripping keywords from the underwater shader.

The stripping system is still not perfect and probably never will be. An alternative will need to be explored.

Thanks to Kospy for reporting and providing a solution for _Addressables_.