### PR TITLE
Fix caustics not rendering in XR SPI when shadow simulation is disabled

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/TextureArrayHelpers.cs
@@ -66,17 +66,17 @@ namespace Crest
             return texture;
         }
 
-        public static Texture2DArray CreateTexture2DArray(Texture2D texture)
+        public static Texture2DArray CreateTexture2DArray(Texture2D texture, int depth)
         {
             var array = new Texture2DArray(
                 SMALL_TEXTURE_DIM, SMALL_TEXTURE_DIM,
-                LodDataMgr.MAX_LOD_COUNT,
+                depth,
                 texture.format,
                 false,
                 false
             );
 
-            for (int textureArrayIndex = 0; textureArrayIndex < LodDataMgr.MAX_LOD_COUNT; textureArrayIndex++)
+            for (var textureArrayIndex = 0; textureArrayIndex < array.depth; textureArrayIndex++)
             {
                 // There is a bug using Graphics.CopyTexture with Texture2DArray when "Texture Quality"
                 // (QualitySettings.masterTextureLimit) is not "Full Res" (0) where result is junk (white from what I
@@ -119,7 +119,7 @@ namespace Crest
 
         static void CreateBlackTexArray()
         {
-            _blackTextureArray = CreateTexture2DArray(Texture2D.blackTexture);
+            _blackTextureArray = CreateTexture2DArray(Texture2D.blackTexture, LodDataMgr.MAX_LOD_COUNT);
             _blackTextureArray.name = "Crest Black Texture2DArray";
         }
     }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs
@@ -25,6 +25,9 @@ namespace Crest
 
     public static class XRHelpers
     {
+        // NOTE: This is the same value as Unity, but in the future it could be higher.
+        const int k_MaximumViews = 2;
+
 #if _XR_ENABLED
         readonly static List<XRDisplaySubsystem> _displayList = new List<XRDisplaySubsystem>();
 
@@ -59,6 +62,20 @@ namespace Crest
 #else
                 return false;
 #endif
+            }
+        }
+
+        static Texture2DArray s_WhiteTexture = null;
+        public static Texture2DArray WhiteTexture
+        {
+            get
+            {
+                if (s_WhiteTexture == null)
+                {
+                    s_WhiteTexture = TextureArrayHelpers.CreateTexture2DArray(Texture2D.whiteTexture, k_MaximumViews);
+                    s_WhiteTexture.name = "Crest White Texture XR";
+                }
+                return s_WhiteTexture;
             }
         }
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrSeaFloorDepth.cs
@@ -103,7 +103,7 @@ namespace Crest
         {
             var texture = TextureArrayHelpers.CreateTexture2D(s_nullColor, TextureFormat.RFloat);
             texture.name = "Sea Floor Depth Null Texture2D";
-            s_nullTexture = TextureArrayHelpers.CreateTexture2DArray(texture);
+            s_nullTexture = TextureArrayHelpers.CreateTexture2DArray(texture, MAX_LOD_COUNT);
             s_nullTexture.name = "Sea Floor Depth Null Texture2DArray";
             Helpers.Destroy(texture);
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -120,12 +120,6 @@ namespace Crest
         {
             base.OnDisable();
 
-            // Built-in RP only.
-            {
-                // Black for shadows. White for unshadowed.
-                Shader.SetGlobalTexture(sp_CrestScreenSpaceShadowTexture, Texture2D.whiteTexture);
-            }
-
             CleanUpShadowCommandBuffers();
 
             for (var index = 0; index < _renderMaterial.Length; index++)
@@ -454,14 +448,20 @@ namespace Crest
         public static void BindNullToGraphicsShaders()
         {
             Shader.SetGlobalTexture(ParamIdSampler(), s_nullTexture);
+        }
 
-            // Built-in RP only.
+        public static void BindScreenSpaceNullToGraphicsShaders(Camera camera)
+        {
+            // Black for shadowed. White for unshadowed. Built-in RP only.
+            if (camera.stereoEnabled && XRHelpers.IsSinglePass)
             {
-                // Black for shadows. White for unshadowed.
+                Shader.SetGlobalTexture(sp_CrestScreenSpaceShadowTexture, XRHelpers.WhiteTexture);
+            }
+            else
+            {
                 Shader.SetGlobalTexture(sp_CrestScreenSpaceShadowTexture, Texture2D.whiteTexture);
             }
         }
-
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void InitStatics()

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -604,6 +604,22 @@ namespace Crest
             _canSkipCulling = false;
 
             _generatedSettingsHash = CalculateSettingsHash();
+
+            Camera.onPreRender -= OnPreRenderCamera;
+            Camera.onPreRender += OnPreRenderCamera;
+        }
+
+        void OnPreRenderCamera(Camera camera)
+        {
+            if (!Helpers.MaskIncludesLayer(camera.cullingMask, Layer))
+            {
+                return;
+            }
+
+            if (!CreateShadowData)
+            {
+                LodDataMgrShadow.BindScreenSpaceNullToGraphicsShaders(camera);
+            }
         }
 
         internal void Rebuild()
@@ -1406,6 +1422,8 @@ namespace Crest
             _bufCascadeDataTgt?.Dispose();
             _bufCascadeDataSrc?.Dispose();
             _bufPerCascadeInstanceDataSource?.Dispose();
+
+            Camera.onPreRender -= OnPreRenderCamera;
         }
 
         /// <summary>

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -66,6 +66,10 @@ Fixed
 
    -  Fixed *Underwater Curtain* lighting not matching the water surface causing a visible seam at the far plane.
 
+.. only:: birp
+
+   -  Fixed caustics not rendering in XR `SPI` when shadow simulation is disabled. `[BIRP]`
+
 .. only:: hdrp
 
    -  Fixed ocean moving in edit mode when *Always Refresh* is disabled. `[HDRP]`


### PR DESCRIPTION
XR SPI needs a texture array with two dimensions but was given a texture.