### PR TITLE
Fix shadow sim running for all cameras

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -456,6 +456,11 @@ namespace Crest
         static float _lastUpdateEditorTime = -1f;
         public static float LastUpdateEditorTime => _lastUpdateEditorTime;
         static int _editorFrames = 0;
+
+        // Useful for rate limiting processes called outside of RunUpdate like camera events.
+        static int s_EditorFramesSinceUpdate = 0;
+        public static int EditorFramesSinceUpdate => Application.isPlaying ? 0 : s_EditorFramesSinceUpdate;
+        public static bool IsWithinEditorUpdate => EditorFramesSinceUpdate == 0;
 #endif
 
         BuildCommandBuffer _commandbufferBuilder;
@@ -638,6 +643,8 @@ namespace Crest
 #if UNITY_EDITOR
         static void EditorUpdate()
         {
+            s_EditorFramesSinceUpdate++;
+
             if (Instance == null) return;
 
             if (!EditorApplication.isPlaying)
@@ -645,6 +652,7 @@ namespace Crest
                 if (EditorApplication.timeSinceStartup - _lastUpdateEditorTime > 1f / Mathf.Clamp(Instance._editModeFPS, 0.01f, 60f))
                 {
                     _editorFrames++;
+                    s_EditorFramesSinceUpdate = 0;
 
                     _lastUpdateEditorTime = (float)EditorApplication.timeSinceStartup;
 
@@ -881,6 +889,9 @@ namespace Crest
         {
             // Init here from 2019.3 onwards
             Instance = null;
+#if UNITY_EDITOR
+            s_EditorFramesSinceUpdate = 0;
+#endif
         }
 
         void LateUpdate()

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -70,6 +70,8 @@ Fixed
 .. only:: birp
 
    -  Fixed caustics not rendering in XR `SPI` when shadow simulation is disabled. `[BIRP]`
+   -  Fixed XR spectator camera breaking if shadow simulation enabled. `[BIRP]`
+   -  Fixed shadow simulation executing for all cameras which could cause incorrect shadows. `[BIRP]`
 
 .. only:: hdrp
 


### PR DESCRIPTION
CBs on lights will run for all cameras so we need to restrict it to a single camera by adding and removing the CB using the camera events.

This broke XR spectator camera and could cause incorrect shadows in the simulation.

There is a possible Unity bug where the shadow input draw calls are duplicated and without any commands applied to them (including setting the render target).