### PR TITLE
Support multiple cameras for Underwater Renderer

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/XRHelpers.cs
@@ -139,7 +139,7 @@ namespace Crest
             SubsystemManager.GetInstances(_displayList);
 #endif
 
-            if (!IsRunning || !IsSinglePass)
+            if (!camera.stereoEnabled || !IsSinglePass)
             {
                 return;
             }

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -17,6 +17,8 @@ Changed
 ^^^^^^^
 .. bullet_list::
 
+   -  Add support for multiple cameras to the *Underwater Renderer*.
+      One limitation is that underwater culling will be disabled when using multiple *Underwater Renderer*s.
    -  ShapeFFT/Gerstner can now take a mesh renderer as an input.
    -  Add *Crest/Inputs/Shape Waves/Sample Spectrum* shader which samples the spectrum using a texture.
    -  Ocean inputs provided via the *Register* components now sort on sibling index in addition to queue, so multiple inputs with the same queue can be organised in the hierarchy to control sort order.
@@ -62,6 +64,7 @@ Fixed
    -  Prevent bad values (NaN etc) from propagating in the *Dynamic Waves* simulation.
       This manifested as the water surface disappearing from a singlar point.
    -  Fix shader include path error when moving `Crest` folder from the standard location.
+   -  No longer disable the *Underwater Renderer* if it fails validation.
 
    .. only:: birp or urp
 


### PR DESCRIPTION
The _Underwater Renderer_ can now support multiple cameras including almost all of its features and optimisations. Exceptions are underwater culling and _Surface Self Intersection Fix Mode_. It is possible to support these too but would require some re-architecturing of the _Ocean Renderer_.

The current architecture is not ideal for multiple cameras, but was still possible and so worth doing. A re-architecture will improve things when a breaking change can be made.

Also no longer disable UR if fails validation in edit mode.