### PR TITLE
Sphere Water Interaction GPU Instancing

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -213,7 +213,7 @@ namespace Crest
             float Filter(ILodDataInput data, out int isTransition);
         }
 
-        protected void SubmitDraws(int lodIdx, CommandBuffer buf)
+        protected virtual void SubmitDraws(int lodIdx, CommandBuffer buf)
         {
             var lt = OceanRenderer.Instance._lodTransform;
             lt._renderData[lodIdx].Current.Validate(0, SimName);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrDynWaves.cs
@@ -4,6 +4,7 @@
 
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
+using UnityEngine.Rendering;
 
 namespace Crest
 {
@@ -102,6 +103,19 @@ namespace Crest
             // because the depth is scheduled to render just before the animated waves, and this sim happens before animated waves.
             LodDataMgrSeaFloorDepth.Bind(simMaterial);
             LodDataMgrFlow.Bind(simMaterial);
+        }
+
+        protected override void SubmitDraws(int lodIdx, CommandBuffer buffer)
+        {
+            base.SubmitDraws(lodIdx, buffer);
+
+#if UNITY_EDITOR
+            if (Application.isPlaying)
+#endif
+            {
+                // SWI needs special handling. They are not registered like other inputs.
+                SphereWaterInteraction.SubmitDraws(this, lodIdx, buffer);
+            }
         }
 
         public static void CountWaveSims(int countFrom, out int o_present, out int o_active)

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -40,6 +40,7 @@ Changed
    -  Set *Ocean Renderer* *Wind Speed* default value to the maxmimum to reduce UX friction for new users.
    -  Also search *Addressables* and *Resources* for ocean materials when stripping keywords from underwater shader.
    -  Add *Ocean Renderer > Extents Size Multiplier* to adjust the extents so they can be increased in size to meet the horizon in cases where they do not.
+   -  Greatly improve performance when many SphereWaterInteraction components are used by utilising GPU Instancing.
 
 
 Fixed


### PR DESCRIPTION
Greatly improves performance when many SWI instances are in the scene. Without instancing, there would be one draw call per LOD per instance. Now there is only one draw call per LOD.

This has been implemented for SWI only as it is necessary for its scalability due to the nature of its usage often been as a composite and requiring several instances to achieve a desired shape.

For example, the "Spinner" example had 126 draw calls and now has only seven draw calls.

GPU instancing can only draw 1023 instances per draw, which should be more than enough, so for now the SWI also carries this limitation.

Another downside of instancing is that inputs cannot be sorted, but I do not believe there is a use case for that anyway.

Eventually moving towards compute shaders will replace this.