### PR TITLE
Do not execute in background

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -153,6 +153,13 @@ namespace Crest
         void OnPreCullCamera(Camera camera)
         {
 #if UNITY_EDITOR
+            // Do not execute when editor is not active to conserve power and prevent possible leaks.
+            if (!UnityEditorInternal.InternalEditorUtility.isApplicationActive)
+            {
+                BufCopyShadowMap?.Clear();
+                return;
+            }
+
             if (!OceanRenderer.IsWithinEditorUpdate)
             {
                 return;
@@ -195,6 +202,13 @@ namespace Crest
         void OnPostRenderCamera(Camera camera)
         {
 #if UNITY_EDITOR
+            // Do not execute when editor is not active to conserve power and prevent possible leaks.
+            if (!UnityEditorInternal.InternalEditorUtility.isApplicationActive)
+            {
+                BufCopyShadowMap?.Clear();
+                return;
+            }
+
             if (!OceanRenderer.IsWithinEditorUpdate)
             {
                 return;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -676,6 +676,12 @@ namespace Crest
 #if UNITY_EDITOR
         static void EditorUpdate()
         {
+            // Do not execute when editor is not active to conserve power and prevent possible leaks.
+            if (!UnityEditorInternal.InternalEditorUtility.isApplicationActive)
+            {
+                return;
+            }
+
             s_EditorFramesSinceUpdate++;
 
             if (Instance == null) return;

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.cs
@@ -336,6 +336,16 @@ namespace Crest
 
         void OnPreRender()
         {
+#if UNITY_EDITOR
+            // Do not execute when editor is not active to conserve power and prevent possible leaks.
+            if (!UnityEditorInternal.InternalEditorUtility.isApplicationActive)
+            {
+                _oceanMaskCommandBuffer?.Clear();
+                _underwaterEffectCommandBuffer?.Clear();
+                return;
+            }
+#endif
+
             UpdateOceanRendererStateForCamera();
 
             if (!IsActive)
@@ -507,6 +517,16 @@ namespace Crest
 
         void OnBeforeRender(Camera camera)
         {
+#if UNITY_EDITOR
+            // Do not execute when editor is not active to conserve power and prevent possible leaks.
+            if (!UnityEditorInternal.InternalEditorUtility.isApplicationActive)
+            {
+                _oceanMaskCommandBuffer?.Clear();
+                _underwaterEffectCommandBuffer?.Clear();
+                return;
+            }
+#endif
+
             if (!IsActiveForEditorCamera(camera, this))
             {
                 return;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -13,6 +13,13 @@ Release Notes
 |version|
 ---------
 
+Changed
+^^^^^^^
+.. bullet_list::
+
+   -  No longer execute when editor is inactive (ie out of focus) to prevent edge cases where memory leaks can occur and to save energy.
+
+
 Fixed
 ^^^^^
 .. bullet_list::


### PR DESCRIPTION
In certain cases memory would slowly increase indefinitely. It would be cleared when editor became active again but would like to avoid leaks altogether.

This could be a Unity bug but more effective to patch than report. It also has the benefit of saving energy.