### PR TITLE
Fix water renderer bounds thrashing in edit mode

### DIFF
--- a/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
+++ b/crest/Assets/Crest/Crest-Examples/Whirlpool/Scripts/Whirlpool.cs
@@ -8,7 +8,7 @@ namespace Crest
 {
     [ExecuteDuringEditMode]
     [AddComponentMenu(Internal.Constants.MENU_PREFIX_EXAMPLE + "Whirlpool")]
-    public class Whirlpool : CustomMonoBehaviour
+    public class Whirlpool : CustomMonoBehaviour, LodDataMgrAnimWaves.IShapeUpdatable
     {
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
@@ -83,6 +83,8 @@ namespace Crest
             CreateOrDestroyDynamicWaves();
 
             UpdateMaterials();
+
+            LodDataMgrAnimWaves.RegisterUpdatable(this);
         }
 
         void OnDisable()
@@ -93,6 +95,13 @@ namespace Crest
             Helpers.Destroy(_displacementMaterial);
             Helpers.Destroy(_flowMaterial);
             Helpers.Destroy(_dampDynWavesMaterial);
+
+            LodDataMgrAnimWaves.DeregisterUpdatable(this);
+        }
+
+        public void CrestUpdate(UnityEngine.Rendering.CommandBuffer buf)
+        {
+            OceanRenderer.Instance.ReportMaxDisplacementFromShape(0f, _amplitude, 0f);
         }
 
         void CreateOrDestroy<RegisterInputType>(bool toggle, string shaderName, ref GameObject input, ref Material material) where RegisterInputType : RegisterLodDataInputBase
@@ -146,8 +155,6 @@ namespace Crest
             {
                 return;
             }
-
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(0f, _amplitude, 0f);
 
             UpdateMaterials();
             UpdateInputs();

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -11,7 +11,7 @@ namespace Crest
     /// </summary>
     [AddComponentMenu(MENU_PREFIX + "Animated Waves Input")]
     [HelpURL(Internal.Constants.HELP_URL_BASE_USER + "ocean-simulation.html" + Internal.Constants.HELP_URL_RP + "#animated-waves")]
-    public class RegisterAnimWavesInput : RegisterLodDataInputWithSplineSupport<LodDataMgrAnimWaves>
+    public class RegisterAnimWavesInput : RegisterLodDataInputWithSplineSupport<LodDataMgrAnimWaves>, LodDataMgrAnimWaves.IShapeUpdatable
     {
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
@@ -50,7 +50,21 @@ namespace Crest
         [Predicated(typeof(MeshRenderer)), DecoratedField]
         bool _reportRendererBoundsToOceanSystem = false;
 
-        protected override void Update()
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            LodDataMgrAnimWaves.RegisterUpdatable(this);
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            LodDataMgrAnimWaves.DeregisterUpdatable(this);
+        }
+
+        public void CrestUpdate(UnityEngine.Rendering.CommandBuffer buf)
         {
             base.Update();
 

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -10,7 +10,7 @@ namespace Crest
     /// Registers a custom input to affect the water height.
     /// </summary>
     [AddComponentMenu(MENU_PREFIX + "Height Input")]
-    public partial class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrSeaFloorDepth>
+    public partial class RegisterHeightInput : RegisterLodDataInputWithSplineSupport<LodDataMgrSeaFloorDepth>, LodDataMgrAnimWaves.IShapeUpdatable
     {
         /// <summary>
         /// The version of this asset. Can be used to migrate across versions. This value should
@@ -39,10 +39,22 @@ namespace Crest
         [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;
 
-        protected override void Update()
+        protected override void OnEnable()
         {
-            base.Update();
+            base.OnEnable();
 
+            LodDataMgrAnimWaves.RegisterUpdatable(this);
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+
+            LodDataMgrAnimWaves.DeregisterUpdatable(this);
+        }
+
+        public void CrestUpdate(UnityEngine.Rendering.CommandBuffer buf)
+        {
             if (OceanRenderer.Instance == null)
             {
                 return;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -28,6 +28,7 @@ Fixed
       To not have per frame `GC` allocations, ensure *Spectrum Fixed At Runtime* is enabled.
    -  Remove or reduce several runtime `GC` allocations.
    -  Remove several editor `GC` allocations.
+   -  Fix culling and performance issues in edit mode when using RegisterHeightInput, RegisterAnimWavesInput or Whirlpool.
 
    .. only:: birp
 


### PR DESCRIPTION
Fixes renderer bounds thrashing in edit mode if using RegisterAnimWavesInput, RegisterHeightInput or Whirlpool.

There was a mismatch in reporting maximum displacement where the OR was clearing reported displacement in EditorApplication.update but these components were reporting in Update. Chunk renderer bounds are updated in Update so it would have alternating reported displacements which caused thrashing. It incurred a performance penalty and incorrect culling.