### PR TITLE
Reduce Water Body material override leaks

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -281,54 +281,58 @@ namespace Crest
         }
     }
 
-    static class Extensions
+    namespace Internal
     {
-        public static void SetKeyword(this Material material, string keyword, bool enabled)
+        static class Extensions
         {
-            if (enabled)
+            public static void SetKeyword(this Material material, string keyword, bool enabled)
             {
-                material.EnableKeyword(keyword);
+                if (enabled)
+                {
+                    material.EnableKeyword(keyword);
+                }
+                else
+                {
+                    material.DisableKeyword(keyword);
+                }
             }
-            else
-            {
-                material.DisableKeyword(keyword);
-            }
-        }
 
-        public static void SetKeyword(this ComputeShader shader, string keyword, bool enabled)
-        {
-            if (enabled)
+            public static void SetKeyword(this ComputeShader shader, string keyword, bool enabled)
             {
-                shader.EnableKeyword(keyword);
+                if (enabled)
+                {
+                    shader.EnableKeyword(keyword);
+                }
+                else
+                {
+                    shader.DisableKeyword(keyword);
+                }
             }
-            else
-            {
-                shader.DisableKeyword(keyword);
-            }
-        }
 
-        public static void SetShaderKeyword(this CommandBuffer buffer, string keyword, bool enabled)
-        {
-            if (enabled)
+            public static void SetShaderKeyword(this CommandBuffer buffer, string keyword, bool enabled)
             {
-                buffer.EnableShaderKeyword(keyword);
+                if (enabled)
+                {
+                    buffer.EnableShaderKeyword(keyword);
+                }
+                else
+                {
+                    buffer.DisableShaderKeyword(keyword);
+                }
             }
-            else
-            {
-                buffer.DisableShaderKeyword(keyword);
-            }
-        }
 
-        ///<summary>
-        /// Sets the msaaSamples property to the highest supported MSAA level in the settings.
-        ///</summary>
-        public static void SetMSAASamples(this ref RenderTextureDescriptor descriptor, Camera camera)
-        {
-            // QualitySettings.antiAliasing is zero when disabled which is invalid for msaaSamples.
-            // We need to set this first as GetRenderTextureSupportedMSAASampleCount uses it:
-            // https://docs.unity3d.com/ScriptReference/SystemInfo.GetRenderTextureSupportedMSAASampleCount.html
-            descriptor.msaaSamples = Helpers.IsMSAAEnabled(camera) ? Mathf.Max(QualitySettings.antiAliasing, 1) : 1;
-            descriptor.msaaSamples = SystemInfo.GetRenderTextureSupportedMSAASampleCount(descriptor);
+            ///<summary>
+            /// Sets the msaaSamples property to the highest supported MSAA level in the settings.
+            ///</summary>
+            public static void SetMSAASamples(this ref RenderTextureDescriptor descriptor, Camera camera)
+            {
+                // QualitySettings.antiAliasing is zero when disabled which is invalid for msaaSamples.
+                // We need to set this first as GetRenderTextureSupportedMSAASampleCount uses it:
+                // https://docs.unity3d.com/ScriptReference/SystemInfo.GetRenderTextureSupportedMSAASampleCount.html
+                descriptor.msaaSamples = Helpers.IsMSAAEnabled(camera) ? Mathf.Max(QualitySettings.antiAliasing, 1) : 1;
+                descriptor.msaaSamples = SystemInfo.GetRenderTextureSupportedMSAASampleCount(descriptor);
+            }
         }
     }
+
 }

--- a/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Helpers/Helpers.cs
@@ -285,6 +285,17 @@ namespace Crest
     {
         static class Extensions
         {
+            // Swizzle
+            public static Vector2 XZ(this Vector3 v) => new Vector2(v.x, v.z);
+            public static Vector2 XY(this Vector4 v) => new Vector2(v.x, v.y);
+            public static Vector2 ZW(this Vector4 v) => new Vector2(v.z, v.w);
+            public static Vector3 XNZ(this Vector2 v, float n = 0f) => new Vector3(v.x, n, v.y);
+            public static Vector3 XNZ(this Vector3 v, float n = 0f) => new Vector3(v.x, n, v.z);
+            public static Vector3 XNN(this Vector3 v, float n = 0f) => new Vector3(v.x, n, n);
+            public static Vector3 NNZ(this Vector3 v, float n = 0f) => new Vector3(n, n, v.z);
+            public static Vector4 XYNN(this Vector2 v, float n = 0f) => new Vector4(v.x, v.y, n, n);
+            public static Vector4 NNZW(this Vector2 v, float n = 0f) => new Vector4(n, n, v.x, v.y);
+
             public static void SetKeyword(this Material material, string keyword, bool enabled)
             {
                 if (enabled)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -2,6 +2,7 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Crest.Internal;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1313,6 +1313,7 @@ namespace Crest
                 if (!canSkipCulling)
                 {
                     var chunkBounds = tile.Rend.bounds;
+                    var chunkUndisplacedBoundsXZ = tile.UnexpandedBoundsXZ;
 
                     var largestOverlap = 0f;
                     var overlappingOne = false;
@@ -1338,10 +1339,14 @@ namespace Crest
                             {
                                 var overlap = 0f;
                                 {
-                                    var xMin = Mathf.Max(bounds.min.x, chunkBounds.min.x);
-                                    var xMax = Mathf.Min(bounds.max.x, chunkBounds.max.x);
-                                    var zMin = Mathf.Max(bounds.min.z, chunkBounds.min.z);
-                                    var zMax = Mathf.Min(bounds.max.z, chunkBounds.max.z);
+                                    // Use the unexpanded bounds to prevent leaking as generally this feature will be
+                                    // for an inland body of water where hopefully there is attenuation between it and
+                                    // the ocean to handle the ocean's displacement. The inland water body will unlikely
+                                    // have large displacement but can be mitigated with a decent buffer zone.
+                                    var xMin = Mathf.Max(bounds.min.x, chunkUndisplacedBoundsXZ.min.x);
+                                    var xMax = Mathf.Min(bounds.max.x, chunkUndisplacedBoundsXZ.max.x);
+                                    var zMin = Mathf.Max(bounds.min.z, chunkUndisplacedBoundsXZ.min.y);
+                                    var zMax = Mathf.Min(bounds.max.z, chunkUndisplacedBoundsXZ.max.y);
                                     if (xMin < xMax && zMin < zMax)
                                     {
                                         overlap = (xMax - xMin) * (zMax - zMin);

--- a/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanValidation.cs
@@ -10,6 +10,7 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Crest.EditorHelpers;
+using Crest.Internal;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Effect.cs
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Crest.Internal;
+
 namespace Crest
 {
     using Unity.Collections;

--- a/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Underwater/UnderwaterRenderer.Mask.cs
@@ -2,6 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+using Crest.Internal;
+
 namespace Crest
 {
     using System.Collections.Generic;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -17,6 +17,7 @@ Changed
 ^^^^^^^
 .. bullet_list::
 
+   -  Reduce *Water Body* material override feature leaking outside of water bodies.
    -  No longer execute when editor is inactive (ie out of focus) to prevent edge cases where memory leaks can occur and to save energy.
    -  Improve *Water Body* gizmo by adding a wireframe.
 


### PR DESCRIPTION
The water tile's expanded bounds would cause materials to leak outside of the water body.

Use the unexpanded bounds to reduce leaking as generally this feature will be for an inland body of water where hopefully there is attenuation between it and the ocean to handle the ocean's displacement. The inland water body will unlikely have large displacement but can be mitigated with a decent buffer zone.