### PR TITLE
Improve culling by reducing displacement over-reporting

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterHeightInput.cs
@@ -36,6 +36,7 @@ namespace Crest
         protected override bool FollowHorizontalMotion => true;
 
         [Header("Height Input Settings")]
+        [HideInInspector]
         [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;
 
@@ -55,33 +56,30 @@ namespace Crest
 
         public void CrestUpdate(UnityEngine.Rendering.CommandBuffer buf)
         {
-            if (OceanRenderer.Instance == null)
+            var ocean = OceanRenderer.Instance;
+
+            if (ocean == null)
             {
                 return;
             }
 
-            var maxDispVert = _maxDisplacementVertical;
+            var minimum = ocean.SeaLevel;
+            var maximum = minimum;
 
             // let ocean system know how far from the sea level this shape may displace the surface
             if (_renderer != null)
             {
-                var minY = _renderer.bounds.min.y;
-                var maxY = _renderer.bounds.max.y;
-                var seaLevel = OceanRenderer.Instance.SeaLevel;
-                maxDispVert = Mathf.Max(maxDispVert, Mathf.Abs(seaLevel - minY), Mathf.Abs(seaLevel - maxY));
+                minimum = _renderer.bounds.min.y;
+                maximum = _renderer.bounds.max.y;
             }
             else if (_splineMaterial != null &&
                 ShapeGerstnerSplineHandling.MinMaxHeightValid(_splinePointHeightMin, _splinePointHeightMax))
             {
-                var seaLevel = OceanRenderer.Instance.SeaLevel;
-                maxDispVert = Mathf.Max(maxDispVert,
-                    Mathf.Abs(seaLevel - _splinePointHeightMin), Mathf.Abs(seaLevel - _splinePointHeightMax));
+                minimum = _splinePointHeightMin;
+                maximum = _splinePointHeightMax;
             }
 
-            if (maxDispVert > 0f)
-            {
-                OceanRenderer.Instance.ReportMaxDisplacementFromShape(0f, maxDispVert, 0f);
-            }
+            OceanRenderer.Instance.ReportDisplacementFromHeight(minimum, maximum);
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -306,6 +306,7 @@ namespace Crest
         protected Material _splineMaterial;
         Spline.Spline _spline;
         Mesh _splineMesh;
+        protected Vector3[] _splineBoundingPoints = new Vector3[0];
 
         protected abstract string SplineShaderName { get; }
         protected abstract Vector2 DefaultCustomData { get; }
@@ -331,7 +332,7 @@ namespace Crest
             var radius = _overrideSplineSettings ? _radius : _spline.Radius;
             var subdivs = _overrideSplineSettings ? _subdivisions : _spline.Subdivisions;
             ShapeGerstnerSplineHandling.GenerateMeshFromSpline<SplinePointCustomData>(_spline, transform, subdivs,
-                radius, DefaultCustomData, ref _splineMesh, out _splinePointHeightMin, out _splinePointHeightMax);
+                radius, DefaultCustomData, ref _splineMesh, out _splinePointHeightMin, out _splinePointHeightMax, ref _splineBoundingPoints);
 
             if (_splineMaterial == null)
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -339,7 +339,7 @@ namespace Crest
                 // to allow for horizontal displacement
                 mesh.RecalculateBounds();
                 bounds = mesh.bounds;
-                bounds.extents = new Vector3(bounds.extents.x + dx, 100f, bounds.extents.z + dx);
+                bounds.extents = new Vector3(bounds.extents.x + dx, bounds.extents.y, bounds.extents.z + dx);
                 mesh.bounds = bounds;
                 mesh.name = pt.ToString();
             }

--- a/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanBuilder.cs
@@ -446,7 +446,11 @@ namespace Crest
                 {
                     var oceanChunkRenderer = patch.AddComponent<OceanChunkRenderer>();
                     oceanChunkRenderer._boundsLocal = meshBounds[(int)patchTypes[i]];
-                    patch.AddComponent<MeshFilter>().sharedMesh = meshData[(int)patchTypes[i]];
+
+                    var mesh = Object.Instantiate(meshData[(int)patchTypes[i]]);
+                    mesh.name = meshData[(int)patchTypes[i]].name;
+                    patch.AddComponent<MeshFilter>().sharedMesh = mesh;
+
                     oceanChunkRenderer.SetInstanceData(lodIndex);
                     tiles.Add(oceanChunkRenderer);
                 }

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -194,12 +194,27 @@ namespace Crest
         // can change depending on view altitude
         public static void ExpandBoundsForDisplacements(Transform transform, ref Bounds bounds)
         {
-            var boundsPadding = OceanRenderer.Instance.MaxHorizDisplacement;
+            var ocean = OceanRenderer.Instance;
+
+            var boundsPadding = ocean.MaxHorizDisplacement;
             var expandXZ = boundsPadding / transform.lossyScale.x;
-            var boundsY = OceanRenderer.Instance.MaxVertDisplacement;
-            // extend the kinematic bounds slightly to give room for dynamic sim stuff
-            boundsY += 5f;
-            bounds.extents = new Vector3(bounds.extents.x + expandXZ, boundsY / transform.lossyScale.y, bounds.extents.z + expandXZ);
+            var boundsY = ocean.MaxVertDisplacement;
+
+            // Extend the kinematic bounds slightly to give room for dynamic waves.
+            if (ocean._lodDataDynWaves != null)
+            {
+                boundsY += 5f;
+            }
+
+            var minimumWaterLevelBounds = ocean.MinimumHeight * 0.5f;
+            var maximumWaterLevelBounds = ocean.MaximumHeight * 0.5f;
+
+            boundsY += minimumWaterLevelBounds + maximumWaterLevelBounds;
+
+            bounds.extents = new Vector3(bounds.extents.x + expandXZ, boundsY, bounds.extents.z + expandXZ);
+
+            var offset = maximumWaterLevelBounds - minimumWaterLevelBounds;
+            bounds.center = new Vector3(bounds.center.x, bounds.center.y + offset, bounds.center.z);
         }
 
         public void SetInstanceData(int lodIndex)

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -53,17 +53,8 @@ namespace Crest
         void Start()
         {
             Rend = GetComponent<Renderer>();
-#if UNITY_EDITOR
-            if (!Application.isPlaying)
-            {
-                _mesh = GetComponent<MeshFilter>().sharedMesh;
-            }
-            else
-#endif
-            {
-                // An unshared mesh will break instancing, but a shared mesh will break culling due to shared bounds.
-                _mesh = GetComponent<MeshFilter>().mesh;
-            }
+            // Meshes are cloned so it is safe to use sharedMesh in play mode. We need clones to modify the render bounds.
+            _mesh = GetComponent<MeshFilter>().sharedMesh;
 
             UpdateMeshBounds();
 
@@ -163,6 +154,10 @@ namespace Crest
             Rend.SetPropertyBlock(_mpb.materialPropertyBlock);
         }
 
+        void OnDestroy()
+        {
+            Helpers.Destroy(_mesh);
+        }
 
         // Called when visible to a camera
         void OnWillRenderObject()

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1390,12 +1390,7 @@ namespace Crest
 
         void LateUpdateResetMaxDisplacementFromShape()
         {
-            if (FrameCount != _maxDisplacementCachedTime)
-            {
-                _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = 0f;
-            }
-
-            _maxDisplacementCachedTime = FrameCount;
+            _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = _minVertDispFromHeight = _maxVertDispFromHeight = 0f;
         }
 
         /// <summary>
@@ -1417,10 +1412,18 @@ namespace Crest
             _maxVertDispFromShape += maxVertDisp;
             _maxVertDispFromWaves += maxVertDispFromWaves;
         }
+        public void ReportDisplacementFromHeight(float minimum, float maximum)
+        {
+            _minVertDispFromHeight = Mathf.Max(_minVertDispFromHeight, Mathf.Abs(Mathf.Min(minimum, SeaLevel) - SeaLevel));
+            _maxVertDispFromHeight = Mathf.Max(_maxVertDispFromHeight, Mathf.Abs(Mathf.Max(maximum, SeaLevel) - SeaLevel));
+        }
         float _maxHorizDispFromShape = 0f;
         float _maxVertDispFromShape = 0f;
         float _maxVertDispFromWaves = 0f;
-        int _maxDisplacementCachedTime = 0;
+        float _minVertDispFromHeight = 0f;
+        float _maxVertDispFromHeight = 0f;
+        public float MinimumHeight => _minVertDispFromHeight;
+        public float MaximumHeight => _maxVertDispFromHeight;
         /// <summary>
         /// The maximum horizontal distance that the shape scripts are displacing the shape.
         /// </summary>

--- a/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanRenderer.cs
@@ -1390,7 +1390,7 @@ namespace Crest
 
         void LateUpdateResetMaxDisplacementFromShape()
         {
-            _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = _minVertDispFromHeight = _maxVertDispFromHeight = 0f;
+            _maxHorizDispFromShape = _maxVertDispFromShape = _maxVertDispFromWaves = 0f;
         }
 
         /// <summary>
@@ -1412,18 +1412,9 @@ namespace Crest
             _maxVertDispFromShape += maxVertDisp;
             _maxVertDispFromWaves += maxVertDispFromWaves;
         }
-        public void ReportDisplacementFromHeight(float minimum, float maximum)
-        {
-            _minVertDispFromHeight = Mathf.Max(_minVertDispFromHeight, Mathf.Abs(Mathf.Min(minimum, SeaLevel) - SeaLevel));
-            _maxVertDispFromHeight = Mathf.Max(_maxVertDispFromHeight, Mathf.Abs(Mathf.Max(maximum, SeaLevel) - SeaLevel));
-        }
         float _maxHorizDispFromShape = 0f;
         float _maxVertDispFromShape = 0f;
         float _maxVertDispFromWaves = 0f;
-        float _minVertDispFromHeight = 0f;
-        float _maxVertDispFromHeight = 0f;
-        public float MinimumHeight => _minVertDispFromHeight;
-        public float MaximumHeight => _maxVertDispFromHeight;
         /// <summary>
         /// The maximum horizontal distance that the shape scripts are displacing the shape.
         /// </summary>

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/FFT/ShapeFFT.cs
@@ -48,6 +48,15 @@ namespace Crest
         [Tooltip("FFT waves will loop with a period of this many seconds. Smaller values decrease data size but can make waves visibly repetitive."), Predicated("_enableBakedCollision"), Range(4f, 128f)]
         public float _timeLoopLength = 32f;
 
+
+        // Debug
+        [Space(10)]
+
+        [SerializeField]
+        DebugFields _debug = new DebugFields();
+        protected override DebugFields DebugSettings => _debug;
+
+
         internal float LoopPeriod => _enableBakedCollision ? _timeLoopLength : -1f;
 
         protected override int MinimumResolution => 16;
@@ -107,7 +116,13 @@ namespace Crest
         protected override void ReportMaxDisplacement()
         {
             // Apply weight or will cause popping due to scale change.
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxHorizontalDisplacement * _weight, _maxVerticalDisplacement * _weight, _maxVerticalDisplacement * _weight);
+            _maxHorizDisp = _maxHorizontalDisplacement * _weight;
+            _maxVertDisp = _maxWavesDisp = _maxVerticalDisplacement * _weight;
+
+            if (IsGlobalWaves)
+            {
+                OceanRenderer.Instance.ReportMaxDisplacementFromShape(_maxHorizDisp, _maxVertDisp, _maxVertDisp);
+            }
         }
 
         protected override void DestroySharedResources()
@@ -118,7 +133,7 @@ namespace Crest
 #if UNITY_EDITOR
         void OnGUI()
         {
-            if (_debugDrawSlicesInEditor)
+            if (_debug._drawSlicesInEditor)
             {
                 FFTCompute.OnGUI(_resolution, LoopPeriod, _windTurbulence, WindDirRadForFFT, WindSpeed, _activeSpectrum);
             }
@@ -224,6 +239,8 @@ namespace Crest
             var selectCurrentSettingsLabel = "Select current settings";
             if (OceanRenderer.Instance._simSettingsAnimatedWaves != null)
             {
+                GUILayout.Space(10);
+
                 if (GUILayout.Button(bakeLabel))
                 {
                     FFTBaker.BakeShapeFFT(target as ShapeFFT);

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstner.cs
@@ -40,6 +40,15 @@ namespace Crest
         [Tooltip("Change to get a different set of waves.")]
         public int _randomSeed = 0;
 
+
+        // Debug
+        [Space(10)]
+
+        [SerializeField]
+        DebugFields _debug = new DebugFields();
+        protected override DebugFields DebugSettings => _debug;
+
+
         protected override int MinimumResolution => 8;
         protected override int MaximumResolution => 64;
 
@@ -449,7 +458,14 @@ namespace Crest
             // Apply weight or will cause popping due to scale change.
             ampSum *= _weight;
 
-            OceanRenderer.Instance.ReportMaxDisplacementFromShape(ampSum * _activeSpectrum._chop, ampSum, ampSum);
+            _maxHorizDisp = ampSum * _activeSpectrum._chop;
+            _maxVertDisp = ampSum;
+            _maxWavesDisp = ampSum;
+
+            if (IsGlobalWaves)
+            {
+                OceanRenderer.Instance.ReportMaxDisplacementFromShape(ampSum * _activeSpectrum._chop, ampSum, ampSum);
+            }
         }
 
         protected override void OnEnable()
@@ -488,7 +504,7 @@ namespace Crest
 #if UNITY_EDITOR
         void OnGUI()
         {
-            if (_debugDrawSlicesInEditor && _waveBuffers != null && _waveBuffers.IsCreated())
+            if (_debug._drawSlicesInEditor && _waveBuffers != null && _waveBuffers.IsCreated())
             {
                 OceanDebugGUI.DrawTextureArray(_waveBuffers, 8, 0.5f);
             }

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerSplineHandling.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerSplineHandling.cs
@@ -12,12 +12,12 @@ namespace Crest
     /// </summary>
     public static class ShapeGerstnerSplineHandling
     {
-        public static bool GenerateMeshFromSpline(Spline.Spline spline, Transform transform, int subdivisions, float radius, Vector2 customDataDefault, ref Mesh mesh, out float minHeight, out float maxHeight)
+        public static bool GenerateMeshFromSpline(Spline.Spline spline, Transform transform, int subdivisions, float radius, Vector2 customDataDefault, ref Mesh mesh, out float minHeight, out float maxHeight, ref Vector3[] verts)
         {
-            return GenerateMeshFromSpline<SplinePointDataNone>(spline, transform, subdivisions, radius, customDataDefault, ref mesh, out minHeight, out maxHeight);
+            return GenerateMeshFromSpline<SplinePointDataNone>(spline, transform, subdivisions, radius, customDataDefault, ref mesh, out minHeight, out maxHeight, ref verts);
         }
 
-        public static bool GenerateMeshFromSpline<SplinePointCustomData>(Spline.Spline spline, Transform transform, int subdivisions, float radius, Vector2 customDataDefault, ref Mesh mesh, out float minHeight, out float maxHeight)
+        public static bool GenerateMeshFromSpline<SplinePointCustomData>(Spline.Spline spline, Transform transform, int subdivisions, float radius, Vector2 customDataDefault, ref Mesh mesh, out float minHeight, out float maxHeight, ref Vector3[] verts)
             where SplinePointCustomData : ISplinePointCustomData
         {
             minHeight = 10000f;
@@ -196,7 +196,7 @@ namespace Crest
                 }
             }
 
-            return UpdateMesh(transform, sampledPtsOffSplineLeft, sampledPtsOffSplineRight, customData, spline._closed, ref mesh);
+            return UpdateMesh(transform, sampledPtsOffSplineLeft, sampledPtsOffSplineRight, customData, spline._closed, ref mesh, ref verts);
         }
 
         // Ensures that the set of points are always moving "forwards", where forwards direction is defined by
@@ -247,7 +247,7 @@ namespace Crest
         }
 
         // Generates a mesh from the points sampled along the spline, and corresponding offset points. Bridges points with a ribbon of triangles.
-        static bool UpdateMesh(Transform transform, Vector3[] sampledPtsOffSplineLeft, Vector3[] sampledPtsOffSplineRight, Vector2[] customData, bool closed, ref Mesh mesh)
+        static bool UpdateMesh(Transform transform, Vector3[] sampledPtsOffSplineLeft, Vector3[] sampledPtsOffSplineRight, Vector2[] customData, bool closed, ref Mesh mesh, ref Vector3[] verts)
         {
             if (mesh == null)
             {
@@ -274,7 +274,11 @@ namespace Crest
             var triCount = (sampledPtsOffSplineLeft.Length - 1) * 2;
             var indices = new int[triCount * 3];
             var vertCount = 2 * sampledPtsOffSplineLeft.Length;
-            var verts = new Vector3[vertCount];
+            if (vertCount != verts?.Length)
+            {
+                // Consumer will use vertices to calculate a transformed bounds (XZ only) like a renderer would.
+                verts = new Vector3[vertCount];
+            }
             var uvs = new Vector2[vertCount];
             var uvs2 = new Vector2[vertCount];
             var uvs3 = new Vector2[vertCount];

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -33,6 +33,7 @@ Fixed
    -  Remove several editor `GC` allocations.
    -  Fix culling and performance issues in edit mode when using RegisterHeightInput, RegisterAnimWavesInput or Whirlpool.
    -  Fix gizmos not drawing for inputs when using an attached renderer.
+   -  Fix potential cases where water tiles were being culled incorrectly.
 
    .. only:: birp
 
@@ -42,6 +43,14 @@ Fixed
 
       -  Fix *Underwater Renderer* compatibility with depth prepass.
       -  Fix *Underwater Renderer* not working with multiple cameras in certain cases.
+
+
+Performance
+^^^^^^^^^^^
+.. bullet_list::
+
+   -  Improve water tile culling significantly.
+      The bounds for each tile are normally expanded to accommodate mesh displacement (to prevent culling), but they were much larger than required in many cases leading to reduced culling hits which is no longer the case.
 
 
 4.16


### PR DESCRIPTION
This is a significant improvement to the displacement reporting mechanism which expands the water tile bounds to prevent culling. In many cases these were being expanded much larger than they needed to be.

Height is now reported separately and takes the minimum and maximum as it was additive before. Bounds also have an offset applied instead of expanding on both sides of the sea level to encompass varying heights.

Both height and displacement that come from a local input (renderer, spline, etc) are bounds tested against each water tile so that only the applicable inputs are included when reporting.

The end result is a significant improvement to culling of water tiles.