### PR TITLE
Fix wave blending not applying to waves during transition towards the end of cascades

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Interaction/SphereWaterInteraction.cs
@@ -108,6 +108,8 @@ namespace Crest
 
         public bool Enabled => true;
 
+        public bool IgnoreTransitionWeight => false;
+
         private void Start()
         {
             if (OceanRenderer.Instance == null)

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -210,7 +210,7 @@ namespace Crest
 
         public interface IDrawFilter
         {
-            float Filter(ILodDataInput data, out int isTransition);
+            float Filter(ILodDataInput data, out int isTransition, out float alpha);
         }
 
         protected virtual void SubmitDraws(int lodIdx, CommandBuffer buf)
@@ -247,10 +247,10 @@ namespace Crest
                     continue;
                 }
 
-                float weight = filter.Filter(draw.Value, out var isTransition);
-                if (weight > 0f)
+                var weight = filter.Filter(draw.Value, out var isTransition, out var alpha);
+                if ((weight > 0f && alpha > 0f) || (draw.Value.IgnoreTransitionWeight && weight > 0f))
                 {
-                    draw.Value.Draw(this, buf, weight, isTransition, lodIdx);
+                    draw.Value.Draw(this, buf, weight * alpha, isTransition, lodIdx);
                 }
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgrAnimWaves.cs
@@ -169,10 +169,11 @@ namespace Crest
             public int _lodCount;
             public float _globalMaxWavelength;
 
-            public float Filter(ILodDataInput data, out int isTransition)
+            public float Filter(ILodDataInput data, out int isTransition, out float alpha)
             {
                 var drawOctaveWavelength = data.Wavelength;
                 isTransition = 0;
+                alpha = 1f;
 
                 // No wavelength preference - don't draw per-lod
                 if (drawOctaveWavelength == 0f)
@@ -192,13 +193,15 @@ namespace Crest
                     if (_lodIdx == _lodCount - 2)
                     {
                         isTransition = 1;
-                        return 1f - OceanRenderer.Instance.ViewerAltitudeLevelAlpha;
+                        alpha = 1f - OceanRenderer.Instance.ViewerAltitudeLevelAlpha;
                     }
 
                     if (_lodIdx == _lodCount - 1)
                     {
-                        return OceanRenderer.Instance.ViewerAltitudeLevelAlpha;
+                        alpha = OceanRenderer.Instance.ViewerAltitudeLevelAlpha;
                     }
+
+                    return 1f;
                 }
                 else if (drawOctaveWavelength < _lodMaxWavelength)
                 {
@@ -213,9 +216,10 @@ namespace Crest
 
         public class FilterNoLodPreference : IDrawFilter
         {
-            public float Filter(ILodDataInput data, out int isTransition)
+            public float Filter(ILodDataInput data, out int isTransition, out float alpha)
             {
                 isTransition = 0;
+                alpha = 1f;
                 return data.Wavelength == 0f ? 1f : 0f;
             }
         }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterLodDataInput.cs
@@ -34,6 +34,8 @@ namespace Crest
         /// Whether to apply this input.
         /// </summary>
         bool Enabled { get; }
+
+        bool IgnoreTransitionWeight { get; }
     }
 
     /// <summary>
@@ -175,6 +177,8 @@ namespace Crest
                 return s_Quad = Resources.GetBuiltinResource<Mesh>("Quad.fbx");
             }
         }
+
+        public bool IgnoreTransitionWeight => false;
     }
 
     /// <summary>

--- a/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
+++ b/crest/Assets/Crest/Crest/Scripts/Shapes/ShapeGerstnerBatched.cs
@@ -89,6 +89,8 @@ namespace Crest
 
             public bool Enabled { get; set; }
 
+            public bool IgnoreTransitionWeight => false;
+
             public bool HasWaves { get; set; }
 
             public void Draw(LodDataMgr lodData, CommandBuffer buf, float weight, int isTransition, int lodIdx)

--- a/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
+++ b/crest/Assets/Crest/Crest/Scripts/WaterBody.cs
@@ -57,6 +57,7 @@ namespace Crest
             // Render to all cascades
             public float Wavelength => 0f;
             public bool Enabled => true;
+            public bool IgnoreTransitionWeight => false;
 
             public Matrix4x4 _transform;
 

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -35,6 +35,7 @@ Fixed
    -  Fix gizmos not drawing for inputs when using an attached renderer.
    -  Fix potential cases where water tiles were being culled incorrectly.
    -  Fix *Sphere Water Interaction* not working in builds.
+   -  Fix larger waves not blending out when using wave blending.
 
    .. only:: birp
 


### PR DESCRIPTION
Larger waves that are transitioning towards the end of the LOD chain were not having the blend pass applied to them, or not fully, due to the transition weight being passed into the blend pass. By parting the transition weight out, it can be excluded from the blend pass.