### PR TITLE
Fix Graphics API edge case causing rendering artefacts

### DIFF
--- a/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
+++ b/crest/Assets/Crest/Crest/Shaders/OceanEmission.hlsl
@@ -19,7 +19,8 @@ half3 ScatterColour
 {
 	// base colour
 	float v = abs(i_view.y);
-	half3 col = lerp(_Diffuse, _DiffuseGrazing, 1. - pow(v, 1.0));
+	// Previously caused rendering artifacts. See issue #1040.
+	half3 col = lerp(_DiffuseGrazing, _Diffuse, v);
 
 #if _SHADOWS_ON
 	col = lerp(_DiffuseShadow, col, i_shadow);

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -37,6 +37,7 @@ Fixed
 
       -  Fix *Underwater Renderer* compatibility with depth prepass.
       -  Fix *Underwater Renderer* not working with multiple cameras in certain cases.
+      -  Fix rendering artifacts when *Windows Graphics API* is set to *Direct3D11* and the *Android Graphics API* is set to *Vulkan*.
 
 
 4.16


### PR DESCRIPTION
Fixes #1040 

It is an issue with FXC so Unity cannot fix the problem. But they did provide the solution. Thank you.