### PR TITLE
Release Ocean Renderer resources in OnDestroy

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/LodDataMgr.cs
@@ -288,5 +288,15 @@ namespace Crest
 
             Helpers.Destroy(_defaultSettings);
         }
+
+        internal virtual void Enable()
+        {
+
+        }
+
+        internal virtual void Disable()
+        {
+
+        }
     }
 }

--- a/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/Shadows/LodDataMgrShadow.cs
@@ -111,6 +111,13 @@ namespace Crest
         {
             base.OnEnable();
 
+            Enable();
+        }
+
+        internal override void Enable()
+        {
+            base.Enable();
+
             {
                 Camera.onPreCull -= OnPreCullCamera;
                 Camera.onPreCull += OnPreCullCamera;
@@ -121,16 +128,23 @@ namespace Crest
             CleanUpShadowCommandBuffers();
         }
 
-        internal override void OnDisable()
+        internal override void Disable()
         {
-            base.OnDisable();
+            base.Disable();
+
+            CleanUpShadowCommandBuffers();
 
             {
                 Camera.onPreCull -= OnPreCullCamera;
                 Camera.onPostRender -= OnPostRenderCamera;
             }
+        }
 
-            CleanUpShadowCommandBuffers();
+        internal override void OnDisable()
+        {
+            base.OnDisable();
+
+            Disable();
 
             for (var index = 0; index < _renderMaterial.Length; index++)
             {

--- a/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
+++ b/crest/Assets/Crest/Crest/Scripts/OceanChunkRenderer.cs
@@ -308,7 +308,10 @@ namespace Crest
 #if UNITY_EDITOR
         void OnDrawGizmosSelected()
         {
-            Rend.bounds.GizmosDraw();
+            if (Rend != null)
+            {
+                Rend.bounds.GizmosDraw();
+            }
 
             if (WaterBody.WaterBodies.Count > 0)
             {

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -24,6 +24,8 @@ Changed
    -  Use *Register Height Input* in *Boat* scene instead of *Register Animated Waves Input*.
    -  Rate limit shadow simulation to *Ocean Renderer > Editor Mode FPS*.
    -  Move *Ocean Renderer* debug options into foldout.
+   -  Release *Ocean Renderer* resources in *OnDestroy* instead of *OnDisable* to prevent performance penality of rebuilding the system.
+      The option *Debug > Destroy Resources In On Disable* will revert this behaviour if needed.
 
 
 Fixed


### PR DESCRIPTION
Fixes #751

Releasing resources in _OnDisable_ means rebuilding everything in _OnEnable_ which makes toggling the OR impractical. Several use cases have emerged which warrants the change. _OnDisable_ is always used in edit mode as _OnDestroy_ is not reliably called there.

A debug option (*Destroy Resources In On Disable*) will revert this behaviour if needed.