### PR TITLE
Reduce input displacement queries

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterAnimWavesInput.cs
@@ -39,7 +39,7 @@ namespace Crest
 
         [SerializeField, Tooltip(k_displacementCorrectionTooltip)]
         bool _followHorizontalMotion = true;
-        protected override bool FollowHorizontalMotion => _followHorizontalMotion;
+        protected override bool FollowHorizontalMotion => base.FollowHorizontalMotion || _followHorizontalMotion;
 
         [SerializeField, Tooltip("Inform ocean how much this input will displace the ocean surface vertically. This is used to set bounding box heights for the ocean tiles.")]
         float _maxDisplacementVertical = 0f;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterClipSurfaceInput.cs
@@ -207,8 +207,10 @@ namespace Crest
             }
         }
 
-        private void LateUpdate()
+        protected override void LateUpdate()
         {
+            base.LateUpdate();
+
             if (OceanRenderer.Instance == null || (_mode == Mode.Geometry && _renderer == null))
             {
                 return;

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFlowInput.cs
@@ -30,7 +30,7 @@ namespace Crest
 
         protected override string ShaderPrefix => "Crest/Inputs/Flow";
 
-        protected override bool FollowHorizontalMotion => _followHorizontalMotion;
+        protected override bool FollowHorizontalMotion => base.FollowHorizontalMotion || _followHorizontalMotion;
 
         protected override string SplineShaderName => "Hidden/Crest/Inputs/Flow/Spline Geometry";
         protected override Vector2 DefaultCustomData => new Vector2(SplinePointDataFlow.k_defaultSpeed, 0f);

--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterFoamInput.cs
@@ -30,7 +30,7 @@ namespace Crest
 
         protected override string ShaderPrefix => "Crest/Inputs/Foam";
 
-        protected override bool FollowHorizontalMotion => _followHorizontalMotion;
+        protected override bool FollowHorizontalMotion => base.FollowHorizontalMotion || _followHorizontalMotion;
 
         protected override string SplineShaderName => "Hidden/Crest/Inputs/Foam/Spline Geometry";
         protected override Vector2 DefaultCustomData => Vector2.right;

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -72,6 +72,7 @@ Performance
 
    -  Improve water tile culling significantly.
       The bounds for each tile are normally expanded to accommodate mesh displacement (to prevent culling), but they were much larger than required in many cases leading to reduced culling hits which is no longer the case.
+   -  Reduce the amount of displacement queries LOD inputs make significantly making performance more scalable.
    -  Minor performance optimisations.
 
 


### PR DESCRIPTION
Some inputs will query displacements to counter water movement to stay in position. This was done in the Draw method which is called per LOD which was unnecessary. This significantly reduces queries.