### PR TITLE
Make Ocean Depth Cache depth relative

### DIFF
--- a/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
+++ b/crest/Assets/Crest/Crest/Scripts/LodData/RegisterSeaFloorDepthInput.cs
@@ -3,6 +3,7 @@
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Crest
 {
@@ -33,6 +34,15 @@ namespace Crest
 
         protected override string ShaderPrefix => "Crest/Inputs/Depth";
 
+        // Workaround to ODC depth not being relative. This allows the change without break current baked depth caches.
+        [SerializeField, HideInInspector]
+        internal bool _relative;
+
+        public static class ShaderIDs
+        {
+            public static readonly int s_HeightOffset = Shader.PropertyToID("_HeightOffset");
+        }
+
         protected override void OnEnable()
         {
             base.OnEnable();
@@ -44,6 +54,12 @@ namespace Crest
                     rend.material = new Material(Shader.Find("Crest/Inputs/Depth/Ocean Depth From Geometry"));
                 }
             }
+        }
+
+        public override void Draw(LodDataMgr lodData, CommandBuffer buf, float weight, int isTransition, int lodIdx)
+        {
+            buf.SetGlobalFloat(ShaderIDs.s_HeightOffset, _relative ? transform.position.y : 0f);
+            base.Draw(lodData, buf, weight, isTransition, lodIdx);
         }
 
 #if UNITY_EDITOR

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/CopyDepthIntoCache.shader
@@ -2,6 +2,10 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
+// Copies the depth buffer into the cache as object-space height. Object-space is used instead of world-space to allow
+// relative movement of baked depth caches afterwards. It is converted to world-space in another shader before writing
+// into the LOD data.
+
 Shader "Crest/Copy Depth Buffer Into Cache"
 {
 	SubShader
@@ -30,6 +34,7 @@ Shader "Crest/Copy Depth Buffer Into Cache"
 			CBUFFER_END
 
 			sampler2D _CamDepthBuffer;
+			float _HeightOffset;
 
 			struct Attributes
 			{
@@ -69,7 +74,7 @@ Shader "Crest/Copy Depth Buffer Into Cache"
 				altitude = lerp(_HeightNearHeightFar.x, _HeightNearHeightFar.y, linear01Z);
 #endif
 
-				return float4(altitude, 0.0, 0.0, 1.0);
+				return float4(altitude - _HeightOffset, 0.0, 0.0, 1.0);
 			}
 
 			ENDCG

--- a/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
+++ b/crest/Assets/Crest/Crest/Shaders/OceanInputs/Resources/OceanDepthsCache.shader
@@ -2,7 +2,8 @@
 
 // This file is subject to the MIT License as seen in the root of this folder structure (LICENSE)
 
-// Draw cached terrain heights into current frame data
+// Draw cached world-space heights into current frame data. If heights are coming from an ODC, then they are in
+// object-space and are converted to world-space as the LOD data stores world-space height.
 
 Shader "Crest/Inputs/Depth/Cached Depths"
 {
@@ -26,6 +27,7 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 			#include "UnityCG.cginc"
 
 			sampler2D _MainTex;
+			float _HeightOffset;
 
 			CBUFFER_START(CrestPerOceanInput)
 			float4 _MainTex_ST;
@@ -53,7 +55,7 @@ Shader "Crest/Inputs/Depth/Cached Depths"
 
 			float2 Frag(Varyings input) : SV_Target
 			{
-				return float2(tex2D(_MainTex, input.uv).x, 0.0);
+				return float2(tex2D(_MainTex, input.uv).x + _HeightOffset, 0.0);
 			}
 			ENDCG
 		}

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -26,6 +26,8 @@ Changed
    -  Move *Ocean Renderer* debug options into foldout.
    -  Release *Ocean Renderer* resources in *OnDestroy* instead of *OnDisable* to prevent performance penality of rebuilding the system.
       The option *Debug > Destroy Resources In On Disable* will revert this behaviour if needed.
+   -  Make *Ocean Depth Cache* depth relative.
+      This benefits baked depth caches by allowing them to be moved after baking providing the contents are moved with it.
 
 
 Fixed


### PR DESCRIPTION
If a baked depth cache is moved after baking, the depth will be incorrect. This solves that by making the depth relative to the transform. Now it can be moved providing the contents (terrain etc) are also moved with it.

To avoid breaking current depth caches, this is only applied to new ODCs or after hitting _Save cache to file_. There is an edge case which will break existing baked depth caches where a user swaps out a relative baked depth cache texture for a non relative one which can be solved by simply re-baking.